### PR TITLE
Time-step in controller state

### DIFF
--- a/probdiffeq/_adaptive.py
+++ b/probdiffeq/_adaptive.py
@@ -161,7 +161,7 @@ class AdaptiveIVPSolver(Generic[T]):
     def init_fn(self, dt0, **solver_init_kwargs):
         """Initialise the IVP solver state."""
         # Initialise the components
-        state_control = self.control.init_fn(dt0)
+        state_control = self.control.init_state_from_dt(dt0)
         state_solver = self.solver.init_fn(**solver_init_kwargs)
 
         # Initialise (prototypes for) proposed values
@@ -240,7 +240,7 @@ class AdaptiveIVPSolver(Generic[T]):
         posterior = self.solver.step_fn(
             state=state.accepted,
             vector_field=vector_field,
-            dt=self.control.extract_fn(state_control),
+            dt=self.control.extract_dt_from_state(state_control),
             parameters=parameters,
         )
         # Normalise the error and propose a new step.
@@ -286,7 +286,7 @@ class AdaptiveIVPSolver(Generic[T]):
 
     def extract_fn(self, state: _AdaptiveState[S, C], /) -> S:
         solver_extract = self.solver.extract_fn(state.solution)
-        control_extract = self.control.extract_fn(state.control)
+        control_extract = self.control.extract_dt_from_state(state.control)
 
         # return BOTH dt & solver_extract.
         #  Usually, only the latter is necessary.
@@ -297,7 +297,7 @@ class AdaptiveIVPSolver(Generic[T]):
 
     def extract_terminal_value_fn(self, state: _AdaptiveState[S, C], /) -> S:
         solver_extract = self.solver.extract_terminal_value_fn(state.solution)
-        control_extract = self.control.extract_fn(state.control)
+        control_extract = self.control.extract_dt_from_state(state.control)
         return control_extract, solver_extract
 
 

