### PR TITLE
Taylor mode AD with scan

### DIFF
--- a/probdiffeq/taylor.py
+++ b/probdiffeq/taylor.py
@@ -30,13 +30,34 @@ def taylor_mode_fn(
     # Initial Taylor series (u_0, u_1, ..., u_k)
     primals = vf(*initial_values)
     taylor_coeffs = [*initial_values, primals]
-    for _ in range(num - 1):
-        series = _subsets(taylor_coeffs[1:], num_arguments)  # for high-order ODEs
-        primals, series_new = jax.experimental.jet.jet(
-            vf, primals=initial_values, series=series
-        )
-        taylor_coeffs = [*initial_values, primals, *series_new]
-    return taylor_coeffs
+
+    def body_fn(tcoeffs, _):
+        # Pad the Taylor coefficients in zeros, call jet, and return the solution.
+        # Why does this even work? Because the $i$th output coefficiant of jet()
+        # is independent of the $i+j$th input coefficient
+        # (see the explanation in taylor_mode_doubling_fn about triangular Jacobians)
+        series = _subsets(tcoeffs[1:], num_arguments)  # for high-order ODEs
+        p, s_new = jax.experimental.jet.jet(vf, primals=initial_values, series=series)
+
+        # The final values in s_new are nonsensical
+        # (well, they are not; but we dont care about them)
+        # so we take them out
+        tcoeffs = [*initial_values, p, *s_new[:-1]]
+        return tcoeffs, None
+
+    # Pad the initial Taylor series with zeros
+    num_outputs = num_arguments + num
+    zeros = jnp.zeros_like(primals)
+    taylor_coeffs = _pad_to_length(taylor_coeffs, length=num_outputs, value=zeros)
+
+    taylor_coeffs, _ = jax.lax.scan(
+        body_fn, init=taylor_coeffs, xs=None, length=num - 1
+    )
+    return taylor_coeffs[:num_outputs]
+
+
+def _pad_to_length(x, /, *, length, value):
+    return x + [value] * (length - len(x))
 
 
 def _subsets(x, /, n):

--- a/probdiffeq/taylor.py
+++ b/probdiffeq/taylor.py
@@ -40,7 +40,7 @@ def taylor_mode_fn(
         p, s_new = jax.experimental.jet.jet(vf, primals=initial_values, series=series)
 
         # The final values in s_new are nonsensical
-        # (well, they are not; but we dont care about them)
+        # (well, they are not; but we don't care about them)
         # so we take them out
         tcoeffs = [*initial_values, p, *s_new[:-1]]
         return tcoeffs, None

--- a/tests/test_taylor.py
+++ b/tests/test_taylor.py
@@ -29,7 +29,7 @@ def case_runge_kutta_starter():
 
 @pytest_cases.fixture(name="num_derivatives_max")
 def fixture_num_derivatives_max():
-    return 3
+    return 5
 
 
 @pytest_cases.case(tags=["first"])


### PR DESCRIPTION
This PR establishes an implementation of taylor_mode_fn that uses a scan instead of a for loop.