### PR TITLE
Improve usage of `posterior` vocabulary in solvers

### DIFF
--- a/probdiffeq/implementations/_collections.py
+++ b/probdiffeq/implementations/_collections.py
@@ -131,14 +131,14 @@ class AbstractExtrapolation(abc.ABC, Generic[SSVTypeVar, CacheTypeVar]):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def begin_extrapolation(self, p0, /, dt) -> Tuple[SSVTypeVar, CacheTypeVar]:
+    def begin_extrapolation(self, s0, /, dt) -> Tuple[SSVTypeVar, CacheTypeVar]:
         raise NotImplementedError
 
     @abc.abstractmethod
     def complete_extrapolation_without_reversal(
         self,
         output_begin: SSVTypeVar,
-        p0,
+        s0,
         cache: CacheTypeVar,
         output_scale,
     ):
@@ -148,7 +148,7 @@ class AbstractExtrapolation(abc.ABC, Generic[SSVTypeVar, CacheTypeVar]):
     def complete_extrapolation_with_reversal(
         self,
         output_begin: SSVTypeVar,
-        p0,
+        s0,
         cache: CacheTypeVar,
         output_scale,
     ):

--- a/probdiffeq/implementations/blockdiag/extra.py
+++ b/probdiffeq/implementations/blockdiag/extra.py
@@ -46,15 +46,15 @@ class _BlockDiag(_collections.AbstractExtrapolation):
         (extra,) = children
         return cls(extra)
 
-    def begin_extrapolation(self, p0, /, dt):
+    def begin_extrapolation(self, s0, /, dt):
         fn = jax.vmap(type(self.extra).begin_extrapolation, in_axes=(0, 0, None))
-        return fn(self.extra, p0, dt)
+        return fn(self.extra, s0, dt)
 
     def complete_extrapolation_without_reversal(
-        self, output_begin, /, p0, output_scale
+        self, output_begin, /, s0, output_scale
     ):
         fn = jax.vmap(type(self.extra).complete_extrapolation_without_reversal)
-        return fn(self.extra, output_begin, p0, output_scale)
+        return fn(self.extra, output_begin, s0, output_scale)
 
     def init_conditional(self, ssv_proto):
         return jax.vmap(type(self.extra).init_conditional)(self.extra, ssv_proto)
@@ -75,6 +75,6 @@ class _BlockDiag(_collections.AbstractExtrapolation):
         fn_vmap = jax.vmap(type(self.extra).init_output_scale)
         return fn_vmap(self.extra, output_scale)
 
-    def complete_extrapolation_with_reversal(self, output_begin, /, p0, output_scale):
+    def complete_extrapolation_with_reversal(self, output_begin, /, s0, output_scale):
         fn = jax.vmap(type(self.extra).complete_extrapolation_with_reversal)
-        return fn(self.extra, output_begin, p0, output_scale)
+        return fn(self.extra, output_begin, s0, output_scale)

--- a/probdiffeq/implementations/dense/extra.py
+++ b/probdiffeq/implementations/dense/extra.py
@@ -96,9 +96,9 @@ class _DenseIBM(_collections.AbstractExtrapolation):
     def init_error_estimate(self):
         return jnp.zeros(self.ode_shape)  # the initialisation is error-free
 
-    def begin_extrapolation(self, p0, /, dt):
+    def begin_extrapolation(self, s0, /, dt):
         p, p_inv = self._assemble_preconditioner(dt=dt)
-        m0_p = p_inv * p0.hidden_state.mean
+        m0_p = p_inv * s0.hidden_state.mean
         m_ext_p = self.a @ m0_p
         m_ext = p * m_ext_p
         q_sqrtm = p[:, None] * self.q_sqrtm_lower
