### PR TITLE
More efficinet extract_qoi for Iso* solvers

### DIFF
--- a/probdiffeq/implementations/dense/_vars.py
+++ b/probdiffeq/implementations/dense/_vars.py
@@ -47,9 +47,9 @@ class DenseStateSpaceVar(_collections.StateSpaceVar):
     def extract_qoi(self):
         if self.hidden_state.mean.ndim == 1:
             return self._select_derivative(self.hidden_state.mean, i=0)
-        return jax.vmap(self._select_derivative, in_axes=(0, None))(
-            self.hidden_state.mean, 0
-        )
+
+        select_fn = jax.vmap(self._select_derivative, in_axes=(0, None))
+        return select_fn(self.hidden_state.mean, 0)
 
     def extract_qoi_from_sample(self, u, /):
         if u.ndim == 1:

--- a/probdiffeq/implementations/iso/_vars.py
+++ b/probdiffeq/implementations/iso/_vars.py
@@ -22,7 +22,7 @@ class IsoStateSpaceVar(_collections.StateSpaceVar):
         return IsoNormal(m_obs, r_obs.T), (ssv, gain)
 
     def extract_qoi(self) -> jax.Array:
-        return self.marginal_nth_derivative(0).mean
+        return self.hidden_state.mean[0, :]
 
     def extract_qoi_from_sample(self, u, /) -> jax.Array:
         return u[..., 0, :]


### PR DESCRIPTION
Resolves #459.

Only affects the Iso* solvers. All others were sensible to begin with.