### PR TITLE
Initial step in solver signature

### DIFF
--- a/docs/dev_docs/changelog.md
+++ b/docs/dev_docs/changelog.md
@@ -2,6 +2,12 @@
 
 ## v0.2.0
 
+This version overhauls large parts of the API. 
+Much of the functionality now looks different.
+Almost all implementations remain identical to before, though, and the API changes
+reduce to renaming function parameters.
+Change to the new API according to the instructions below.
+
 Notable breaking changes:
 
 * `solution_routines.py` has been renamed to `ivpsolve.py`. 
@@ -29,7 +35,10 @@ Notable breaking changes:
   The advantages of this change are much less code to achieve the same logic, 
   more freedom to change background-implementations without worrying about API, 
   and improved ease of maintenance (no more classmethods, no more custom pytree node registration.)
-
+* `extract_fn` and `extract_terminal_value_fn` in the solvers are now positional only. 
+  They only depend on a single argument (`state`) and since the term `state` is so incredibly overloaded
+  we make it positional only now, and will rename it afterwards. 
+  To update your code, replace `solver.extract_*fn(state=x)` with `solver.extract_*fn(x)`.
 
 Notable enhancements:
 

--- a/docs/dev_docs/changelog.md
+++ b/docs/dev_docs/changelog.md
@@ -36,7 +36,8 @@ Notable enhancements:
 * Scalar solvers are now part of the public API. While all "other" methods are for IVPs of shape `(d,)`,
   scalar solvers target problems of shape `()` (i.e. if the initial values are floats, not arrays).
 * The public API has been defined (see the developer docs). Notably, this document describes changes in which modules necessitate an entry in this changelog.
-
+* `dt0` can now be provided to the solution routines. To do so, call `simulate_terminal_values(..., dt0=1.)` replacing `1.` with appropriate values.
+  This change is completely backwards-compatible. The argument `dt0` is entirely optional, and its default value is set to the same as before.
 
 
 Notable bug fixes:

--- a/docs/dev_docs/public_api.md
+++ b/docs/dev_docs/public_api.md
@@ -1,6 +1,6 @@
 # Private and public API
 
-All public functions and classes in the following modules and packages are considered public API:
+All public functions and class-creators in the following modules and packages are considered public API:
 
 * `ivpsolvers.py`
 * `ivpsolve.py`
@@ -12,8 +12,9 @@ All public functions and classes in the following modules and packages are consi
 * `implementations.recipes.py`
 * `implementations.cubature.py`
 
-Exceptions from this rule are all functions and classes  that are marked as `warning: highly experimental`,
-e.g., `taylor.taylor_mode_doubling_fn`.
+Exceptions of this rule are all functions and class-creators that are 
+marked as `warning: highly experimental`, e.g., `taylor.taylor_mode_doubling_fn`.
+
 
 Breaking changes in these public modules are officially considered breaking changes.
 This means that the minor version number is increased according the the rules of semantic versioning

--- a/probdiffeq/_adaptive.py
+++ b/probdiffeq/_adaptive.py
@@ -101,6 +101,9 @@ class AdaptiveIVPSolver(Generic[T]):
         solver: T,
         atol=1e-4,
         rtol=1e-2,
+        # todo: replace the default with `None`.
+        #  function evaluations in signatures
+        #  are not a great idea...
         control=controls.ProportionalIntegral(),
         norm_ord=None,
         numerical_zero=1e-10,
@@ -163,7 +166,9 @@ class AdaptiveIVPSolver(Generic[T]):
     @jax.jit
     def init_fn(self, *, taylor_coefficients, t0, dt0):
         """Initialise the IVP solver state."""
-        # todo: make a function of posterior, state_control, and dt_proposed
+        # todo: make init() a function of state_solver,
+        #  state_control, and dt_proposed. Make extract_fn() return those.
+
         # Initialise the components
         state_solver = self.solver.init_fn(
             taylor_coefficients=taylor_coefficients, t0=t0
@@ -293,10 +298,10 @@ class AdaptiveIVPSolver(Generic[T]):
             control=state.control,
         )
 
-    def extract_fn(self, *, state: _AdaptiveState[S, C]) -> S:
+    def extract_fn(self, state: _AdaptiveState[S, C], /) -> S:
         return self.solver.extract_fn(state.solution)
 
-    def extract_terminal_value_fn(self, *, state: _AdaptiveState[S, C]) -> S:
+    def extract_terminal_value_fn(self, state: _AdaptiveState[S, C], /) -> S:
         return self.solver.extract_terminal_value_fn(state.solution)
 
 

--- a/probdiffeq/_adaptive.py
+++ b/probdiffeq/_adaptive.py
@@ -101,15 +101,15 @@ class AdaptiveIVPSolver(Generic[T]):
         solver: T,
         atol=1e-4,
         rtol=1e-2,
-        # todo: replace the default with `None`.
-        #  function evaluations in signatures
-        #  are not a great idea...
-        control=controls.ProportionalIntegral(),
+        control=None,
         norm_ord=None,
         numerical_zero=1e-10,
         while_loop_fn=jax.lax.while_loop,
         reference_state_fn=_reference_state_fn_max_abs,
     ):