@@ -120,13 +120,13 @@ class _DenseIBM(_collections.AbstractExtrapolation):
         return p, p_inv
 
     def complete_extrapolation_without_reversal(
-        self, output_begin, /, p0, output_scale
+        self, output_begin, /, s0, output_scale
     ):
         _, _, p, p_inv = output_begin.cache
         m_ext = output_begin.hidden_state.mean
         l_ext_p = _sqrt_util.sum_of_sqrtm_factors(
             R_stack=(
-                (self.a @ (p_inv[:, None] * p0.hidden_state.cov_sqrtm_lower)).T,
+                (self.a @ (p_inv[:, None] * s0.hidden_state.cov_sqrtm_lower)).T,
                 (output_scale * self.q_sqrtm_lower).T,
             )
         ).T
@@ -136,11 +136,11 @@ class _DenseIBM(_collections.AbstractExtrapolation):
         rv = _vars.DenseNormal(mean=m_ext, cov_sqrtm_lower=l_ext)
         return _vars.DenseStateSpaceVar(rv, cache=None, target_shape=shape)
 
-    def complete_extrapolation_with_reversal(self, output_begin, /, p0, output_scale):
+    def complete_extrapolation_with_reversal(self, output_begin, /, s0, output_scale):
         m_ext_p, m0_p, p, p_inv = output_begin.cache
         m_ext = output_begin.hidden_state.mean
 
