### PR TITLE
Removed JITs

### DIFF
--- a/odefilter/_control_flow.py
+++ b/odefilter/_control_flow.py
@@ -1,7 +1,5 @@
 """Custom control flow. Extends jax.lax."""
 
-import functools
-
 import jax
 import jax.numpy as jnp
 
@@ -9,8 +7,6 @@ import jax.numpy as jnp
 # todo: this function only works if the output of scan has the same
 #  pytree structure as the init;
 #  i.e., if the carry type is the solution type.
-# todo: remove the jit?
-@functools.partial(jax.jit, static_argnames=["f", "reverse"])
 def scan_with_init(*, f, init, xs, reverse=False):
     """Scan, but include the ``init`` parameter into the output.
 

--- a/odefilter/dense_output.py
+++ b/odefilter/dense_output.py
@@ -1,14 +1,11 @@
 """Do fun stuff with the solution objects."""
 
-import functools
 from typing import Any, NamedTuple
 
 import jax
 import jax.numpy as jnp
 
 
-# todo: why do we need this function??
-@functools.partial(jax.jit, static_argnames=["shape"])
 def sample(key, *, solution, solver, shape=()):
     return solver.strategy.sample(key, posterior=solution.posterior, shape=shape)
 

--- a/odefilter/ivpsolve.py
+++ b/odefilter/ivpsolve.py
@@ -1,7 +1,6 @@
 """ODE solver routines."""
 
 
-import functools
 import warnings
 
 import jax
@@ -16,7 +15,6 @@ from odefilter.strategies import smoothers
 #  to match the signature of the vector field?
 
 
-@functools.partial(jax.jit, static_argnums=[0])
 def simulate_terminal_values(
     vector_field, initial_values, t0, t1, solver, parameters=(), **options
 ):
@@ -47,7 +45,6 @@ def simulate_terminal_values(
     )
 
 
-@functools.partial(jax.jit, static_argnums=[0])
 def simulate_checkpoints(
     vector_field, initial_values, ts, solver, parameters=(), **options
 ):

--- a/odefilter/odefiltersolve.py
+++ b/odefilter/odefiltersolve.py
@@ -10,7 +10,6 @@ from odefilter import _adaptive, _control_flow
 #  it is generally safer to use the ivpsolve.py methods.
 
 
-@jax.jit
 def odefilter_terminal_values(
     vector_field, taylor_coefficients, t0, t1, solver, parameters, **options
 ):
@@ -31,7 +30,6 @@ def odefilter_terminal_values(
     return adaptive_solver.extract_terminal_value_fn(state=solution)
 
 
-@jax.jit
 def odefilter_checkpoints(
     vector_field, taylor_coefficients, ts, solver, parameters, **options
 ):


### PR DESCRIPTION
Resolves #181 

The solution is to jit nothing, _except_ for functions whose performance is runtime-critical to `ivpsolve.solve()`.
These functions include:
* init_fn and step_fn in _adaptive.AdaptiveODEFilter()
* taylor series

Everything else is jitted no more. 