### PR TITLE
Flexible while_loop backend in simulate_terminal_values

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
   test:
     name: Test with ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/probdiffeq/_solution_routines_impl.py
+++ b/probdiffeq/_solution_routines_impl.py
@@ -19,7 +19,6 @@ def simulate_terminal_values(
     while_loop_fn_per_step,
     **options
 ):
-    print("todo: make the same changes for solve_and_save_at")
     adaptive_solver = _adaptive.AdaptiveIVPSolver(
         solver=solver, while_loop_fn=while_loop_fn_per_step, **options
     )
@@ -38,9 +37,18 @@ def simulate_terminal_values(
 
 
 def solve_and_save_at(
-    vector_field, taylor_coefficients, save_at, solver, parameters, **options
+    vector_field,
+    taylor_coefficients,
+    save_at,
+    solver,
+    parameters,
+    while_loop_fn_temporal,
+    while_loop_fn_per_step,
+    **options
 ):
-    adaptive_solver = _adaptive.AdaptiveIVPSolver(solver=solver, **options)
+    adaptive_solver = _adaptive.AdaptiveIVPSolver(
+        solver=solver, while_loop_fn=while_loop_fn_per_step, **options
+    )
 
     def advance_to_next_checkpoint(s, t_next):
         s_next = _advance_ivp_solution_adaptively(
@@ -49,6 +57,7 @@ def solve_and_save_at(
             vector_field=vector_field,
             adaptive_solver=adaptive_solver,
             parameters=parameters,
+            while_loop_fn=while_loop_fn_temporal,
         )
         return s_next, s_next
 

--- a/probdiffeq/_solution_routines_impl.py
+++ b/probdiffeq/_solution_routines_impl.py
@@ -18,7 +18,11 @@ def simulate_terminal_values(
     while_loop_fn,
     **options
 ):
-    adaptive_solver = _adaptive.AdaptiveIVPSolver(solver=solver, **options)
+    print("todo: split into rejection_while_loop and time_while_loop or so")
+    print("todo: make the same changes for solve_and_save_at")
+    adaptive_solver = _adaptive.AdaptiveIVPSolver(
+        solver=solver, while_loop_fn=while_loop_fn, **options
+    )
 
     state0 = adaptive_solver.init_fn(taylor_coefficients=taylor_coefficients, t0=t0)
 

--- a/probdiffeq/_solution_routines_impl.py
+++ b/probdiffeq/_solution_routines_impl.py
@@ -5,13 +5,18 @@ Essentially, these functions implement the IVP solution routines after
 initialisation of the Taylor coefficients.
 """
 
-import jax
-
 from probdiffeq import _adaptive, _control_flow
 
 
 def simulate_terminal_values(
-    vector_field, taylor_coefficients, t0, t1, solver, parameters, **options
+    vector_field,
+    taylor_coefficients,
+    t0,
+    t1,
+    solver,
+    parameters,
+    while_loop_fn,
+    **options
 ):
     adaptive_solver = _adaptive.AdaptiveIVPSolver(solver=solver, **options)
 
@@ -23,6 +28,7 @@ def simulate_terminal_values(
         vector_field=vector_field,
         adaptive_solver=adaptive_solver,
         parameters=parameters,
+        while_loop_fn=while_loop_fn,
     )
     return adaptive_solver.extract_terminal_value_fn(state=solution)
 
@@ -55,7 +61,7 @@ def solve_and_save_at(
 
 
 def _advance_ivp_solution_adaptively(
-    vector_field, t1, state0, adaptive_solver, parameters
+    vector_field, t1, state0, adaptive_solver, parameters, while_loop_fn
 ):
     """Advance an IVP solution to the next state."""
 
@@ -68,7 +74,7 @@ def _advance_ivp_solution_adaptively(
         )
         return state
 
-    sol = jax.lax.while_loop(
+    sol = while_loop_fn(
         cond_fun=cond_fun,
         body_fun=body_fun,
         init_val=state0,

--- a/probdiffeq/_solution_routines_impl.py
+++ b/probdiffeq/_solution_routines_impl.py
@@ -15,13 +15,13 @@ def simulate_terminal_values(
     t1,
     solver,
     parameters,
-    while_loop_fn,
+    while_loop_fn_temporal,
+    while_loop_fn_per_step,
     **options
 ):
-    print("todo: split into rejection_while_loop and time_while_loop or so")
     print("todo: make the same changes for solve_and_save_at")
     adaptive_solver = _adaptive.AdaptiveIVPSolver(
-        solver=solver, while_loop_fn=while_loop_fn, **options
+        solver=solver, while_loop_fn=while_loop_fn_per_step, **options
     )
 
     state0 = adaptive_solver.init_fn(taylor_coefficients=taylor_coefficients, t0=t0)
@@ -32,7 +32,7 @@ def simulate_terminal_values(
         vector_field=vector_field,
         adaptive_solver=adaptive_solver,
         parameters=parameters,
-        while_loop_fn=while_loop_fn,
+        while_loop_fn=while_loop_fn_temporal,
     )
     return adaptive_solver.extract_terminal_value_fn(state=solution)
 

--- a/probdiffeq/solution_routines.py
+++ b/probdiffeq/solution_routines.py
@@ -20,8 +20,8 @@ def simulate_terminal_values(
     t0,
     t1,
     solver,
-    while_loop_fn,
     parameters=(),
+    while_loop_fn=jax.lax.while_loop,
     taylor_fn=taylor.taylor_mode_fn,
     **options,
 ):

--- a/probdiffeq/solution_routines.py
+++ b/probdiffeq/solution_routines.py
@@ -20,6 +20,7 @@ def simulate_terminal_values(
     t0,
     t1,
     solver,
+    while_loop_fn,
     parameters=(),
     taylor_fn=taylor.taylor_mode_fn,
     **options,
@@ -43,6 +44,7 @@ def simulate_terminal_values(
         t1=t1,
         solver=solver,
         parameters=parameters,
+        while_loop_fn=while_loop_fn,
         **options,
     )
 

--- a/probdiffeq/solution_routines.py
+++ b/probdiffeq/solution_routines.py
@@ -58,6 +58,8 @@ def solve_and_save_at(
     solver,
     parameters=(),
     taylor_fn=taylor.taylor_mode_fn,
+    while_loop_fn_temporal=jax.lax.while_loop,
+    while_loop_fn_per_step=jax.lax.while_loop,
     **options,
 ):
     """Solve an initial value problem \
@@ -94,6 +96,8 @@ def solve_and_save_at(
         save_at=save_at,
         solver=solver,
         parameters=parameters,
+        while_loop_fn_temporal=while_loop_fn_temporal,
+        while_loop_fn_per_step=while_loop_fn_per_step,
         **options,
     )
 

--- a/probdiffeq/solution_routines.py
+++ b/probdiffeq/solution_routines.py
@@ -21,7 +21,8 @@ def simulate_terminal_values(
     t1,
     solver,
     parameters=(),
-    while_loop_fn=jax.lax.while_loop,
+    while_loop_fn_temporal=jax.lax.while_loop,
+    while_loop_fn_per_step=jax.lax.while_loop,
     taylor_fn=taylor.taylor_mode_fn,
     **options,
 ):
@@ -44,7 +45,8 @@ def simulate_terminal_values(
         t1=t1,
         solver=solver,
         parameters=parameters,
-        while_loop_fn=while_loop_fn,
+        while_loop_fn_temporal=while_loop_fn_temporal,
+        while_loop_fn_per_step=while_loop_fn_per_step,
         **options,
     )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ test =
     diffeqzoo
     tornadox
     diffrax
+    equinox
 lint =
     %(test)s
     pre-commit

--- a/tests/test_simulate_terminal_values.py
+++ b/tests/test_simulate_terminal_values.py
@@ -1,6 +1,5 @@
 """Tests for solving IVPs for the terminal value."""
 
-import jax
 import jax.numpy as jnp
 import pytest_cases
 
@@ -36,7 +35,6 @@ def fixture_solution_terminal_values(
         atol=solver_config.atol_solve,
         rtol=solver_config.rtol_solve,
         taylor_fn=taylor.taylor_mode_fn,
-        while_loop_fn=jax.lax.while_loop,
     )
     return (solution.t, solution.u), (
         ode_problem.t1,

--- a/tests/test_simulate_terminal_values.py
+++ b/tests/test_simulate_terminal_values.py
@@ -1,5 +1,6 @@
 """Tests for solving IVPs for the terminal value."""
 
+import jax
 import jax.numpy as jnp
 import pytest_cases
 
@@ -35,6 +36,7 @@ def fixture_solution_terminal_values(
         atol=solver_config.atol_solve,
         rtol=solver_config.rtol_solve,
         taylor_fn=taylor.taylor_mode_fn,
+        while_loop_fn=jax.lax.while_loop,
     )
     return (solution.t, solution.u), (
         ode_problem.t1,

--- a/tests/test_simulate_terminal_values.py
+++ b/tests/test_simulate_terminal_values.py
@@ -1,6 +1,7 @@
 """Tests for solving IVPs for the terminal value."""
 
 import functools
+from typing import Any, NamedTuple
 
 import equinox as eqx
 import jax
@@ -11,6 +12,61 @@ import pytest_cases
 from probdiffeq import solution_routines, solvers, taylor, test_util
 from probdiffeq.implementations import recipes
 from probdiffeq.strategies import filters, smoothers
+
+# Generate interesting test cases
+
+
+class _SimulateTerminalValuesConfig(NamedTuple):
+    ode_problem: Any
+    solver_fn: Any
+    impl_fn: Any
+    strat_fn: Any
+    solver_config: Any
+    loop_fn: Any
+
+
+@pytest_cases.case
+@pytest_cases.parametrize_with_cases("ode_problem", cases=".problem_cases")
+@pytest_cases.parametrize_with_cases("impl_fn", cases=".impl_cases")
+def case_setup_all_implementations(ode_problem, impl_fn, solver_config):
+    return _SimulateTerminalValuesConfig(
+        ode_problem=ode_problem,
+        solver_fn=solvers.MLESolver,
+        impl_fn=impl_fn,
+        strat_fn=filters.Filter,
+        solver_config=solver_config,
+        loop_fn=jax.lax.while_loop,
+    )
+
+
+@pytest_cases.case
+@pytest_cases.parametrize_with_cases("ode_problem", cases=".problem_cases")
+@pytest_cases.parametrize(
+    "strat_fn", [filters.Filter, smoothers.Smoother, smoothers.FixedPointSmoother]
+)
+def case_setup_all_strategies(ode_problem, strat_fn, solver_config):
+    return _SimulateTerminalValuesConfig(
+        ode_problem=ode_problem,
+        solver_fn=solvers.MLESolver,
+        impl_fn=recipes.BlockDiagTS0.from_params,
+        strat_fn=strat_fn,
+        solver_config=solver_config,
+        loop_fn=jax.lax.while_loop,
+    )
+
+
+@pytest_cases.case
+@pytest_cases.parametrize_with_cases("ode_problem", cases=".problem_cases")
+@pytest_cases.parametrize_with_cases("solver_fn", cases=".solver_cases")
+def case_setup_all_solvers(ode_problem, solver_fn, solver_config):
+    return _SimulateTerminalValuesConfig(
+        ode_problem=ode_problem,
+        solver_fn=solver_fn,
+        impl_fn=recipes.BlockDiagTS0.from_params,
+        strat_fn=filters.Filter,
+        solver_config=solver_config,
+        loop_fn=jax.lax.while_loop,
+    )
 
 
 @pytest_cases.case(id="jax.lax.while_loop")
@@ -28,42 +84,56 @@ def case_loop_eqx():
     return lo
 
 
-@pytest_cases.fixture(scope="session", name="solution_terminal_values")
+@pytest_cases.case
 @pytest_cases.parametrize_with_cases("ode_problem", cases=".problem_cases")
-@pytest_cases.parametrize_with_cases("impl_fn", cases=".impl_cases")
-@pytest_cases.parametrize_with_cases("solver_fn", cases=".solver_cases")
 @pytest_cases.parametrize_with_cases("loop_fn", cases=".", prefix="case_loop_")
-@pytest_cases.parametrize(
-    "strat_fn", [filters.Filter, smoothers.Smoother, smoothers.FixedPointSmoother]
+def case_setup_all_loops(ode_problem, loop_fn, solver_config):
+    return _SimulateTerminalValuesConfig(
+        ode_problem=ode_problem,
+        solver_fn=solvers.MLESolver,
+        impl_fn=recipes.BlockDiagTS0.from_params,
+        strat_fn=filters.Filter,
+        solver_config=solver_config,
+        loop_fn=loop_fn,
+    )
+
+
+# Compute the IVP solution for given setups
+
+
+@pytest_cases.fixture(scope="session", name="solution_terminal_values")
+@pytest_cases.parametrize_with_cases(
+    "setup", cases=".", prefix="case_setup_", scope="session"
 )
-def fixture_solution_terminal_values(
-    ode_problem, solver_fn, impl_fn, strat_fn, solver_config, loop_fn
-):
-    ode_shape = ode_problem.initial_values[0].shape
+def fixture_solution_terminal_values(setup):
+    ode_shape = setup.ode_problem.initial_values[0].shape
     solver = test_util.generate_solver(
-        solver_factory=solver_fn,
-        strategy_factory=strat_fn,
-        impl_factory=impl_fn,
+        solver_factory=setup.solver_fn,
+        strategy_factory=setup.strat_fn,
+        impl_factory=setup.impl_fn,
         ode_shape=ode_shape,
         num_derivatives=4,
     )
     solution = solution_routines.simulate_terminal_values(
-        ode_problem.vector_field,
-        ode_problem.initial_values,
-        t0=ode_problem.t0,
-        t1=ode_problem.t1,
-        parameters=ode_problem.args,
+        setup.ode_problem.vector_field,
+        setup.ode_problem.initial_values,
+        t0=setup.ode_problem.t0,
+        t1=setup.ode_problem.t1,
+        parameters=setup.ode_problem.args,
         solver=solver,
-        atol=solver_config.atol_solve,
-        rtol=solver_config.rtol_solve,
+        atol=setup.solver_config.atol_solve,
+        rtol=setup.solver_config.rtol_solve,
         taylor_fn=taylor.taylor_mode_fn,
-        while_loop_fn_temporal=loop_fn,
-        while_loop_fn_per_step=loop_fn,
+        while_loop_fn_temporal=setup.loop_fn,
+        while_loop_fn_per_step=setup.loop_fn,
     )
 
     sol = (solution.t, solution.u)
-    sol_ref = (ode_problem.t1, ode_problem.solution(ode_problem.t1))
+    sol_ref = (setup.ode_problem.t1, setup.ode_problem.solution(setup.ode_problem.t1))
     return sol, sol_ref
+
+
+# Actual tests
 
 
 def test_terminal_values_correct(solution_terminal_values, solver_config):
@@ -76,15 +146,12 @@ def test_terminal_values_correct(solution_terminal_values, solver_config):
 
 
 @pytest_cases.parametrize_with_cases("ode_problem", cases=".problem_cases")
-@pytest_cases.parametrize("impl_fn", [recipes.BlockDiagTS0.from_params])
-@pytest_cases.parametrize("solver_fn", [solvers.MLESolver])
-@pytest_cases.parametrize("strat_fn", [filters.Filter])
-def test_jvp(ode_problem, solver_fn, impl_fn, strat_fn, solver_config):
+def test_jvp(ode_problem, solver_config):
     ode_shape = ode_problem.initial_values[0].shape
     solver = test_util.generate_solver(
-        solver_factory=solver_fn,
-        strategy_factory=strat_fn,
-        impl_factory=impl_fn,
+        solver_factory=solvers.MLESolver,
+        strategy_factory=filters.Filter,
+        impl_factory=recipes.BlockDiagTS0.from_params,
         ode_shape=ode_shape,
         num_derivatives=2,
     )

--- a/tests/test_simulate_terminal_values.py
+++ b/tests/test_simulate_terminal_values.py
@@ -60,10 +60,10 @@ def fixture_solution_terminal_values(
         while_loop_fn_temporal=loop_fn,
         while_loop_fn_per_step=loop_fn,
     )
-    return (solution.t, solution.u), (
-        ode_problem.t1,
-        ode_problem.solution(ode_problem.t1),
-    )
+
+    sol = (solution.t, solution.u)
+    sol_ref = (ode_problem.t1, ode_problem.solution(ode_problem.t1))
+    return sol, sol_ref
 
 
 def test_terminal_values_correct(solution_terminal_values, solver_config):

--- a/tests/test_simulate_terminal_values.py
+++ b/tests/test_simulate_terminal_values.py
@@ -57,7 +57,8 @@ def fixture_solution_terminal_values(
         atol=solver_config.atol_solve,
         rtol=solver_config.rtol_solve,
         taylor_fn=taylor.taylor_mode_fn,
-        while_loop_fn=loop_fn,
+        while_loop_fn_temporal=loop_fn,
+        while_loop_fn_per_step=loop_fn,
     )
     return (solution.t, solution.u), (
         ode_problem.t1,

--- a/tests/test_simulate_terminal_values.py
+++ b/tests/test_simulate_terminal_values.py
@@ -13,15 +13,31 @@ from probdiffeq.implementations import recipes
 from probdiffeq.strategies import filters, smoothers
 
 
+@pytest_cases.case(id="jax.lax.while_loop")
+def case_loop_lax():
+    return jax.lax.while_loop
+
+
+@pytest_cases.case(id="eqx.bounded_while_loop")
+def case_loop_eqx():
+    def lo(cond_fun, body_fun, init_val):
+        return eqx.internal.while_loop(
+            cond_fun, body_fun, init_val, kind="bounded", max_steps=50
+        )
+
+    return lo
+
+
 @pytest_cases.fixture(scope="session", name="solution_terminal_values")
 @pytest_cases.parametrize_with_cases("ode_problem", cases=".problem_cases")
 @pytest_cases.parametrize_with_cases("impl_fn", cases=".impl_cases")
 @pytest_cases.parametrize_with_cases("solver_fn", cases=".solver_cases")
+@pytest_cases.parametrize_with_cases("loop_fn", cases=".", prefix="case_loop_")
 @pytest_cases.parametrize(
     "strat_fn", [filters.Filter, smoothers.Smoother, smoothers.FixedPointSmoother]
 )
 def fixture_solution_terminal_values(
-    ode_problem, solver_fn, impl_fn, strat_fn, solver_config
+    ode_problem, solver_fn, impl_fn, strat_fn, solver_config, loop_fn
 ):
     ode_shape = ode_problem.initial_values[0].shape
     solver = test_util.generate_solver(
@@ -41,6 +57,7 @@ def fixture_solution_terminal_values(
         atol=solver_config.atol_solve,
         rtol=solver_config.rtol_solve,
         taylor_fn=taylor.taylor_mode_fn,
+        while_loop_fn=loop_fn,
     )
     return (solution.t, solution.u), (
         ode_problem.t1,
@@ -61,9 +78,7 @@ def test_terminal_values_correct(solution_terminal_values, solver_config):
 @pytest_cases.parametrize("impl_fn", [recipes.BlockDiagTS0.from_params])
 @pytest_cases.parametrize("solver_fn", [solvers.MLESolver])
 @pytest_cases.parametrize("strat_fn", [filters.Filter])
-def test_simulate_terminal_values_jvp(
-    ode_problem, solver_fn, impl_fn, strat_fn, solver_config
-):
+def test_jvp(ode_problem, solver_fn, impl_fn, strat_fn, solver_config, loop_fn):
     ode_shape = ode_problem.initial_values[0].shape
     solver = test_util.generate_solver(
         solver_factory=solver_fn,
@@ -73,63 +88,27 @@ def test_simulate_terminal_values_jvp(
         num_derivatives=2,
     )
 
-    @jax.jit
-    def init_to_terminal_value(init):
-        solution = solution_routines.simulate_terminal_values(
-            ode_problem.vector_field,
-            (init,),
-            t0=ode_problem.t0,
-            t1=ode_problem.t1,
-            parameters=ode_problem.args,
-            solver=solver,
-            atol=solver_config.atol_solve,
-            rtol=solver_config.rtol_solve,
-        )
-        return solution.u
+    fn = functools.partial(
+        _init_to_terminal_value,
+        ode_problem=ode_problem,
+        solver=solver,
+        solver_config=solver_config,
+    )
+    u0 = ode_problem.initial_values[0]
 
-    fn, u0 = init_to_terminal_value, ode_problem.initial_values[0]
     jvp = functools.partial(jax.jvp, fn)
     jax.test_util.check_jvp(fn, jvp, (u0,))
 
 
-@pytest_cases.parametrize_with_cases("ode_problem", cases=".problem_cases")
-@pytest_cases.parametrize("impl_fn", [recipes.DenseTS1.from_params])
-@pytest_cases.parametrize("solver_fn", [solvers.MLESolver])
-@pytest_cases.parametrize("strat_fn", [filters.Filter])
-def test_simulate_terminal_values_vjp(
-    ode_problem, solver_fn, impl_fn, strat_fn, solver_config
-):
-    ode_shape = ode_problem.initial_values[0].shape
-    solver = test_util.generate_solver(
-        solver_factory=solver_fn,
-        strategy_factory=strat_fn,
-        impl_factory=impl_fn,
-        ode_shape=ode_shape,
-        num_derivatives=1,
+def _init_to_terminal_value(init, ode_problem, solver, solver_config):
+    solution = solution_routines.simulate_terminal_values(
+        ode_problem.vector_field,
+        (init,),
+        t0=ode_problem.t0,
+        t1=ode_problem.t1,
+        parameters=ode_problem.args,
+        solver=solver,
+        atol=solver_config.atol_solve,
+        rtol=solver_config.rtol_solve,
     )
-
-    def loop_fn(**kwargs):
-        def lo(cond_fun, body_fun, init_val):
-            return eqx.internal.while_loop(cond_fun, body_fun, init_val, **kwargs)
-
-        return lo
-
-    @jax.jit
-    def init_to_terminal_value(init):
-        solution = solution_routines.simulate_terminal_values(
-            ode_problem.vector_field,
-            (init,),
-            t0=ode_problem.t0,
-            t1=ode_problem.t1,
-            parameters=ode_problem.args,
-            solver=solver,
-            atol=solver_config.atol_solve,
-            rtol=solver_config.rtol_solve,
-            while_loop_fn=loop_fn(kind="bounded", max_steps=100),
-        )
-        return solution.u.T @ solution.u
-
-    fn, u0 = init_to_terminal_value, ode_problem.initial_values[0]
-    print(jax.value_and_grad(fn)(u0))
-    vjp = functools.partial(jax.vjp, fn)
-    jax.test_util.check_vjp(fn, vjp, (u0,))
+    return solution.u.T @ solution.u

--- a/tests/test_simulate_terminal_values.py
+++ b/tests/test_simulate_terminal_values.py
@@ -1,9 +1,15 @@
 """Tests for solving IVPs for the terminal value."""
 
+import functools
+
+import equinox as eqx
+import jax
 import jax.numpy as jnp
+import jax.test_util
 import pytest_cases
 
-from probdiffeq import solution_routines, taylor, test_util
+from probdiffeq import solution_routines, solvers, taylor, test_util
+from probdiffeq.implementations import recipes
 from probdiffeq.strategies import filters, smoothers
 
 
@@ -44,15 +50,86 @@ def fixture_solution_terminal_values(
 
 def test_terminal_values_correct(solution_terminal_values, solver_config):
     (t, u), (t_ref, u_ref) = solution_terminal_values
-    assert jnp.allclose(
-        t,
-        t_ref,
-        atol=solver_config.atol_assert,
-        rtol=solver_config.rtol_assert,
+
+    atol = solver_config.atol_assert
+    rtol = solver_config.rtol_assert
+    assert jnp.allclose(t, t_ref, atol=atol, rtol=rtol)
+    assert jnp.allclose(u, u_ref, atol=atol, rtol=rtol)
+
+
+@pytest_cases.parametrize_with_cases("ode_problem", cases=".problem_cases")
+@pytest_cases.parametrize("impl_fn", [recipes.BlockDiagTS0.from_params])
+@pytest_cases.parametrize("solver_fn", [solvers.MLESolver])
+@pytest_cases.parametrize("strat_fn", [filters.Filter])
+def test_simulate_terminal_values_jvp(
+    ode_problem, solver_fn, impl_fn, strat_fn, solver_config
+):
+    ode_shape = ode_problem.initial_values[0].shape
+    solver = test_util.generate_solver(
+        solver_factory=solver_fn,
+        strategy_factory=strat_fn,
+        impl_factory=impl_fn,
+        ode_shape=ode_shape,
+        num_derivatives=2,
     )
-    assert jnp.allclose(
-        u,
-        u_ref,
-        atol=solver_config.atol_assert,
-        rtol=solver_config.rtol_assert,
+
+    @jax.jit
+    def init_to_terminal_value(init):
+        solution = solution_routines.simulate_terminal_values(
+            ode_problem.vector_field,
+            (init,),
+            t0=ode_problem.t0,
+            t1=ode_problem.t1,
+            parameters=ode_problem.args,
+            solver=solver,
+            atol=solver_config.atol_solve,
+            rtol=solver_config.rtol_solve,
+        )
+        return solution.u
+
+    fn, u0 = init_to_terminal_value, ode_problem.initial_values[0]
+    jvp = functools.partial(jax.jvp, fn)
+    jax.test_util.check_jvp(fn, jvp, (u0,))
+
+
+@pytest_cases.parametrize_with_cases("ode_problem", cases=".problem_cases")
+@pytest_cases.parametrize("impl_fn", [recipes.DenseTS1.from_params])
+@pytest_cases.parametrize("solver_fn", [solvers.MLESolver])
+@pytest_cases.parametrize("strat_fn", [filters.Filter])
+def test_simulate_terminal_values_vjp(
+    ode_problem, solver_fn, impl_fn, strat_fn, solver_config
+):
+    ode_shape = ode_problem.initial_values[0].shape
+    solver = test_util.generate_solver(
+        solver_factory=solver_fn,
+        strategy_factory=strat_fn,
+        impl_factory=impl_fn,
+        ode_shape=ode_shape,
+        num_derivatives=1,
     )
+
+    def loop_fn(**kwargs):
+        def lo(cond_fun, body_fun, init_val):
+            return eqx.internal.while_loop(cond_fun, body_fun, init_val, **kwargs)
+
+        return lo
+
+    @jax.jit
+    def init_to_terminal_value(init):
+        solution = solution_routines.simulate_terminal_values(
+            ode_problem.vector_field,
+            (init,),
+            t0=ode_problem.t0,
+            t1=ode_problem.t1,
+            parameters=ode_problem.args,
+            solver=solver,
+            atol=solver_config.atol_solve,
+            rtol=solver_config.rtol_solve,
+            while_loop_fn=loop_fn(kind="bounded", max_steps=100),
+        )
+        return solution.u.T @ solution.u
+
+    fn, u0 = init_to_terminal_value, ode_problem.initial_values[0]
+    print(jax.value_and_grad(fn)(u0))
+    vjp = functools.partial(jax.vjp, fn)
+    jax.test_util.check_vjp(fn, vjp, (u0,))

--- a/tests/test_simulate_terminal_values.py
+++ b/tests/test_simulate_terminal_values.py
@@ -79,7 +79,7 @@ def test_terminal_values_correct(solution_terminal_values, solver_config):
 @pytest_cases.parametrize("impl_fn", [recipes.BlockDiagTS0.from_params])
 @pytest_cases.parametrize("solver_fn", [solvers.MLESolver])
 @pytest_cases.parametrize("strat_fn", [filters.Filter])
-def test_jvp(ode_problem, solver_fn, impl_fn, strat_fn, solver_config, loop_fn):
+def test_jvp(ode_problem, solver_fn, impl_fn, strat_fn, solver_config):
     ode_shape = ode_problem.initial_values[0].shape
     solver = test_util.generate_solver(
         solver_factory=solver_fn,

--- a/tests/test_solve_and_save_at.py
+++ b/tests/test_solve_and_save_at.py
@@ -1,12 +1,68 @@
 """Tests for solving IVPs for checkpoints."""
+from typing import Any, NamedTuple
+
 import equinox as eqx
 import jax
 import jax.numpy as jnp
 import pytest
 import pytest_cases
 
-from probdiffeq import solution_routines, taylor, test_util
+from probdiffeq import solution_routines, solvers, taylor, test_util
+from probdiffeq.implementations import recipes
 from probdiffeq.strategies import filters, smoothers
+
+# Generate interesting test cases
+
+
+class _SolveAndSaveAtConfig(NamedTuple):
+    ode_problem: Any
+    solver_fn: Any
+    impl_fn: Any
+    strat_fn: Any
+    loop_fn: Any
+    solver_config: Any
+
+
+@pytest_cases.case
+@pytest_cases.parametrize_with_cases("ode_problem", cases=".problem_cases")
+@pytest_cases.parametrize_with_cases("impl_fn", cases=".impl_cases")
+def case_setup_all_implementations(ode_problem, impl_fn, solver_config):
+    return _SolveAndSaveAtConfig(
+        ode_problem=ode_problem,
+        solver_fn=solvers.MLESolver,
+        impl_fn=impl_fn,
+        strat_fn=filters.Filter,
+        solver_config=solver_config,
+        loop_fn=jax.lax.while_loop,
+    )
+
+
+@pytest_cases.case
+@pytest_cases.parametrize_with_cases("ode_problem", cases=".problem_cases")
+@pytest_cases.parametrize("strat_fn", [filters.Filter, smoothers.FixedPointSmoother])
+def case_setup_all_strategies(ode_problem, strat_fn, solver_config):
+    return _SolveAndSaveAtConfig(
+        ode_problem=ode_problem,
+        solver_fn=solvers.MLESolver,
+        impl_fn=recipes.BlockDiagTS0.from_params,
+        strat_fn=strat_fn,
+        solver_config=solver_config,
+        loop_fn=jax.lax.while_loop,
+    )
+
+
+@pytest_cases.case
+@pytest_cases.parametrize_with_cases("ode_problem", cases=".problem_cases")
+@pytest_cases.parametrize_with_cases("solver_fn", cases=".solver_cases")
+def case_setup_all_solvers(ode_problem, solver_fn, solver_config):
+    return _SolveAndSaveAtConfig(
+        ode_problem=ode_problem,
+        solver_fn=solver_fn,
+        impl_fn=recipes.BlockDiagTS0.from_params,
+        strat_fn=filters.Filter,
+        solver_config=solver_config,
+        loop_fn=jax.lax.while_loop,
+    )
 
 
 @pytest_cases.case(id="jax.lax.while_loop")
@@ -24,40 +80,50 @@ def case_loop_eqx():
     return lo
 
 
-@pytest_cases.fixture(scope="session", name="solution_save_at")
-@pytest_cases.parametrize_with_cases("impl_fn", cases=".impl_cases")
-@pytest_cases.parametrize_with_cases("solver_fn", cases=".solver_cases")
-@pytest_cases.parametrize("strat_fn", [filters.Filter, smoothers.FixedPointSmoother])
-@pytest_cases.parametrize_with_cases("loop_fn", cases=".", prefix="case_loop_")
+@pytest_cases.case
 @pytest_cases.parametrize_with_cases("ode_problem", cases=".problem_cases")
-def fixture_solution_save_at(
-    ode_problem, solver_fn, impl_fn, strat_fn, solver_config, loop_fn
-):
-    ode_shape = ode_problem.initial_values[0].shape
+@pytest_cases.parametrize_with_cases("loop_fn", cases=".", prefix="case_loop_")
+def case_setup_all_loops(ode_problem, loop_fn, solver_config):
+    return _SolveAndSaveAtConfig(
+        ode_problem=ode_problem,
+        solver_fn=solvers.MLESolver,
+        impl_fn=recipes.BlockDiagTS0.from_params,
+        strat_fn=filters.Filter,
+        solver_config=solver_config,
+        loop_fn=loop_fn,
+    )
+
+
+@pytest_cases.fixture(scope="session", name="solution_save_at")
+@pytest_cases.parametrize_with_cases(
+    "setup", cases=".", prefix="case_setup_", scope="session"
+)
+def fixture_solution_save_at(setup):
+    ode_shape = setup.ode_problem.initial_values[0].shape
     solver = test_util.generate_solver(
-        solver_factory=solver_fn,
-        strategy_factory=strat_fn,
-        impl_factory=impl_fn,
+        solver_factory=setup.solver_fn,
+        strategy_factory=setup.strat_fn,
+        impl_factory=setup.impl_fn,
         ode_shape=ode_shape,
         num_derivatives=4,
     )
 
-    t0, t1 = ode_problem.t0, ode_problem.t1
-    save_at = solver_config.grid_for_save_at_fn(t0, t1)
+    t0, t1 = setup.ode_problem.t0, setup.ode_problem.t1
+    save_at = setup.solver_config.grid_for_save_at_fn(t0, t1)
 
     solution = solution_routines.solve_and_save_at(
-        ode_problem.vector_field,
-        ode_problem.initial_values,
+        setup.ode_problem.vector_field,
+        setup.ode_problem.initial_values,
         save_at=save_at,
-        parameters=ode_problem.args,
+        parameters=setup.ode_problem.args,
         solver=solver,
-        atol=solver_config.atol_solve,
-        rtol=solver_config.rtol_solve,
+        atol=setup.solver_config.atol_solve,
+        rtol=setup.solver_config.rtol_solve,
         taylor_fn=taylor.taylor_mode_fn,
-        while_loop_fn_temporal=loop_fn,
-        while_loop_fn_per_step=loop_fn,
+        while_loop_fn_temporal=setup.loop_fn,
+        while_loop_fn_per_step=setup.loop_fn,
     )
-    return solution.u, jax.vmap(ode_problem.solution)(solution.t)
+    return solution.u, jax.vmap(setup.ode_problem.solution)(solution.t)
 
 
 def test_solution_correct(solution_save_at, solver_config):


### PR DESCRIPTION
Resolves #453 for simulate_terminal_values and solve_and_save_at without adding any (optional) dependencies by introducing a `while_loop_fn` argument in the solution routines.

Note: gradient-computation is not part of the tests, but postponed to #470 