-        l0_p = p_inv[:, None] * p0.hidden_state.cov_sqrtm_lower
+        l0_p = p_inv[:, None] * s0.hidden_state.cov_sqrtm_lower
         r_ext_p, (r_bw_p, g_bw_p) = _sqrt_util.revert_conditional(
             R_X_F=(self.a @ l0_p).T,
             R_X=l0_p.T,

--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -193,7 +193,7 @@ class CalibrationFreeSolver(AbstractSolver):
         extrapolated = self.strategy.complete_extrapolation(
             output_extra,
             output_scale=state.output_scale_prior,
-            posterior_previous=state.posterior,
+            state_previous=state.posterior,
         )
 
         # Complete step (incl. calibration!)
@@ -259,7 +259,7 @@ class DynamicSolver(AbstractSolver):
 
         extrapolated = self.strategy.complete_extrapolation(
             output_extra,
-            posterior_previous=state.posterior,
+            state_previous=state.posterior,
             output_scale=output_scale,
         )
 
@@ -327,7 +327,7 @@ class MLESolver(AbstractSolver):
         extrapolated = self.strategy.complete_extrapolation(
             output_extra,
             output_scale=state.output_scale_prior,
-            posterior_previous=state.posterior,
+            state_previous=state.posterior,
         )
         # Complete step (incl. calibration!)
         observed, (corrected, _) = self.strategy.complete_correction(

--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -114,8 +114,8 @@ class AbstractSolver(abc.ABC):
         self, s0: _State, s1: _State, t
     ) -> _collections.InterpRes[_State]:
         acc_p, sol_p, prev_p = self.strategy.case_interpolate(
-            p0=s0.strategy,
-            p1=s1.strategy,
+            s0=s0.strategy,
+            s1=s1.strategy,
             t=t,
             t0=s0.t,
             t1=s1.t,
@@ -135,8 +135,8 @@ class AbstractSolver(abc.ABC):
     ) -> _collections.InterpRes[_State]:
         # todo: are all these arguments needed?
         acc_p, sol_p, prev_p = self.strategy.case_right_corner(
-            p0=s0.strategy,
-            p1=s1.strategy,
+            s0=s0.strategy,
+            s1=s1.strategy,
             t=t,
             t0=s0.t,
             t1=s1.t,

--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -15,6 +15,7 @@ class _State(NamedTuple):
     # Same as in solution.Solution()
     t: Any
     u: Any
+    # todo: rename this to 'strategy', indicating the strategy's state.
     posterior: Any
     num_data_points: Any
 
@@ -57,7 +58,7 @@ class AbstractSolver(abc.ABC):
     def extract_terminal_values_fn(self, state: _State, /) -> solution.Solution:
         raise NotImplementedError
 
-    def solution_from_tcoeffs(self, taylor_coefficients, /, **kwargs):
+    def solution_from_tcoeffs(self, taylor_coefficients, /, t, output_scale):
         """Construct an initial `Solution` object.
 
         An (even if empty) solution object is needed to initialise the solver.
@@ -66,10 +67,7 @@ class AbstractSolver(abc.ABC):
         """
         posterior = self.strategy.init(taylor_coefficients=taylor_coefficients)
         u = taylor_coefficients[0]
-        return self.solution_from_posterior(posterior, u=u, **kwargs)
 
-    def solution_from_posterior(self, posterior, /, *, u, t, output_scale):
-        """Use for initialisation but also for interpolation."""
         # todo: if we `init()` this output scale, should we also `extract()`?
         output_scale = self.strategy.init_output_scale(output_scale)
 

--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -365,8 +365,8 @@ class MLESolver(AbstractSolver):
             return fn_vmap(diffsqrtm, obs)
 
         x = obs.mahalanobis_norm(jnp.zeros_like(obs.mean)) / jnp.sqrt(obs.mean.size)
-        sum = _sqrt_util.sqrt_sum_square(jnp.sqrt(n) * diffsqrtm, x)
-        return sum / jnp.sqrt(n + 1)
+        sum_updated = _sqrt_util.sqrt_sum_square(jnp.sqrt(n) * diffsqrtm, x)
+        return sum_updated / jnp.sqrt(n + 1)
 
     def extract_fn(self, state: _State, /) -> solution.Solution:
         # 'state' is batched. Thus, output scale is an array instead of a scalar.

--- a/probdiffeq/strategies/_strategy.py
+++ b/probdiffeq/strategies/_strategy.py
@@ -50,13 +50,13 @@ class Strategy(abc.ABC, Generic[S, P]):
 
     @abc.abstractmethod
     def case_right_corner(
-        self, *, p0: S, p1: S, t, t0, t1, output_scale
+        self, *, s0: S, s1: S, t, t0, t1, output_scale
     ) -> _collections.InterpRes[S]:
         raise NotImplementedError
 
     @abc.abstractmethod
     def case_interpolate(
-        self, *, p0: S, p1: S, t, t0, t1, output_scale
+        self, *, s0: S, s1: S, t, t0, t1, output_scale
     ) -> _collections.InterpRes[S]:
         raise NotImplementedError
 

--- a/probdiffeq/strategies/_strategy.py
+++ b/probdiffeq/strategies/_strategy.py
@@ -7,14 +7,19 @@ import jax
 
 from probdiffeq import _collections
 
+S = TypeVar("S")
+"""A type-variable to indicate strategy-state types."""
+
 P = TypeVar("P")
-"""A type-variable to indicate strategy-state ("posterior") types."""
+"""A type-variable to indicate strategy-solution ("posterior") types."""
 
 
 @jax.tree_util.register_pytree_node_class
-class Strategy(abc.ABC, Generic[P]):
+class Strategy(abc.ABC, Generic[S, P]):
     """Inference strategy interface."""
 
+    # todo: self.extrapolation and self.correction instead of self.implementation.*
+    #  maybe ask for Smoother(*ts0_iso()).
     def __init__(self, implementation):
         self.implementation = implementation
 
@@ -22,41 +27,42 @@ class Strategy(abc.ABC, Generic[P]):
         args = f"implementation={self.implementation}"
         return f"{self.__class__.__name__}({args})"
 
+    # todo: init() should be init(S) -> P. make empty_solution(tcoeffs) fn.
     @abc.abstractmethod
-    def init(self, *, taylor_coefficients) -> P:
+    def init(self, *, taylor_coefficients) -> S:
         raise NotImplementedError
 
     @abc.abstractmethod
-    def extract(self, posterior: P, /):
+    def extract(self, state: S, /) -> P:
         raise NotImplementedError
 
     @abc.abstractmethod
-    def extract_u(self, posterior: P, /):
+    def extract_u(self, state: S, /):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def extract_marginals(self, posterior: P, /):
+    def extract_marginals(self, state: S, /):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def extract_marginals_terminal_values(self, posterior: P, /):
+    def extract_marginals_terminal_values(self, state: S, /):
         raise NotImplementedError
 
     @abc.abstractmethod
     def case_right_corner(
-        self, *, p0: P, p1: P, t, t0, t1, output_scale
-    ) -> _collections.InterpRes[P]:
+        self, *, p0: S, p1: S, t, t0, t1, output_scale
+    ) -> _collections.InterpRes[S]:
         raise NotImplementedError
 
     @abc.abstractmethod
     def case_interpolate(
-        self, *, p0: P, p1: P, t, t0, t1, output_scale
-    ) -> _collections.InterpRes[P]:
+        self, *, p0: S, p1: S, t, t0, t1, output_scale
+    ) -> _collections.InterpRes[S]:
         raise NotImplementedError
 
     @abc.abstractmethod
     def offgrid_marginals(
-        self, *, t, marginals, posterior, posterior_previous: P, t0, t1, output_scale
+        self, *, t, marginals, posterior: P, posterior_previous: P, t0, t1, output_scale
     ):
         raise NotImplementedError
 