--- a/probdiffeq/_adaptive.py
+++ b/probdiffeq/_adaptive.py
@@ -232,7 +232,7 @@ class AdaptiveIVPSolver(Generic[T]):
         propose a future time-step based on tolerances and error estimates."""
         # Some controllers like to clip the terminal value instead of interpolating.
         # This must happen _before_ the step.
-        state_control = self.control.clip_fn(
+        state_control = self.control.clip(
             t=state.accepted.t, state=state.control, t1=t1
         )
 
@@ -251,7 +251,7 @@ class AdaptiveIVPSolver(Generic[T]):
             rtol=self.rtol,
             norm_ord=self.norm_ord,
         )
-        state_control = self.control.control_fn(
+        state_control = self.control.apply(
             state=state_control,
             error_normalised=error_normalised,
             error_contraction_rate=self.error_contraction_rate,

--- a/probdiffeq/_adaptive.py
+++ b/probdiffeq/_adaptive.py
@@ -24,7 +24,6 @@ class _AdaptiveState(Generic[S, C]):
 
     def __init__(
         self,
-        dt_proposed,
         error_norm_proposed,
         control: C,
         proposed: S,
@@ -32,7 +31,6 @@ class _AdaptiveState(Generic[S, C]):
         solution: S,
         previous: S,
     ):
-        self.dt_proposed = dt_proposed
         self.error_norm_proposed = error_norm_proposed
         self.control = control
         self.proposed = proposed
@@ -43,7 +41,6 @@ class _AdaptiveState(Generic[S, C]):
     def __repr__(self):
         return (
             f"{self.__class__.__name__}("
-            f"\n\tdt_proposed={self.dt_proposed},"
             f"\n\terror_norm_proposed={self.error_norm_proposed},"
             f"\n\tcontrol={self.control},"
             f"\n\tproposed={self.proposed},"
@@ -55,7 +52,6 @@ class _AdaptiveState(Generic[S, C]):
 
     def tree_flatten(self):
         children = (
-            self.dt_proposed,
             self.error_norm_proposed,
             self.control,
             self.proposed,
@@ -69,7 +65,6 @@ class _AdaptiveState(Generic[S, C]):
     @classmethod
     def tree_unflatten(cls, _aux, children):
         (
-            dt_proposed,
             error_norm_proposed,
             control,
             proposed,
@@ -78,7 +73,6 @@ class _AdaptiveState(Generic[S, C]):
             previous,
         ) = children
         return cls(
-            dt_proposed=dt_proposed,
             error_norm_proposed=error_norm_proposed,
             control=control,
             proposed=proposed,
@@ -164,16 +158,13 @@ class AdaptiveIVPSolver(Generic[T]):
         return self.solver.strategy.implementation.extrapolation.num_derivatives + 1
 
     @jax.jit
-    def init_fn(self, dt0, **kwargs):
+    def init_fn(self, dt0, **solver_init_kwargs):
         """Initialise the IVP solver state."""
-        # todo: make init() a function of state_solver,
-        #  state_control, and dt_proposed. Make extract_fn() return those.
-
         # Initialise the components
-        state_solver = self.solver.init_fn(**kwargs)
+        state_control = self.control.init_fn(dt0)
+        state_solver = self.solver.init_fn(**solver_init_kwargs)
 
         # Initialise (prototypes for) proposed values
-        state_control = self.control.init_fn()
         error_norm_proposed = self._normalise_error(
             error_estimate=state_solver.error_estimate,
             u=state_solver.u,
@@ -182,7 +173,6 @@ class AdaptiveIVPSolver(Generic[T]):
             norm_ord=self.norm_ord,
         )
         return _AdaptiveState(
-            dt_proposed=dt0,
             error_norm_proposed=error_norm_proposed,
             solution=state_solver,
             proposed=state_solver,
@@ -229,7 +219,6 @@ class AdaptiveIVPSolver(Generic[T]):
 
         _, state_new = self.while_loop_fn(cond_fn, body_fn, init_fn(state0))
         return _AdaptiveState(
-            dt_proposed=state_new.dt_proposed,
             error_norm_proposed=_inf_like(state_new.error_norm_proposed),
             proposed=_inf_like(state_new.proposed),  # meaningless?
             accepted=state_new.proposed,  # holla! New! :)
@@ -243,13 +232,15 @@ class AdaptiveIVPSolver(Generic[T]):
         propose a future time-step based on tolerances and error estimates."""
         # Some controllers like to clip the terminal value instead of interpolating.
         # This must happen _before_ the step.
-        dt = self.control.clip_fn(state=state.accepted, dt=state.dt_proposed, t1=t1)
+        state_control = self.control.clip_fn(
+            t=state.accepted.t, state=state.control, t1=t1
+        )
 
         # Perform the actual step.
         posterior = self.solver.step_fn(
             state=state.accepted,
             vector_field=vector_field,
-            dt=dt,
+            dt=self.control.extract_fn(state_control),
             parameters=parameters,
         )
         # Normalise the error and propose a new step.
@@ -260,14 +251,12 @@ class AdaptiveIVPSolver(Generic[T]):
             rtol=self.rtol,
             norm_ord=self.norm_ord,
         )
