### PR TITLE
IBM factories

### DIFF
--- a/probdiffeq/implementations/iso/extra.py
+++ b/probdiffeq/implementations/iso/extra.py
@@ -10,8 +10,20 @@ from probdiffeq.implementations import _collections, _ibm_util
 from probdiffeq.implementations.iso import _conds, _vars
 
 
+def ibm_iso(num_derivatives):
+    a, q_sqrtm = _ibm_util.system_matrices_1d(num_derivatives=num_derivatives)
+    _tmp = _ibm_util.preconditioner_prepare(num_derivatives=num_derivatives)
+    scales, powers = _tmp
+    return _IsoIBM(
+        a=a,
+        q_sqrtm_lower=q_sqrtm,
+        preconditioner_scales=scales,
+        preconditioner_powers=powers,
+    )
+
+
 @jax.tree_util.register_pytree_node_class
-class IsoIBM(_collections.AbstractExtrapolation):
+class _IsoIBM(_collections.AbstractExtrapolation):
     def __init__(self, a, q_sqrtm_lower, preconditioner_scales, preconditioner_powers):
         self.a = a
         self.q_sqrtm_lower = q_sqrtm_lower
@@ -39,18 +51,6 @@ class IsoIBM(_collections.AbstractExtrapolation):
         return cls(
             a=a,
             q_sqrtm_lower=q_sqrtm_lower,
-            preconditioner_scales=scales,
-            preconditioner_powers=powers,
-        )
-
-    @classmethod
-    def from_params(cls, num_derivatives):
-        a, q_sqrtm = _ibm_util.system_matrices_1d(num_derivatives=num_derivatives)
-        _tmp = _ibm_util.preconditioner_prepare(num_derivatives=num_derivatives)
-        scales, powers = _tmp
-        return cls(
-            a=a,
-            q_sqrtm_lower=q_sqrtm,
             preconditioner_scales=scales,
             preconditioner_powers=powers,
         )

--- a/probdiffeq/implementations/recipes.py
+++ b/probdiffeq/implementations/recipes.py
@@ -100,7 +100,7 @@ class DenseTS1(AbstractImplementation):
         correction = dense_corr.DenseTaylorFirstOrder(
             ode_shape=ode_shape, ode_order=ode_order
         )