@@ -65,21 +71,21 @@ class Strategy(abc.ABC, Generic[P]):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def begin_extrapolation(self, posterior: P, /, *, dt):
+    def begin_extrapolation(self, state: S, /, *, dt) -> S:
         raise NotImplementedError
 
     @abc.abstractmethod
     def complete_extrapolation(
-        self, output_extra: P, /, *, output_scale, posterior_previous: P
-    ):
+        self, output_extra: S, /, *, output_scale, state_previous: S
+    ) -> S:
         raise NotImplementedError
 
     @abc.abstractmethod
-    def begin_correction(self, output_extra: P, /, *, vector_field, t, p):
+    def begin_correction(self, output_extra: S, /, *, vector_field, t, p):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def complete_correction(self, extrapolated: P, /, *, cache_obs):
+    def complete_correction(self, extrapolated: S, /, *, cache_obs):
         raise NotImplementedError
 
     def tree_flatten(self):

--- a/probdiffeq/strategies/filters.py
+++ b/probdiffeq/strategies/filters.py
@@ -29,7 +29,7 @@ class _FiState(NamedTuple):
 
 
 @jax.tree_util.register_pytree_node_class
-class Filter(_strategy.Strategy[_FiState]):
+class Filter(_strategy.Strategy[_FiState, Any]):
     """Filter strategy."""
 
     # todo: this should not operate on taylor_coefficients but on some SSV.
@@ -58,7 +58,7 @@ class Filter(_strategy.Strategy[_FiState]):
         output_extra = self.begin_extrapolation(p0, dt=dt)
         extrapolated = self.complete_extrapolation(
             output_extra,
-            posterior_previous=p0,
+            state_previous=p0,
             output_scale=output_scale,
         )
         return _collections.InterpRes(
@@ -119,14 +119,14 @@ class Filter(_strategy.Strategy[_FiState]):
         /,
         *,
         output_scale,
-        posterior_previous: _FiState,
+        state_previous: _FiState,
     ) -> _FiState:
         extra = self.implementation.extrapolation
         extrapolate_fn = extra.complete_extrapolation_without_reversal
         # todo: extrapolation needs a serious signature-variable-renaming...
         ssv = extrapolate_fn(
             output_extra.ssv,
-            p0=posterior_previous.ssv,
+            p0=state_previous.ssv,
             output_scale=output_scale,
         )
         return _FiState(ssv)

--- a/probdiffeq/strategies/filters.py
+++ b/probdiffeq/strategies/filters.py
@@ -45,24 +45,24 @@ class Filter(_strategy.Strategy[_FiState, Any]):
     # todo: make interpolation result into a named-tuple.
     #  it is too confusing what those three posteriors mean.
     def case_right_corner(
-        self, *, p0: _FiState, p1: _FiState, t, t0, t1, output_scale
+        self, *, s0: _FiState, s1: _FiState, t, t0, t1, output_scale
     ) -> _collections.InterpRes[_FiState]:  # s1.t == t
