### PR TITLE
Doc-publish only on release instead of every push to main

### DIFF
--- a/.github/workflows/doc-publish.yaml
+++ b/.github/workflows/doc-publish.yaml
@@ -1,8 +1,11 @@
 name: doc-publish
+
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Resolves #445.

Now, the `pip install probdiffeq` content matches the documentation. 