-        dt_proposed, state_control = self.control.control_fn(
-            state=state.control,
+        state_control = self.control.control_fn(
+            state=state_control,
             error_normalised=error_normalised,
             error_contraction_rate=self.error_contraction_rate,
-            dt_previous=state.dt_proposed,
         )
         return _AdaptiveState(
-            dt_proposed=dt_proposed,  # new
             error_norm_proposed=error_normalised,  # new
             proposed=posterior,  # new
             solution=state.solution,  # too early to accept :)
@@ -287,7 +276,6 @@ class AdaptiveIVPSolver(Generic[T]):
             s0=state.previous, s1=state.accepted, t=t
         )
         return _AdaptiveState(
-            dt_proposed=state.dt_proposed,
             error_norm_proposed=state.error_norm_proposed,
             proposed=_inf_like(state.proposed),
             accepted=accepted,  # holla! New! :)
@@ -298,17 +286,19 @@ class AdaptiveIVPSolver(Generic[T]):
 
     def extract_fn(self, state: _AdaptiveState[S, C], /) -> S:
         solver_extract = self.solver.extract_fn(state.solution)
+        control_extract = self.control.extract_fn(state.control)
 
         # return BOTH dt & solver_extract.
         #  Usually, only the latter is necessary.
         #  but we return both because this way, extract is inverse to init,
         #  and it becomes much easier to restart the solver at a new point
         #  without losing consistency.
-        return state.dt_proposed, solver_extract
+        return control_extract, solver_extract
 
     def extract_terminal_value_fn(self, state: _AdaptiveState[S, C], /) -> S:
         solver_extract = self.solver.extract_terminal_value_fn(state.solution)
-        return state.dt_proposed, solver_extract
+        control_extract = self.control.extract_fn(state.control)
+        return control_extract, solver_extract
 
 
 def _inf_like(tree):

--- a/probdiffeq/controls.py
+++ b/probdiffeq/controls.py
@@ -15,7 +15,7 @@ class AbstractControl(abc.ABC, Generic[S]):
     """Interface for control-algorithms."""
 
     @abc.abstractmethod
-    def init_fn(self, dt0: jax.Array) -> S:
+    def init_state_from_dt(self, dt0: jax.Array) -> S:
         """Initialise the controller state."""
         raise NotImplementedError
 
@@ -30,7 +30,7 @@ class AbstractControl(abc.ABC, Generic[S]):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def extract_fn(self, state: S) -> jax.Array:
+    def extract_dt_from_state(self, state: S) -> jax.Array:
         """Extract the time-step from the controller state."""
         raise NotImplementedError
 
@@ -66,7 +66,7 @@ class _ProportionalIntegralCommon(AbstractControl[_PIState]):
     def tree_unflatten(cls, _aux, children):
         return cls(*children)
 
-    def init_fn(self, dt0):
+    def init_state_from_dt(self, dt0):
         return _PIState(dt_proposed=dt0, error_norm_previously_accepted=1.0)
 
     @abc.abstractmethod
@@ -99,7 +99,7 @@ class _ProportionalIntegralCommon(AbstractControl[_PIState]):
         )
         return state
 
-    def extract_fn(self, state: _PIState) -> jax.Array:
+    def extract_dt_from_state(self, state: _PIState) -> jax.Array:
         return state.dt_proposed
 
 
@@ -146,7 +146,7 @@ class _IntegralCommon(AbstractControl[_IState]):
     def tree_unflatten(cls, _aux, children):
         return cls(*children)
 
-    def init_fn(self, dt0) -> _IState:
+    def init_state_from_dt(self, dt0) -> _IState:
         return _IState(dt0)
 
     @abc.abstractmethod
@@ -166,7 +166,7 @@ class _IntegralCommon(AbstractControl[_IState]):
         dt = scale_factor * state.dt_proposed
         return _IState(dt)
 
-    def extract_fn(self, state: _IState) -> jax.Array:
+    def extract_dt_from_state(self, state: _IState) -> jax.Array:
         return state.dt_proposed
 
 

--- a/probdiffeq/controls.py
+++ b/probdiffeq/controls.py
@@ -2,39 +2,49 @@
 
 import abc
 import dataclasses
-from typing import NamedTuple
+from typing import Generic, NamedTuple, TypeVar
 
 import jax
 import jax.numpy as jnp
 
+S = TypeVar("S")
+"""Controller state."""
 
-class AbstractControl(abc.ABC):
+
+class AbstractControl(abc.ABC, Generic[S]):
+    """Interface for control-algorithms."""
+
     @abc.abstractmethod
-    def init_fn(self):
+    def init_fn(self, dt0: jax.Array) -> S:
         """Initialise the controller state."""
         raise NotImplementedError
 
     @abc.abstractmethod
-    def control_fn(
-        self, *, state, error_normalised, error_contraction_rate, dt_previous
-    ):
+    def control_fn(self, error_normalised, error_contraction_rate, state: S) -> S:
         r"""Propose a time-step $\Delta t$."""
         raise NotImplementedError
 
     @abc.abstractmethod
-    def clip_fn(self, *, state, dt, t1):
+    def clip_fn(self, t, t1, state: S) -> S:
+        """(Optionally) clip the current step to not exceed t1."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def extract_fn(self, state: S) -> jax.Array:
+        """Extract the time-step from the controller state."""
         raise NotImplementedError
 
 
 class _PIState(NamedTuple):
     """Proportional-integral controller state."""
 
-    error_norm_previously_accepted: float
+    dt_proposed: jax.Array  # usually a float
+    error_norm_previously_accepted: jax.Array  # usually a float
 
 
 @jax.tree_util.register_pytree_node_class
 @dataclasses.dataclass
-class _ProportionalIntegralCommon(AbstractControl):
+class _ProportionalIntegralCommon(AbstractControl[_PIState]):
     safety: float = 0.95
     factor_min: float = 0.2
     factor_max: float = 10.0
@@ -56,16 +66,16 @@ class _ProportionalIntegralCommon(AbstractControl):
     def tree_unflatten(cls, _aux, children):
         return cls(*children)
 
-    def init_fn(self):
-        return _PIState(error_norm_previously_accepted=1.0)
+    def init_fn(self, dt0):
+        return _PIState(dt_proposed=dt0, error_norm_previously_accepted=1.0)
 
     @abc.abstractmethod
-    def clip_fn(self, *, state, dt, t1):
+    def clip_fn(self, t, t1, state: _PIState) -> _PIState:
         raise NotImplementedError
 
     def control_fn(
-        self, *, state, error_normalised, error_contraction_rate, dt_previous
-    ):
+        self, error_normalised, error_contraction_rate, state: _PIState
+    ) -> _PIState:
         n1 = self.power_integral_unscaled / error_contraction_rate
         n2 = self.power_proportional_unscaled / error_contraction_rate
 
@@ -81,8 +91,16 @@ class _ProportionalIntegralCommon(AbstractControl):
             error_normalised,
             state.error_norm_previously_accepted,
         )
-        state = _PIState(error_norm_previously_accepted=error_norm_previously_accepted)
-        return scale_factor * dt_previous, state
+
+        dt_proposed = scale_factor * state.dt_proposed
+        state = _PIState(
+            dt_proposed=dt_proposed,
+            error_norm_previously_accepted=error_norm_previously_accepted,
+        )
+        return state
+
+    def extract_fn(self, state: S) -> jax.Array:
+        return state.dt_proposed
 
 
 @jax.tree_util.register_pytree_node_class
@@ -90,8 +108,8 @@ class _ProportionalIntegralCommon(AbstractControl):
 class ProportionalIntegral(_ProportionalIntegralCommon):
     """Proportional-integral (PI) controller."""
 
-    def clip_fn(self, *, state, dt, t1):
-        return dt
+    def clip_fn(self, t, t1, state: _PIState) -> _PIState:
+        return state
 
 
 @jax.tree_util.register_pytree_node_class
@@ -102,8 +120,14 @@ class ProportionalIntegralClipped(_ProportionalIntegralCommon):
     Suggested time-steps are always clipped to $\min(\Delta t, t_1-t)$.
     """
 
-    def clip_fn(self, *, state, dt, t1):
-        return jnp.minimum(dt, t1 - state.t)
+    def clip_fn(self, t, t1, state: _PIState) -> _PIState:
+        dt = state.dt_proposed
+        dt_clipped = jnp.minimum(dt, t1 - t)
+        return _PIState(dt_clipped, state.error_norm_previously_accepted)
+
+
+class _IState(NamedTuple):
+    dt_proposed: jax.Array  # usually a float
 
 
 @jax.tree_util.register_pytree_node_class
@@ -122,16 +146,16 @@ class _IntegralCommon(AbstractControl):
     def tree_unflatten(cls, _aux, children):
         return cls(*children)
 
-    def init_fn(self):
-        return ()
+    def init_fn(self, dt0):
+        return _IState(dt0)
 
     @abc.abstractmethod
-    def clip_fn(self, *, state, dt, t1):
+    def clip_fn(self, t, t1, state):
         raise NotImplementedError
 
     def control_fn(
-        self, *, state, error_normalised, error_contraction_rate, dt_previous
-    ):
+        self, error_normalised, error_contraction_rate, state: _IState
+    ) -> _IState:
         scale_factor_unclipped = self.safety * (
             error_normalised ** (-1.0 / error_contraction_rate)
         )