-        return _collections.InterpRes(accepted=p1, solution=p1, previous=p1)
+        return _collections.InterpRes(accepted=s1, solution=s1, previous=s1)
 
     def case_interpolate(
-        self, *, p0: _FiState, p1: _FiState, t0, t, t1, output_scale
+        self, *, s0: _FiState, s1: _FiState, t0, t, t1, output_scale
     ) -> _collections.InterpRes[_FiState]:
         # A filter interpolates by extrapolating from the previous time-point
         # to the in-between variable. That's it.
         dt = t - t0
-        output_extra = self.begin_extrapolation(p0, dt=dt)
+        output_extra = self.begin_extrapolation(s0, dt=dt)
         extrapolated = self.complete_extrapolation(
             output_extra,
-            state_previous=p0,
+            state_previous=s0,
             output_scale=output_scale,
         )
         return _collections.InterpRes(
-            accepted=p1, solution=extrapolated, previous=extrapolated
+            accepted=s1, solution=extrapolated, previous=extrapolated
         )
 
     def offgrid_marginals(
@@ -78,8 +78,8 @@ class Filter(_strategy.Strategy[_FiState, Any]):
     ) -> Tuple[jax.Array, _FiState]:
         _acc, sol, _prev = self.case_interpolate(
             t=t,
-            p1=_FiState(posterior),
-            p0=_FiState(posterior_previous),
+            s1=_FiState(posterior),
+            s0=_FiState(posterior_previous),
             t0=t0,
             t1=t1,
             output_scale=output_scale,
@@ -126,7 +126,7 @@ class Filter(_strategy.Strategy[_FiState, Any]):
         # todo: extrapolation needs a serious signature-variable-renaming...
         ssv = extrapolate_fn(
             output_extra.ssv,
-            p0=state_previous.ssv,
+            s0=state_previous.ssv,
             output_scale=output_scale,
         )
         return _FiState(ssv)

--- a/probdiffeq/strategies/smoothers.py
+++ b/probdiffeq/strategies/smoothers.py
@@ -134,7 +134,7 @@ class _SmootherCommon(_strategy.Strategy):
         /,
         *,
         output_scale,
-        posterior_previous: MarkovSequence,
+        state_previous: MarkovSequence,
     ):
         raise NotImplementedError
 
@@ -227,13 +227,13 @@ class Smoother(_SmootherCommon):
         /,
         *,
         output_scale,
-        posterior_previous: MarkovSequence,
+        state_previous: MarkovSequence,
     ) -> MarkovSequence:
         extra = self.implementation.extrapolation
         extra_fn = extra.complete_extrapolation_with_reversal
         extrapolated, bw_model = extra_fn(
             output_extra.init,
-            p0=posterior_previous.init,
+            p0=state_previous.init,
             output_scale=output_scale,
         )
         return MarkovSequence(init=extrapolated, backward_model=bw_model)
@@ -312,17 +312,17 @@ class FixedPointSmoother(_SmootherCommon):
         output_extra: MarkovSequence,
         /,
         *,
-        posterior_previous: MarkovSequence,
+        state_previous: MarkovSequence,
         output_scale,
     ):
         _temp = self.implementation.extrapolation.complete_extrapolation_with_reversal(
             output_extra.init,
-            p0=posterior_previous.init,
+            p0=state_previous.init,
             output_scale=output_scale,
         )
         extrapolated, bw_increment = _temp
 
-        merge_fn = posterior_previous.backward_model.merge_with_incoming_conditional
+        merge_fn = state_previous.backward_model.merge_with_incoming_conditional
         backward_model = merge_fn(bw_increment)
 
         return MarkovSequence(init=extrapolated, backward_model=backward_model)