-        extrapolation = dense_extra.DenseIBM.from_params(
+        extrapolation = dense_extra.ibm_dense(
             ode_shape=ode_shape, num_derivatives=num_derivatives
         )
         return cls(correction=correction, extrapolation=extrapolation)
@@ -113,7 +113,7 @@ class DenseTS0(AbstractImplementation):
         correction = dense_corr.DenseTaylorZerothOrder(
             ode_shape=ode_shape, ode_order=ode_order
         )
-        extrapolation = dense_extra.DenseIBM.from_params(
+        extrapolation = dense_extra.ibm_dense(
             ode_shape=ode_shape, num_derivatives=num_derivatives
         )
         return cls(correction=correction, extrapolation=extrapolation)
@@ -133,7 +133,7 @@ class DenseSLR1(AbstractImplementation):
         correction = dense_corr.DenseStatisticalFirstOrder.from_params(
             ode_shape=ode_shape, ode_order=ode_order, cubature_rule_fn=cubature_rule_fn
         )
-        extrapolation = dense_extra.DenseIBM.from_params(
+        extrapolation = dense_extra.ibm_dense(
             ode_shape=ode_shape, num_derivatives=num_derivatives
         )
         return cls(correction=correction, extrapolation=extrapolation)
@@ -164,7 +164,7 @@ class DenseSLR0(AbstractImplementation):
         correction = dense_corr.DenseStatisticalZerothOrder.from_params(
             ode_shape=ode_shape, ode_order=ode_order, cubature_rule_fn=cubature_rule_fn
         )
-        extrapolation = dense_extra.DenseIBM.from_params(
+        extrapolation = dense_extra.ibm_dense(
             ode_shape=ode_shape, num_derivatives=num_derivatives
         )
         return cls(correction=correction, extrapolation=extrapolation)

--- a/probdiffeq/implementations/recipes.py
+++ b/probdiffeq/implementations/recipes.py
@@ -175,5 +175,5 @@ class ScalarTS0(AbstractImplementation):
     @classmethod
     def from_params(cls, *, ode_order=1, num_derivatives=4):
         correction = scalar_corr.TaylorZerothOrder(ode_order=ode_order)
-        extrapolation = scalar_extra.IBM.from_params(num_derivatives=num_derivatives)
+        extrapolation = scalar_extra.ibm_scalar(num_derivatives=num_derivatives)
         return cls(correction=correction, extrapolation=extrapolation)

--- a/probdiffeq/implementations/recipes.py
+++ b/probdiffeq/implementations/recipes.py
@@ -76,7 +76,7 @@ class BlockDiagSLR1(AbstractImplementation):
             correction = blockdiag_corr.BlockDiagStatisticalFirstOrder(
                 ode_shape=ode_shape, ode_order=ode_order, cubature_rule=cubature_rule
             )
-        extrapolation = blockdiag_extra.BlockDiagIBM.from_params(
+        extrapolation = blockdiag_extra.ibm_blockdiag(
             ode_shape=ode_shape, num_derivatives=num_derivatives
         )
         return cls(correction=correction, extrapolation=extrapolation)
@@ -87,7 +87,7 @@ class BlockDiagTS0(AbstractImplementation):
     @classmethod
     def from_params(cls, *, ode_shape, ode_order=1, num_derivatives=4):
         correction = blockdiag_corr.BlockDiagTaylorZerothOrder(ode_order=ode_order)
-        extrapolation = blockdiag_extra.BlockDiagIBM.from_params(
+        extrapolation = blockdiag_extra.ibm_blockdiag(
             ode_shape=ode_shape, num_derivatives=num_derivatives
         )
         return cls(correction=correction, extrapolation=extrapolation)

--- a/probdiffeq/implementations/scalar/extra.py
+++ b/probdiffeq/implementations/scalar/extra.py
@@ -8,8 +8,20 @@ from probdiffeq.implementations import _collections, _ibm_util
 from probdiffeq.implementations.scalar import _conds, _vars
 
 
+def ibm_scalar(num_derivatives):
+    a, q_sqrtm = _ibm_util.system_matrices_1d(num_derivatives=num_derivatives)
+    _tmp = _ibm_util.preconditioner_prepare(num_derivatives=num_derivatives)
+    scales, powers = _tmp
+    return _IBM(
+        a=a,
+        q_sqrtm_lower=q_sqrtm,
+        preconditioner_scales=scales,
+        preconditioner_powers=powers,
+    )
+
+
 @jax.tree_util.register_pytree_node_class
-class IBM(_collections.AbstractExtrapolation):
+class _IBM(_collections.AbstractExtrapolation):
     def __init__(self, a, q_sqrtm_lower, preconditioner_scales, preconditioner_powers):
         self.a = a
         self.q_sqrtm_lower = q_sqrtm_lower
@@ -40,18 +52,6 @@ class IBM(_collections.AbstractExtrapolation):
         return cls(
             a=a,
             q_sqrtm_lower=q_sqrtm_lower,
-            preconditioner_scales=scales,
-            preconditioner_powers=powers,
-        )
-
-    @classmethod
-    def from_params(cls, num_derivatives):
-        a, q_sqrtm = _ibm_util.system_matrices_1d(num_derivatives=num_derivatives)
-        _tmp = _ibm_util.preconditioner_prepare(num_derivatives=num_derivatives)
-        scales, powers = _tmp
-        return cls(
-            a=a,
-            q_sqrtm_lower=q_sqrtm,
             preconditioner_scales=scales,
             preconditioner_powers=powers,
         )


### PR DESCRIPTION
The `*IBM.from_params()` are factory functions now.

The advantages are twofold:

* implementation details of the integrated Brownian motion are hidden (I am planning on simplifying them quite a lot soon, but even if not, nothing is lost)
* It becomes easier to create blockdiag-ibm via vmapping scalar ibm factories. 