@@ -139,7 +163,11 @@ class _IntegralCommon(AbstractControl):
         scale_factor = jnp.maximum(
             self.factor_min, jnp.minimum(scale_factor_unclipped, self.factor_max)
         )
-        return scale_factor * dt_previous, ()
+        dt = scale_factor * state.dt_proposed
+        return _IState(dt)
+
+    def extract_fn(self, state: S) -> jax.Array:
+        return state.dt_proposed
 
 
 @jax.tree_util.register_pytree_node_class
@@ -147,8 +175,8 @@ class _IntegralCommon(AbstractControl):
 class Integral(_IntegralCommon):
     r"""Integral (I) controller."""
 
-    def clip_fn(self, *, state, dt, t1):
-        return dt
+    def clip_fn(self, t, t1, state):
+        return state
 
 
 @jax.tree_util.register_pytree_node_class
@@ -159,5 +187,7 @@ class IntegralClipped(_IntegralCommon):
     Time-steps are always clipped to $\min(\Delta t, t_1-t)$.
     """
 
-    def clip_fn(self, *, state, dt, t1):
-        return jnp.minimum(dt, t1 - state.t)
+    def clip_fn(self, t, t1, state):
+        dt = state.dt_proposed
+        dt_clipped = jnp.minimum(dt, t1 - t)
+        return _IState(dt_clipped)

--- a/probdiffeq/controls.py
+++ b/probdiffeq/controls.py
@@ -99,7 +99,7 @@ class _ProportionalIntegralCommon(AbstractControl[_PIState]):
         )
         return state
 
-    def extract_fn(self, state: S) -> jax.Array:
+    def extract_fn(self, state: _PIState) -> jax.Array:
         return state.dt_proposed
 
 
@@ -132,7 +132,7 @@ class _IState(NamedTuple):
 
 @jax.tree_util.register_pytree_node_class
 @dataclasses.dataclass
-class _IntegralCommon(AbstractControl):
+class _IntegralCommon(AbstractControl[_IState]):
     safety: float = 0.95
     factor_min: float = 0.2
     factor_max: float = 10.0
@@ -146,11 +146,11 @@ class _IntegralCommon(AbstractControl):
     def tree_unflatten(cls, _aux, children):
         return cls(*children)
 
-    def init_fn(self, dt0):
+    def init_fn(self, dt0) -> _IState:
         return _IState(dt0)
 
     @abc.abstractmethod
-    def clip_fn(self, t, t1, state):
+    def clip_fn(self, t, t1, state: _IState) -> _IState:
         raise NotImplementedError
 
     def control_fn(
@@ -166,7 +166,7 @@ class _IntegralCommon(AbstractControl):
         dt = scale_factor * state.dt_proposed
         return _IState(dt)
 
-    def extract_fn(self, state: S) -> jax.Array:
+    def extract_fn(self, state: _IState) -> jax.Array:
         return state.dt_proposed
 
 


### PR DESCRIPTION
This PR moves the time-step into the controller state thereby completing the `x = extract(init(x))` refactor for the controller.

It also updates some of the method names in the controller.

Technically, the changes break some of the API. But since the constructors remain identical, no entry in the changelog. 

From now on, the controller-constructors can be made purely functional at any time. We wait until the other methods have caught up, though. 