--- a/probdiffeq/strategies/smoothers.py
+++ b/probdiffeq/strategies/smoothers.py
@@ -103,13 +103,13 @@ class _SmootherCommon(_strategy.Strategy):
 
     @abc.abstractmethod
     def case_interpolate(
-        self, *, p0: MarkovSequence, p1: MarkovSequence, t, t0, t1, output_scale
+        self, *, s0: MarkovSequence, s1: MarkovSequence, t, t0, t1, output_scale
     ) -> _collections.InterpRes[MarkovSequence]:
         raise NotImplementedError
 
     @abc.abstractmethod
     def case_right_corner(
-        self, *, p0: MarkovSequence, p1: MarkovSequence, t, t0, t1, output_scale
+        self, *, s0: MarkovSequence, s1: MarkovSequence, t, t0, t1, output_scale
     ) -> _collections.InterpRes[MarkovSequence]:
         raise NotImplementedError
 
@@ -205,7 +205,7 @@ class _SmootherCommon(_strategy.Strategy):
         extra_fn = _extra.complete_extrapolation_with_reversal
         extrapolated, bw_model = extra_fn(
             output_extra,
-            p0=rv,
+            s0=rv,
             output_scale=output_scale,
         )
         return extrapolated, bw_model  # should this return a MarkovSequence?
@@ -233,20 +233,20 @@ class Smoother(_SmootherCommon):
         extra_fn = extra.complete_extrapolation_with_reversal
         extrapolated, bw_model = extra_fn(
             output_extra.init,
-            p0=state_previous.init,
+            s0=state_previous.init,
             output_scale=output_scale,
         )
         return MarkovSequence(init=extrapolated, backward_model=bw_model)
 
     def case_right_corner(
-        self, *, p0: MarkovSequence, p1: MarkovSequence, t, t0, t1, output_scale
+        self, *, s0: MarkovSequence, s1: MarkovSequence, t, t0, t1, output_scale
     ) -> _collections.InterpRes[MarkovSequence]:
         # todo: is this duplication unnecessary?
-        accepted = self._duplicate_with_unit_backward_model(posterior=p1)
-        return _collections.InterpRes(accepted=accepted, solution=p1, previous=p1)
+        accepted = self._duplicate_with_unit_backward_model(posterior=s1)
+        return _collections.InterpRes(accepted=accepted, solution=s1, previous=s1)
 
     def case_interpolate(
-        self, *, p0: MarkovSequence, p1: MarkovSequence, t0, t1, t, output_scale
+        self, *, s0: MarkovSequence, s1: MarkovSequence, t0, t1, t, output_scale
     ) -> _collections.InterpRes[MarkovSequence]:
         # A smoother interpolates by reverting the Markov kernels between s0.t and t
         # which gives an extrapolation and a backward transition;
@@ -257,14 +257,14 @@ class Smoother(_SmootherCommon):
 
         # Extrapolate from t0 to t, and from t to t1
         extrapolated0, backward_model0 = self._interpolate_from_to_fn(
-            rv=p0.init, output_scale=output_scale, t=t, t0=t0
+            rv=s0.init, output_scale=output_scale, t=t, t0=t0
         )
         posterior0 = MarkovSequence(init=extrapolated0, backward_model=backward_model0)
 
         _, backward_model1 = self._interpolate_from_to_fn(
             rv=extrapolated0, output_scale=output_scale, t=t1, t0=t
         )
