### PR TITLE
Introduced a changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ and many more.
 * **API DOCUMENTATION:** [LINK](https://pnkraemer.github.io/probdiffeq/api_docs/solution_routines/)
 * **ISSUE TRACKER:** [LINK](https://github.com/pnkraemer/probdiffeq/issues)
 * **BENCHMARKS:** [LINK](https://pnkraemer.github.io/probdiffeq/api_docs/solution_routines/)
+* **CHANGELOG:** [LINK](https://github.com/pnkraemer/probdiffeq/blob/main/docs/CHANGELOG.md)
 
 
 ## Installation

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Change log
+
+## v0.2.0
+
+Notable breaking changes:
+
+* `solution_routines.py` has been renamed to `ivpsolve.py`. 
+  The contents of both modules are identical.
+  This is done to pave the way for boundary value problem solvers
+  and to tighten the correspondence between solvers and solution routines.
+* `solvers.py` has been renamed to `ivpsolvers.py`. 
+  The contents of both modules are identical.
+  This is done to pave the way for boundary value problem solvers
+  and to tighten the correspondence between solvers and solution routines.
+* `cubature.py` has been moved to `probdiffeq.implementations`.
+  The contents of both modules are identical.
+* `dense_output.py` has been renamed to `solution.py` and from now on also contains
+  the `Solution` object (formerly in `solvers.py`). 
+  This has been done to pave the way for boundary value problem solvers.
+* `solution.negative_marginal_log_likelihood` has been renamed to
+  `solution.log_marginal_likelihood` and its output is -1 times the output of the former function.
+  The new term is mathematically more accurate, implements less logic and has a shorter name.
+  The same applies to `solution.negative_marginal_log_likelihood_terminal_values`, which
+  has become `solution.log_marginal_likelihood_terminal_values`.
+
+
+
+Notable enhancements:
+* None
+
+
+## Prior to v0.2.0
+
+This changelog has been started between v0.1.4 and 0.2.0.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,3 +122,5 @@ nav:
           - "benchmarks/stiff_van_der_pol/external.ipynb"
         - High irradiance response (HIRES):
           - "benchmarks/hires/external.ipynb"
+    - Miscellaneous:
+      - Changelog: "CHANGELOG.md"


### PR DESCRIPTION
This PR introduces a change log.

The reason is that the recent PRs have introduced a fair number of breaking changes, and in addition to bumping the version appropriately, we simplify debugging by listing breaking changes and notable extensions in a separate log. 