### PR TITLE
Replaced `jnp.sqrt(jnp.dot(...))` and `jnp.sqrt(jnp.einsum(...))` with square-root arithmetic

### DIFF
--- a/probdiffeq/implementations/blockdiag/corr.py
+++ b/probdiffeq/implementations/blockdiag/corr.py
@@ -129,7 +129,7 @@ class BlockDiagTaylorZerothOrder(_collections.AbstractCorrection):
         marginalise_fn = jax.vmap(_scalar.TaylorZerothOrder.marginalise_observation)
         cache, obs_unbatch = marginalise_fn(self._ts0, fx, m1, x.hidden_state)
 
-        mahalanobis_fn = _scalar.ScalarNormal.mahalanobis_norm
+        mahalanobis_fn = _scalar.NormalQOI.mahalanobis_norm
         mahalanobis_fn_vmap = jax.vmap(mahalanobis_fn)
         output_scale_sqrtm = mahalanobis_fn_vmap(obs_unbatch, jnp.zeros_like(m0))
         error_estimate = obs_unbatch.cov_sqrtm_lower

--- a/probdiffeq/implementations/blockdiag/corr.py
+++ b/probdiffeq/implementations/blockdiag/corr.py
@@ -131,7 +131,7 @@ class BlockDiagTaylorZerothOrder(_collections.AbstractCorrection):
 
         mahalanobis_fn = _scalar.NormalQOI.mahalanobis_norm
         mahalanobis_fn_vmap = jax.vmap(mahalanobis_fn)
-        output_scale_sqrtm = mahalanobis_fn_vmap(obs_unbatch, jnp.zeros_like(m0))
+        output_scale_sqrtm = mahalanobis_fn_vmap(obs_unbatch, jnp.zeros_like(m1))
         error_estimate = obs_unbatch.cov_sqrtm_lower
         return output_scale_sqrtm * error_estimate, output_scale_sqrtm, cache
 

--- a/probdiffeq/implementations/dense/_vars.py
+++ b/probdiffeq/implementations/dense/_vars.py
@@ -112,9 +112,11 @@ class DenseNormal(_collections.AbstractNormal):
         return jnp.reshape(norm_square, ())
 
     def marginal_stds(self):
-        # todo: implement in square-root arithmetic
-        L = self.cov_sqrtm_lower
-        return jnp.sqrt(jnp.einsum("nj,nj->n", L, L))
+        def std(x):
+            std_mat = jnp.linalg.qr(x[..., None], mode="r")
+            return jnp.reshape(std_mat, ())
+
+        return jax.vmap(std)(self.cov_sqrtm_lower)
 
     def residual_white(self, u, /):
         obs_pt, l_obs = self.mean, self.cov_sqrtm_lower

--- a/probdiffeq/implementations/dense/_vars.py
+++ b/probdiffeq/implementations/dense/_vars.py
@@ -100,23 +100,25 @@ class DenseNormal(_collections.AbstractNormal):
     The mean is a (d*n,)-shaped array that represents a (d,n)-shaped matrix.
     """
 
-    # todo: extract _whiten() method?!
-
     def logpdf(self, u, /):
-        m_obs, l_obs = self.mean, self.cov_sqrtm_lower
-
-        res_white = jax.scipy.linalg.solve_triangular(l_obs.T, (m_obs - u), lower=False)
-
-        x1 = jnp.dot(res_white, res_white.T)
-        x2 = jnp.linalg.slogdet(l_obs)[1] ** 2
-        x3 = res_white.size * jnp.log(jnp.pi * 2)
+        x1 = self.mahalanobis_norm(u) ** 2
+        x2 = jnp.linalg.slogdet(self.cov_sqrtm_lower)[1] ** 2
+        x3 = u.size * jnp.log(jnp.pi * 2)
         return -0.5 * (x1 + x2 + x3)
 
     def mahalanobis_norm(self, u, /):
+        res_white = self.residual_white(u)
+        norm_square = jnp.linalg.qr(res_white[:, None], mode="r")
+        return jnp.reshape(norm_square, ())
+
+    def marginal_stds(self):
+        # todo: implement in square-root arithmetic
+        L = self.cov_sqrtm_lower
+        return jnp.sqrt(jnp.einsum("nj,nj->n", L, L))
+
+    def residual_white(self, u, /):
         obs_pt, l_obs = self.mean, self.cov_sqrtm_lower
-        res_white = jax.scipy.linalg.solve_triangular(l_obs.T, obs_pt - u, lower=False)
-        evidence_sqrtm = jnp.sqrt(jnp.dot(res_white, res_white.T) / res_white.size)
-        return evidence_sqrtm
+        return jax.scipy.linalg.solve_triangular(l_obs.T, obs_pt - u, lower=False)
 
     def scale_covariance(self, scale_sqrtm):
         cov_scaled = scale_sqrtm[..., None, None] * self.cov_sqrtm_lower


### PR DESCRIPTION
Replaced a bunch of jnp.dot's, jnp.sqrt's and jnp.einsum's in the state-space model implementations with appropriate QR decompositions.