-        posterior1 = MarkovSequence(init=p1.init, backward_model=backward_model1)
+        posterior1 = MarkovSequence(init=s1.init, backward_model=backward_model1)
 
         return _collections.InterpRes(
             accepted=posterior1, solution=posterior0, previous=posterior0
@@ -284,8 +284,8 @@ class Smoother(_SmootherCommon):
     ):
         acc, _sol, _prev = self.case_interpolate(
             t=t,
-            p1=posterior,
-            p0=posterior_previous,
+            s1=posterior,
+            s0=posterior_previous,
             t0=t0,
             t1=t1,
             output_scale=output_scale,
@@ -317,7 +317,7 @@ class FixedPointSmoother(_SmootherCommon):
     ):
         _temp = self.implementation.extrapolation.complete_extrapolation_with_reversal(
             output_extra.init,
-            p0=state_previous.init,
+            s0=state_previous.init,
             output_scale=output_scale,
         )
         extrapolated, bw_increment = _temp
@@ -328,14 +328,14 @@ class FixedPointSmoother(_SmootherCommon):
         return MarkovSequence(init=extrapolated, backward_model=backward_model)
 
     def case_right_corner(
-        self, *, p0: MarkovSequence, p1: MarkovSequence, t, t0, t1, output_scale
+        self, *, s0: MarkovSequence, s1: MarkovSequence, t, t0, t1, output_scale
     ):  # s1.t == t
         # can we guarantee that the backward model in s1 is the
         # correct backward model to get from s0 to s1?
-        merge_fn = p0.backward_model.merge_with_incoming_conditional
-        backward_model1 = merge_fn(p1.backward_model)
+        merge_fn = s0.backward_model.merge_with_incoming_conditional
+        backward_model1 = merge_fn(s1.backward_model)
 
-        solution = MarkovSequence(init=p1.init, backward_model=backward_model1)
+        solution = MarkovSequence(init=s1.init, backward_model=backward_model1)
         accepted = self._duplicate_with_unit_backward_model(posterior=solution)
         previous = accepted
 
@@ -344,7 +344,7 @@ class FixedPointSmoother(_SmootherCommon):
         )
 
     def case_interpolate(
-        self, *, p0: MarkovSequence, p1: MarkovSequence, t, t0, t1, output_scale
+        self, *, s0: MarkovSequence, s1: MarkovSequence, t, t0, t1, output_scale
     ) -> _collections.InterpRes[MarkovSequence]:
         # A fixed-point smoother interpolates almost like a smoother.
         # The key difference is that when interpolating from s0.t to t,
@@ -355,12 +355,12 @@ class FixedPointSmoother(_SmootherCommon):
 
         # From s0.t to t
         extrapolated0, bw0 = self._interpolate_from_to_fn(
-            rv=p0.init,
+            rv=s0.init,
             output_scale=output_scale,
             t=t,
             t0=t0,
         )
-        backward_model0 = p0.backward_model.merge_with_incoming_conditional(bw0)
+        backward_model0 = s0.backward_model.merge_with_incoming_conditional(bw0)
         solution = MarkovSequence(init=extrapolated0, backward_model=backward_model0)
 
         previous = self._duplicate_with_unit_backward_model(posterior=solution)
@@ -368,7 +368,7 @@ class FixedPointSmoother(_SmootherCommon):
         _, backward_model1 = self._interpolate_from_to_fn(
             rv=extrapolated0, output_scale=output_scale, t=t1, t0=t
         )
-        accepted = MarkovSequence(init=p1.init, backward_model=backward_model1)
+        accepted = MarkovSequence(init=s1.init, backward_model=backward_model1)
         return _collections.InterpRes(
             accepted=accepted, solution=solution, previous=previous
         )

--- a/probdiffeq/taylor.py
+++ b/probdiffeq/taylor.py
@@ -218,7 +218,7 @@ def _rk_filter_step(carry, y, extrapolation, dt):
     # Extrapolate (with fixed-point-style merging)
     x = extrapolation.begin_extrapolation(rv, dt=dt)
     extra, bw_model = extrapolation.complete_extrapolation_with_reversal(
-        x, p0=rv, output_scale=1.0
+        x, s0=rv, output_scale=1.0
     )
     bw_new = bw_old.merge_with_incoming_conditional(bw_model)  # sqrt-fp-smoother!
 


### PR DESCRIPTION
Use the variable name `posterior` only where appropriate. 