+        if control is None:
+            control = controls.ProportionalIntegral()
+
         self.solver = solver
         self.while_loop_fn = while_loop_fn
         self.atol = atol

--- a/probdiffeq/_ivpsolve_impl.py
+++ b/probdiffeq/_ivpsolve_impl.py
@@ -15,6 +15,7 @@ def simulate_terminal_values(
     t1,
     solver,
     parameters,
+    dt0,
     while_loop_fn_temporal,
     while_loop_fn_per_step,
     **options
@@ -23,7 +24,9 @@ def simulate_terminal_values(
         solver=solver, while_loop_fn=while_loop_fn_per_step, **options
     )
 
-    state0 = adaptive_solver.init_fn(taylor_coefficients=taylor_coefficients, t0=t0)
+    state0 = adaptive_solver.init_fn(
+        taylor_coefficients=taylor_coefficients, t0=t0, dt0=dt0
+    )
 
     solution = _advance_ivp_solution_adaptively(
         state0=state0,

--- a/probdiffeq/_ivpsolve_impl.py
+++ b/probdiffeq/_ivpsolve_impl.py
@@ -36,7 +36,7 @@ def simulate_terminal_values(
         parameters=parameters,
         while_loop_fn=while_loop_fn_temporal,
     )
-    return adaptive_solver.extract_terminal_value_fn(state=solution)
+    return adaptive_solver.extract_terminal_value_fn(solution)
 
 
 def solve_and_save_at(
@@ -44,6 +44,7 @@ def solve_and_save_at(
     taylor_coefficients,
     save_at,
     solver,
+    dt0,
     parameters,
     while_loop_fn_temporal,
     while_loop_fn_per_step,
@@ -65,7 +66,9 @@ def solve_and_save_at(
         return s_next, s_next
 
     t0 = save_at[0]
-    state0 = adaptive_solver.init_fn(taylor_coefficients=taylor_coefficients, t0=t0)
+    state0 = adaptive_solver.init_fn(
+        taylor_coefficients=taylor_coefficients, t0=t0, dt0=dt0
+    )
 
     _, solution = _control_flow.scan_with_init(
         f=advance_to_next_checkpoint,
@@ -73,7 +76,7 @@ def solve_and_save_at(
         xs=save_at[1:],
         reverse=False,
     )
-    return adaptive_solver.extract_fn(state=solution)
+    return adaptive_solver.extract_fn(solution)
 
 
 def _advance_ivp_solution_adaptively(
@@ -99,11 +102,13 @@ def _advance_ivp_solution_adaptively(
 
 
 def solve_with_python_while_loop(
-    vector_field, taylor_coefficients, t0, t1, solver, parameters, **options
+    vector_field, taylor_coefficients, t0, t1, solver, dt0, parameters, **options
 ):
     adaptive_solver = _adaptive.AdaptiveIVPSolver(solver=solver, **options)
 
-    state = adaptive_solver.init_fn(taylor_coefficients=taylor_coefficients, t0=t0)
+    state = adaptive_solver.init_fn(
+        taylor_coefficients=taylor_coefficients, t0=t0, dt0=dt0
+    )
     generator = _solution_generator(
         vector_field,
         state=state,
@@ -112,7 +117,7 @@ def solve_with_python_while_loop(
         parameters=parameters,
     )
     forward_solution = _control_flow.tree_stack(list(generator))
-    return adaptive_solver.extract_fn(state=forward_solution)
+    return adaptive_solver.extract_fn(forward_solution)
 
 
 def _solution_generator(vector_field, *, state, t1, adaptive_solver, parameters):
@@ -141,4 +146,4 @@ def solve_fixed_grid(vector_field, taylor_coefficients, grid, solver, parameters
     _, (result, _) = _control_flow.scan_with_init(
         f=body_fn, init=(state, t0), xs=grid[1:]
     )
-    return solver.extract_fn(state=result)
+    return solver.extract_fn(result)

--- a/probdiffeq/ivpsolve.py
+++ b/probdiffeq/ivpsolve.py
@@ -59,6 +59,7 @@ def solve_and_save_at(
     initial_values,
     save_at,
     solver,
+    dt0,
     parameters=(),
     taylor_fn=taylor.taylor_mode_fn,
     while_loop_fn_temporal=jax.lax.while_loop,
@@ -96,6 +97,7 @@ def solve_and_save_at(
         taylor_coefficients=taylor_coefficients,
         save_at=save_at,
         solver=solver,
+        dt0=dt0,
         parameters=parameters,
         while_loop_fn_temporal=while_loop_fn_temporal,
         while_loop_fn_per_step=while_loop_fn_per_step,
@@ -111,6 +113,7 @@ def solve_with_python_while_loop(
     initial_values,
     t0,
     t1,
+    dt0,
     solver,
     parameters=(),
     taylor_fn=taylor.taylor_mode_fn,
@@ -138,6 +141,7 @@ def solve_with_python_while_loop(
         t0=t0,
         t1=t1,
         solver=solver,
+        dt0=dt0,
         parameters=parameters,
         **options,
     )
@@ -174,7 +178,10 @@ def solve_fixed_grid(
     )
 
 
-def dt0(vector_field, initial_values, /, t0, parameters, scale=0.01, nugget=1e-5):
+def propose_dt0(
+    vector_field, initial_values, /, t0, parameters, scale=0.01, nugget=1e-5
+):
+    """Propose an initial time-step."""
     u0, *_ = initial_values
     f0 = vector_field(*initial_values, t=t0, p=parameters)
 

--- a/tests/test_equivalences/test_tornadox_equivalence.py
+++ b/tests/test_equivalences/test_tornadox_equivalence.py
@@ -113,7 +113,7 @@ def case_solver_pair_kronecker_ek0(
         rtol=solver_config.rtol_solve,
         control=controller_probdiffeq,
         parameters=f_args,
-        initial_dt_nugget=0.0,
+        propose_dt0_nugget=0.0,
         reference_state_fn=lambda x, y: jnp.abs(x),
     )
 

--- a/tests/test_equivalences/test_tornadox_equivalence.py
+++ b/tests/test_equivalences/test_tornadox_equivalence.py
@@ -182,7 +182,7 @@ def case_solver_pair_reference_ek1(
         rtol=solver_config.rtol_solve,
         control=controller_probdiffeq,
         parameters=f_args,
-        initial_dt_nugget=0.0,
+        propose_dt0_nugget=0.0,
     )
 
     # Get both into the same format

--- a/tests/test_ivpsolve/test_simulate_terminal_values.py
+++ b/tests/test_ivpsolve/test_simulate_terminal_values.py
@@ -130,12 +130,20 @@ def fixture_solution_terminal_values(setup):
         ode_shape=ode_shape,
         num_derivatives=4,
     )
+
+    ode = setup.ode_problem.vector_field
+    u0s = setup.ode_problem.initial_values
+    t0 = setup.ode_problem.t0
+    parameters = setup.ode_problem.args
+    dt0 = ivpsolve.dt0(ode, u0s, t0=t0, parameters=parameters)
+
     solution = ivpsolve.simulate_terminal_values(
-        setup.ode_problem.vector_field,
-        setup.ode_problem.initial_values,
-        t0=setup.ode_problem.t0,
+        ode,
+        u0s,
+        t0=t0,
         t1=setup.ode_problem.t1,
-        parameters=setup.ode_problem.args,
+        parameters=parameters,
+        dt0=dt0,
         solver=solver,
         atol=setup.solver_config.atol_solve,
         rtol=setup.solver_config.rtol_solve,

--- a/tests/test_ivpsolve/test_simulate_terminal_values.py
+++ b/tests/test_ivpsolve/test_simulate_terminal_values.py
@@ -131,11 +131,14 @@ def fixture_solution_terminal_values(setup):
         num_derivatives=4,
     )
 
+    # todo: move to solver config?
+    #  (But this would involve knowing the IVP at solver-config-creation time,
+    #  which would be a non-trivial change.)
     ode = setup.ode_problem.vector_field
     u0s = setup.ode_problem.initial_values
     t0 = setup.ode_problem.t0
     parameters = setup.ode_problem.args
-    dt0 = ivpsolve.dt0(ode, u0s, t0=t0, parameters=parameters)
+    dt0 = ivpsolve.propose_dt0(ode, u0s, t0=t0, parameters=parameters)
 
     solution = ivpsolve.simulate_terminal_values(
         ode,

--- a/tests/test_ivpsolve/test_solve_and_save_at.py
+++ b/tests/test_ivpsolve/test_solve_and_save_at.py
@@ -126,12 +126,22 @@ def fixture_solution_save_at(setup):
     t0, t1 = setup.ode_problem.t0, setup.ode_problem.t1
     save_at = setup.solver_config.grid_for_save_at_fn(t0, t1)
 
+    # todo: move to solver config?
+    #  (But this would involve knowing the IVP at solver-config-creation time,
+    #  which would be a non-trivial change.)
+    ode = setup.ode_problem.vector_field
+    u0s = setup.ode_problem.initial_values
+    t0 = setup.ode_problem.t0
+    parameters = setup.ode_problem.args
+    dt0 = ivpsolve.propose_dt0(ode, u0s, t0=t0, parameters=parameters)
+
     solution = ivpsolve.solve_and_save_at(
         setup.ode_problem.vector_field,
         setup.ode_problem.initial_values,
         save_at=save_at,
         parameters=setup.ode_problem.args,
         solver=solver,
+        dt0=dt0,
         atol=setup.solver_config.atol_solve,
         rtol=setup.solver_config.rtol_solve,
         taylor_fn=taylor.taylor_mode_fn,


### PR DESCRIPTION
* `dt0` is now an argument to solve(). (Resolves #92)
* extract_fn are positional-only to avoid the `state` variable name (it is extremely overloaded). all those functions depend on a single input argument, so readibility does not suffer. 
