### PR TITLE
Solution assembly outside of ivpsolvers.py

### DIFF
--- a/probdiffeq/_adaptive.py
+++ b/probdiffeq/_adaptive.py
@@ -300,13 +300,7 @@ class AdaptiveIVPSolver(Generic[T]):
     def extract(self, state: _AdaptiveState, /):
         solver_extract = self.solver.extract(state.solution)
         control_extract = self.control.extract_dt_from_state(state.control)
-
-        # return BOTH dt & solver_extract.
-        #  Usually, only the latter is necessary.
-        #  but we return both because this way, extract is inverse to init,
-        #  and it becomes much easier to restart the solver at a new point
-        #  without losing consistency.
-        return control_extract, solver_extract
+        return solver_extract, control_extract
 
     def extract_at_terminal_values(self, state: _AdaptiveState, /):
         solver_extract = self.solver.extract_at_terminal_values(state.solution)

--- a/probdiffeq/_adaptive.py
+++ b/probdiffeq/_adaptive.py
@@ -159,10 +159,10 @@ class AdaptiveIVPSolver(Generic[T]):
         return self.solver.strategy.extrapolation.num_derivatives + 1
 
     @jax.jit
-    def init(self, solution, dt0):
+    def init(self, t, posterior, output_scale, num_steps, dt0):
         """Initialise the IVP solver state."""
         # Initialise the components
-        state_solver = self.solver.init(solution)
+        state_solver = self.solver.init(t, posterior, output_scale, num_steps)
         state_control = self.control.init_state_from_dt(dt0)
 
         # Initialise (prototypes for) proposed values
@@ -311,7 +311,7 @@ class AdaptiveIVPSolver(Generic[T]):
     def extract_at_terminal_values(self, state: _AdaptiveState, /):
         solver_extract = self.solver.extract_at_terminal_values(state.solution)
         control_extract = self.control.extract_dt_from_state(state.control)
-        return control_extract, solver_extract
+        return solver_extract, control_extract
 
 
 def _inf_like(tree):

--- a/probdiffeq/_collocate.py
+++ b/probdiffeq/_collocate.py
@@ -9,7 +9,10 @@ from probdiffeq import _control_flow
 def solve_and_save_at(
     vector_field,
     *,
-    solution,
+    t,
+    posterior,
+    output_scale,
+    num_steps,
     save_at,
     adaptive_solver,
     dt0,
@@ -27,7 +30,7 @@ def solve_and_save_at(
         )
         return s_next, s_next
 
-    state0 = adaptive_solver.init(solution, dt0=dt0)
+    state0 = adaptive_solver.init(t, posterior, output_scale, num_steps, dt0=dt0)
 
     _, solution = _control_flow.scan_with_init(
         f=advance_to_next_checkpoint,
@@ -35,8 +38,8 @@ def solve_and_save_at(
         xs=save_at[1:],
         reverse=False,
     )
-    _dt, sol = adaptive_solver.extract(solution)
-    return sol
+    sol_solver, _sol_control = adaptive_solver.extract(solution)
+    return sol_solver
 
 
 def simulate_terminal_values(

--- a/probdiffeq/_collocate.py
+++ b/probdiffeq/_collocate.py
@@ -42,14 +42,17 @@ def solve_and_save_at(
 def simulate_terminal_values(
     vector_field,
     *,
-    solution,
+    t,
+    posterior,
+    output_scale,
+    num_steps,
     t1,
     adaptive_solver,
     parameters,
     dt0,
     while_loop_fn,
 ):
-    state0 = adaptive_solver.init(solution, dt0=dt0)
+    state0 = adaptive_solver.init(t, posterior, output_scale, num_steps, dt0=dt0)
     solution = _advance_ivp_solution_adaptively(
         state0=state0,
         t1=t1,
@@ -58,8 +61,8 @@ def simulate_terminal_values(
         parameters=parameters,
         while_loop_fn=while_loop_fn,
     )
-    _dt, sol = adaptive_solver.extract_at_terminal_values(solution)
-    return sol
+    (sol_solver, _sol_control) = adaptive_solver.extract_at_terminal_values(solution)
+    return sol_solver
 
 
 def _advance_ivp_solution_adaptively(

--- a/probdiffeq/_collocate.py
+++ b/probdiffeq/_collocate.py
@@ -160,5 +160,5 @@ def solve_fixed_grid(
     _, (result, _) = _control_flow.scan_with_init(
         f=body_fn, init=(state, t0), xs=grid[1:]
     )
-    _ts, *sol = solver.extract(result)
+    _t, *sol = solver.extract(result)
     return sol

--- a/probdiffeq/ivpsolve.py
+++ b/probdiffeq/ivpsolve.py
@@ -6,7 +6,7 @@ import warnings
 import jax
 import jax.numpy as jnp
 
-from probdiffeq import _adaptive, _collocate, taylor
+from probdiffeq import _adaptive, _collocate, solution, taylor
 from probdiffeq.strategies import smoothers
 
 # The high-level checkpoint-style routines
@@ -54,14 +54,26 @@ def simulate_terminal_values(
         nugget = propose_dt0_nugget
         dt0 = propose_dt0(f, u0s, t0=t0, parameters=parameters, nugget=nugget)
 
-    return _collocate.simulate_terminal_values(
+    t, posterior, output_scale, num_steps = _collocate.simulate_terminal_values(
         jax.tree_util.Partial(vector_field),
-        solution=sol,
+        t=sol.t,
+        posterior=sol.posterior,
+        output_scale=sol.output_scale,
+        num_steps=sol.num_steps,
         t1=t1,
         adaptive_solver=adaptive_solver,
         parameters=parameters,
         dt0=dt0,
         while_loop_fn=while_loop_fn_temporal,
+    )
+    u, marginals = posterior.marginals_terminal_value()
+    return solution.Solution(
+        t=t,
+        u=u,
+        marginals=marginals,
+        posterior=posterior,
+        output_scale=output_scale,
+        num_steps=num_steps,
     )
 
 

--- a/probdiffeq/ivpsolve.py
+++ b/probdiffeq/ivpsolve.py
@@ -196,13 +196,25 @@ def solve_with_python_while_loop(
         nugget = propose_dt0_nugget
         dt0 = propose_dt0(f, u0s, t0=t0, parameters=parameters, nugget=nugget)
 
-    return _collocate.solve_with_python_while_loop(
+    t, posterior, output_scale, num_steps = _collocate.solve_with_python_while_loop(
         jax.tree_util.Partial(vector_field),
-        solution=sol,
+        t=sol.t,
+        posterior=sol.posterior,
+        output_scale=sol.output_scale,
+        num_steps=sol.num_steps,
         t1=t1,
         adaptive_solver=adaptive_solver,
         dt0=dt0,
         parameters=parameters,
+    )
+    u, marginals = posterior.marginals()
+    return solution.Solution(
+        t=t,
+        u=u,
+        marginals=marginals,
+        posterior=posterior,
+        output_scale=output_scale,
+        num_steps=num_steps,
     )
 
 
@@ -229,12 +241,23 @@ def solve_fixed_grid(
     sol = solver.solution_from_tcoeffs(
         taylor_coefficients, t=grid[0], output_scale=output_scale
     )
-    return _collocate.solve_fixed_grid(
+    posterior, output_scale, num_steps = _collocate.solve_fixed_grid(
         jax.tree_util.Partial(vector_field),
-        solution=sol,
+        posterior=sol.posterior,
+        output_scale=sol.output_scale,
+        num_steps=sol.num_steps,
         grid=grid,
         solver=solver,
         parameters=parameters,
+    )
+    u, marginals = posterior.marginals()
+    return solution.Solution(
+        t=grid,
+        u=u,
+        marginals=marginals,
+        posterior=posterior,
+        output_scale=output_scale,
+        num_steps=num_steps,
     )
 
 

--- a/probdiffeq/ivpsolve.py
+++ b/probdiffeq/ivpsolve.py
@@ -130,14 +130,26 @@ def solve_and_save_at(
         nugget = propose_dt0_nugget
         dt0 = propose_dt0(f, u0s, t0=t0, parameters=parameters, nugget=nugget)
 
-    return _collocate.solve_and_save_at(
+    t, posterior, output_scale, num_steps = _collocate.solve_and_save_at(
         jax.tree_util.Partial(vector_field),
-        solution=sol,
+        t=sol.t,
+        posterior=sol.posterior,
+        output_scale=sol.output_scale,
+        num_steps=sol.num_steps,
         save_at=save_at,
         adaptive_solver=adaptive_solver,
         dt0=dt0,
         parameters=parameters,
         while_loop_fn=while_loop_fn_temporal,
+    )
+    u, marginals = posterior.marginals()
+    return solution.Solution(
+        t=t,
+        u=u,
+        marginals=marginals,
+        posterior=posterior,
+        output_scale=output_scale,
+        num_steps=num_steps,
     )
 
 

--- a/probdiffeq/ivpsolve.py
+++ b/probdiffeq/ivpsolve.py
@@ -66,7 +66,7 @@ def simulate_terminal_values(
         dt0=dt0,
         while_loop_fn=while_loop_fn_temporal,
     )
-    u, marginals = posterior.marginals_terminal_value()
+    u, marginals = posterior.marginals_at_terminal_values()
     return solution.Solution(
         t=t,
         u=u,

--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -201,17 +201,8 @@ class CalibrationFreeSolver(Solver):
         )
 
     def extract_at_terminal_values(self, state: _State, /) -> solution.Solution:
-        t, u, marginals, posterior = self.strategy.extract_at_terminal_values(
-            state.strategy
-        )
-        return solution.Solution(
-            t=t,
-            u=u,  # new!
-            marginals=marginals,  # new!
-            posterior=posterior,
-            output_scale=state.output_scale_prior,
-            num_steps=state.num_steps,
-        )
+        t, posterior = self.strategy.extract_at_terminal_values(state.strategy)
+        return t, posterior, state.output_scale_prior, state.num_steps
 
 
 @jax.tree_util.register_pytree_node_class
@@ -257,17 +248,8 @@ class DynamicSolver(Solver):
         )
 
     def extract_at_terminal_values(self, state: _State, /) -> solution.Solution:
-        t, u, marginals, posterior = self.strategy.extract_at_terminal_values(
-            state.strategy
-        )
-        return solution.Solution(
-            t=t,
-            u=u,  # new!
-            marginals=marginals,  # new!
-            posterior=posterior,
-            output_scale=state.output_scale_calibrated,
-            num_steps=state.num_steps,
-        )
+        t, posterior = self.strategy.extract_at_terminal_values(state.strategy)
+        return t, posterior, state.output_scale_calibrated, state.num_steps
 
 
 @jax.tree_util.register_pytree_node_class
@@ -348,8 +330,8 @@ class MLESolver(Solver):
         s = state.output_scale_calibrated
         state = self._rescale_covs(state, output_scale=s)
 
-        _sol = self.strategy.extract_at_terminal_values(state.strategy)
-        t, u, marginals, posterior = _sol
+        t, posterior = self.strategy.extract_at_terminal_values(state.strategy)
+        # t, u, marginals, posterior = _sol
         return t, posterior, state.output_scale_calibrated, state.num_steps
         # return solution.Solution(
         #     t=t,

--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -79,7 +79,7 @@ class Solver(abc.ABC):
 
     def init(self, t, posterior, /, output_scale, num_steps) -> _State:
         error_estimate = self.strategy.init_error_estimate()
-        strategy_state = self.strategy.init(t, None, None, posterior)
+        strategy_state = self.strategy.init(t, posterior)
         return _State(
             error_estimate=error_estimate,
             strategy=strategy_state,

--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -190,8 +190,8 @@ class CalibrationFreeSolver(Solver):
         return t, posterior, state.output_scale_prior, state.num_steps
 
     def extract_at_terminal_values(self, state: _State, /):
-        t, posterior = self.strategy.extract_at_terminal_values(state.strategy)
-        return t, posterior, state.output_scale_prior, state.num_steps
+        #  todo: remove this function soon (once MLESolver has the same redundancy)
+        return self.extract(state)
 
 
 @jax.tree_util.register_pytree_node_class
@@ -230,8 +230,8 @@ class DynamicSolver(Solver):
         return t, posterior, state.output_scale_calibrated, state.num_steps
 
     def extract_at_terminal_values(self, state: _State, /):
-        t, posterior = self.strategy.extract_at_terminal_values(state.strategy)
-        return t, posterior, state.output_scale_calibrated, state.num_steps
+        #  todo: remove this function soon (once MLESolver has the same redundancy)
+        return self.extract(state)
 
 
 @jax.tree_util.register_pytree_node_class
@@ -305,7 +305,7 @@ class MLESolver(Solver):
         s = state.output_scale_calibrated
         state = self._rescale_covs(state, output_scale=s)
 
-        t, posterior = self.strategy.extract_at_terminal_values(state.strategy)
+        t, posterior = self.strategy.extract(state.strategy)
         return t, posterior, state.output_scale_calibrated, state.num_steps
 
     def _rescale_covs(self, state, /, *, output_scale):

--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -13,7 +13,6 @@ from probdiffeq._collections import InterpRes  # simplify type signatures
 class _State(NamedTuple):
     """Solver state."""
 
-    # Same as in solution.Solution()
     strategy: Any
 
     error_estimate: Any
@@ -48,11 +47,11 @@ class Solver(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def extract(self, state: _State, /) -> solution.Solution:
+    def extract(self, state: _State, /):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def extract_at_terminal_values(self, state: _State, /) -> solution.Solution:
+    def extract_at_terminal_values(self, state: _State, /):
         raise NotImplementedError
 
     def solution_from_tcoeffs(
@@ -186,11 +185,11 @@ class CalibrationFreeSolver(Solver):
             num_steps=state.num_steps + 1,
         )
 
-    def extract(self, state: _State, /) -> solution.Solution:
+    def extract(self, state: _State, /):
         t, posterior = self.strategy.extract(state.strategy)
         return t, posterior, state.output_scale_prior, state.num_steps
 
-    def extract_at_terminal_values(self, state: _State, /) -> solution.Solution:
+    def extract_at_terminal_values(self, state: _State, /):
         t, posterior = self.strategy.extract_at_terminal_values(state.strategy)
         return t, posterior, state.output_scale_prior, state.num_steps
 
@@ -226,11 +225,11 @@ class DynamicSolver(Solver):
             num_steps=state.num_steps + 1,
         )
 
-    def extract(self, state: _State, /) -> solution.Solution:
+    def extract(self, state: _State, /):
         t, posterior = self.strategy.extract(state.strategy)
         return t, posterior, state.output_scale_calibrated, state.num_steps
 
-    def extract_at_terminal_values(self, state: _State, /) -> solution.Solution:
+    def extract_at_terminal_values(self, state: _State, /):
         t, posterior = self.strategy.extract_at_terminal_values(state.strategy)
         return t, posterior, state.output_scale_calibrated, state.num_steps
 
@@ -288,7 +287,7 @@ class MLESolver(Solver):
         sum_updated = _sqrt_util.sqrt_sum_square(jnp.sqrt(n) * diffsqrtm, x)
         return sum_updated / jnp.sqrt(n + 1)
 
-    def extract(self, state: _State, /) -> solution.Solution:
+    def extract(self, state: _State, /):
         # 'state' is batched. Thus, output scale is an array instead of a scalar.
 
         # Important: Rescale before extracting! Otherwise backward samples are wrong.

--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -306,7 +306,6 @@ class MLESolver(Solver):
         state = self._rescale_covs(state, output_scale=s)
 
         t, posterior = self.strategy.extract_at_terminal_values(state.strategy)
-        # t, u, marginals, posterior = _sol
         return t, posterior, state.output_scale_calibrated, state.num_steps
 
     def _rescale_covs(self, state, /, *, output_scale):

--- a/probdiffeq/solution.py
+++ b/probdiffeq/solution.py
@@ -177,7 +177,7 @@ def log_marginal_likelihood_terminal_values(*, observation_std, u, posterior, st
             f"ndim={jnp.ndim(u)}, shape={jnp.shape(u)} received."
         )
 
-    ssv = strategy.init(None, None, None, posterior).ssv
+    ssv = strategy.init(None, posterior).ssv
     obs, _ = ssv.observe_qoi(observation_std=observation_std)
     return jnp.sum(obs.logpdf(u))
 

--- a/probdiffeq/statespace/iso/_vars.py
+++ b/probdiffeq/statespace/iso/_vars.py
@@ -92,7 +92,7 @@ class IsoNormalHiddenState(_collections.Normal):
         return IsoNormalQOI(mean=mean, cov_sqrtm_lower=cov_sqrtm_lower)
 
     def extract_qoi_from_sample(self, u, /):
-        return u[0, :]
+        return u[..., 0, :]
 
 
 @jax.tree_util.register_pytree_node_class

--- a/probdiffeq/statespace/scalar/_vars.py
+++ b/probdiffeq/statespace/scalar/_vars.py
@@ -155,4 +155,6 @@ class NormalHiddenState(_collections.Normal):
         return NormalQOI(mean=mean, cov_sqrtm_lower=jnp.reshape(cov_sqrtm_lower, ()))
 
     def extract_qoi_from_sample(self, u, /):
-        return u[0]
+        if u.ndim == 1:
+            return u[0]
+        return jax.vmap(self.extract_qoi_from_sample)(u)

--- a/probdiffeq/strategies/_strategy.py
+++ b/probdiffeq/strategies/_strategy.py
@@ -18,7 +18,7 @@ R = TypeVar("R")
 
 
 class Posterior(abc.ABC, Generic[R]):
-    def __init__(self, rv: S, /):
+    def __init__(self, rv: R, /):
         self.rv = rv
 
     def tree_flatten(self):
@@ -55,7 +55,7 @@ class Strategy(abc.ABC, Generic[S, P]):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def init(self, t, u, marginals, solution: P, /) -> S:
+    def init(self, t, solution: P, /) -> S:
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/probdiffeq/strategies/_strategy.py
+++ b/probdiffeq/strategies/_strategy.py
@@ -63,10 +63,6 @@ class Strategy(abc.ABC, Generic[S, P]):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def extract_at_terminal_values(self, state: S, /) -> P:
-        raise NotImplementedError
-
-    @abc.abstractmethod
     def case_right_corner(self, t, *, s0: S, s1: S, output_scale) -> InterpRes[S]:
         raise NotImplementedError
 

--- a/probdiffeq/strategies/_strategy.py
+++ b/probdiffeq/strategies/_strategy.py
@@ -18,18 +18,18 @@ R = TypeVar("R")
 
 
 class Posterior(abc.ABC, Generic[R]):
-    def __init__(self, rv: R, /):
-        self.rv = rv
+    def __init__(self, rand: R, /):
+        self.rand = rand
 
     def tree_flatten(self):
-        children = (self.rv,)
+        children = (self.rand,)
         aux = ()
         return children, aux
 
     @classmethod
     def tree_unflatten(cls, _aux, children):
-        (rv,) = children
-        return cls(rv)
+        (rand,) = children
+        return cls(rand)
 
     @abc.abstractmethod
     def sample(self, key, *, shape):

--- a/probdiffeq/strategies/filters.py
+++ b/probdiffeq/strategies/filters.py
@@ -86,9 +86,7 @@ class Filter(_strategy.Strategy[_FiState, Any]):
         rv = self.extrapolation.filter_extract(ssv, posterior.extra)
 
         solution = FilterDist(rv)  # type: ignore
-        marginals = rv
-        u = posterior.u
-        return t, u, marginals, solution
+        return t, solution
 
     def extract_at_terminal_values(self, posterior: _FiState, /) -> _SolType:
         return self.extract(posterior)

--- a/probdiffeq/strategies/filters.py
+++ b/probdiffeq/strategies/filters.py
@@ -49,6 +49,11 @@ class FilterDist(_strategy.Posterior[S]):
     def sample(self, key, *, shape):
         raise NotImplementedError
 
+    def marginals_terminal_value(self):
+        marginals = self.rv
+        u = marginals.extract_qoi_from_sample(marginals.mean)
+        return u, marginals
+
 
 _SolType = Tuple[float, jax.Array, jax.Array, FilterDist]
 
@@ -64,12 +69,12 @@ class Filter(_strategy.Strategy[_FiState, Any]):
         u = taylor_coefficients[0]
         return u, marginals, sol
 
-    def init(self, t, u, _marginals, solution) -> _FiState:
+    def init(self, t, _u, _marginals, solution) -> _FiState:
         ssv, extra = self.extrapolation.filter_init(solution.rv)
         ssv, corr = self.correction.init(ssv)
         return _FiState(
             t=t,
-            u=u,
+            u=ssv.extract_qoi(),
             ssv=ssv,
             extra=extra,
             corr=corr,

--- a/probdiffeq/strategies/filters.py
+++ b/probdiffeq/strategies/filters.py
@@ -54,6 +54,11 @@ class FilterDist(_strategy.Posterior[S]):
         u = marginals.extract_qoi_from_sample(marginals.mean)
         return u, marginals
 
+    def marginals(self):
+        marginals = self.rv
+        u = marginals.extract_qoi_from_sample(marginals.mean)
+        return u, marginals
+
 
 _SolType = Tuple[float, jax.Array, jax.Array, FilterDist]
 

--- a/probdiffeq/strategies/filters.py
+++ b/probdiffeq/strategies/filters.py
@@ -50,12 +50,12 @@ class FilterDist(_strategy.Posterior[S]):
         raise NotImplementedError
 
     def marginals_at_terminal_values(self):
-        marginals = self.rv
+        marginals = self.rand
         u = marginals.extract_qoi_from_sample(marginals.mean)
         return u, marginals
 
     def marginals(self):
-        marginals = self.rv
+        marginals = self.rand
         u = marginals.extract_qoi_from_sample(marginals.mean)
         return u, marginals
 
@@ -72,7 +72,7 @@ class Filter(_strategy.Strategy[_FiState, Any]):
         return u, marginals, sol
 
     def init(self, t, solution) -> _FiState:
-        ssv, extra = self.extrapolation.filter_init(solution.rv)
+        ssv, extra = self.extrapolation.filter_init(solution.rand)
         ssv, corr = self.correction.init(ssv)
         return _FiState(t=t, u=ssv.extract_qoi(), ssv=ssv, extra=extra, corr=corr)
 

--- a/probdiffeq/strategies/smoothers.py
+++ b/probdiffeq/strategies/smoothers.py
@@ -22,8 +22,6 @@ class SmootherSol(_strategy.Posterior[S]):
 
     def marginals_terminal_value(self):
         marginals = self.rv.init
-        #
-        # marginals = self._extract_marginals(self.rv)
         u = marginals.extract_qoi_from_sample(marginals.mean)
         return u, marginals
 
@@ -123,10 +121,6 @@ class _SmootherCommon(_strategy.Strategy):
         mseq = self.extrapolation.smoother_extract(ssv, state.extra)
         sol = SmootherSol(mseq)  # type: ignore
         return state.t, sol
-        # marginals = self._extract_marginals(mseq)
-        # u = ssv.extract_qoi_from_sample(marginals.mean)
-
-        # return state.t, u, marginals, sol
 
     def extract_at_terminal_values(self, state: _SmState, /):
         ssv = self.correction.extract(state.ssv, state.corr)
@@ -137,7 +131,6 @@ class _SmootherCommon(_strategy.Strategy):
     # Auxiliary routines that are the same among all subclasses
 
     def _interpolate_from_to_fn(self, *, s0, output_scale, t):
-        # todo: act on state instead of rv+t0
         dt = t - s0.t
         ssv, extra = self.extrapolation.smoother_begin(s0.ssv, s0.extra, dt=dt)
         ssv, extra = self.extrapolation.smoother_complete(
@@ -204,7 +197,6 @@ class Smoother(_SmootherCommon):
         state1 = self._interpolate_from_to_fn(s0=s_t, output_scale=output_scale, t=s1.t)
         backward_model1 = state1.extra
 
-        # t_accepted = jnp.maximum(s1.t, t)
         s_1 = _SmState(
             t=s1.t,
             u=s1.u,
@@ -272,8 +264,6 @@ class FixedPointSmoother(_SmootherCommon):
         # correct backward model to get from s0 to s1?
         backward_model1 = s0.extra.merge_with_incoming_conditional(s1.extra)
 
-        # Do we need:
-        #  t_accepted = jnp.maximum(s1.t, t) ?
         solution = _SmState(
             t=t,
             u=s1.u,

--- a/probdiffeq/strategies/smoothers.py
+++ b/probdiffeq/strategies/smoothers.py
@@ -122,12 +122,6 @@ class _SmootherCommon(_strategy.Strategy):
         sol = SmootherSol(mseq)  # type: ignore
         return state.t, sol
 
-    def extract_at_terminal_values(self, state: _SmState, /):
-        ssv = self.correction.extract(state.ssv, state.corr)
-        mseq = self.extrapolation.smoother_extract(ssv, state.extra)
-        sol = SmootherSol(mseq)  # type: ignore
-        return state.t, sol
-
     # Auxiliary routines that are the same among all subclasses
 
     def _interpolate_from_to_fn(self, *, s0, output_scale, t):

--- a/probdiffeq/strategies/smoothers.py
+++ b/probdiffeq/strategies/smoothers.py
@@ -27,6 +27,11 @@ class SmootherSol(_strategy.Posterior[S]):
         u = marginals.extract_qoi_from_sample(marginals.mean)
         return u, marginals
 
+    def marginals(self):
+        marginals = self._extract_marginals(self.rv)
+        u = marginals.extract_qoi_from_sample(marginals.mean)
+        return u, marginals
+
     def _extract_marginals(self, posterior: MarkovSequence, /):
         init = jax.tree_util.tree_map(lambda x: x[-1, ...], posterior.init)
 

--- a/probdiffeq/strategies/smoothers.py
+++ b/probdiffeq/strategies/smoothers.py
@@ -126,10 +126,8 @@ class _SmootherCommon(_strategy.Strategy):
     def extract_at_terminal_values(self, state: _SmState, /):
         ssv = self.correction.extract(state.ssv, state.corr)
         mseq = self.extrapolation.smoother_extract(ssv, state.extra)
-        marginals = mseq.init
-        u = state.u
         sol = SmootherSol(mseq)  # type: ignore
-        return state.t, u, marginals, sol
+        return state.t, sol
 
     # Auxiliary routines that are the same among all subclasses
 

--- a/probdiffeq/strategies/smoothers.py
+++ b/probdiffeq/strategies/smoothers.py
@@ -215,7 +215,7 @@ class Smoother(_SmootherCommon):
             output_scale=output_scale,
         )
         t, posterior = self.extract(acc)
-        marginals = posterior.rand.backward_model.marginalise(posterior.rand.init)
+        marginals = posterior.rand.backward_model.marginalise(marginals)
         u = marginals.extract_qoi_from_sample(marginals.mean)
         return u, marginals
 

--- a/tests/test_equivalences/test_checkpoint_same_grid.py
+++ b/tests/test_equivalences/test_checkpoint_same_grid.py
@@ -66,8 +66,8 @@ def test_smoothing_checkpoint_equals_solver_state(ode_problem, smo, fp_smo, tol)
     assert jnp.allclose(fp_smo_sol.u, smo_sol.u, **tols)
     assert jnp.allclose(fp_smo_sol.marginals.mean, smo_sol.marginals.mean, **tols)
     assert jnp.allclose(
-        fp_smo_sol.posterior.rv.backward_model.noise.mean,
-        smo_sol.posterior.rv.backward_model.noise.mean,
+        fp_smo_sol.posterior.rand.backward_model.noise.mean,
+        smo_sol.posterior.rand.backward_model.noise.mean,
         **tols
     )
     assert jnp.allclose(fp_smo_sol.output_scale, smo_sol.output_scale, **tols)
@@ -81,6 +81,6 @@ def test_smoothing_checkpoint_equals_solver_state(ode_problem, smo, fp_smo, tol)
     l1 = smo_sol.marginals.cov_sqrtm_lower
     assert jnp.allclose(cov(l0), cov(l1), **tols)
 
-    l0 = fp_smo_sol.posterior.rv.backward_model.noise.cov_sqrtm_lower
-    l1 = smo_sol.posterior.rv.backward_model.noise.cov_sqrtm_lower
+    l0 = fp_smo_sol.posterior.rand.backward_model.noise.cov_sqrtm_lower
+    l1 = smo_sol.posterior.rand.backward_model.noise.cov_sqrtm_lower
     assert jnp.allclose(cov(l0), cov(l1), **tols)


### PR DESCRIPTION
This PR moves the `solution.Solution` output-wrap into `ivpsolve.py`. The advantages are few-fold, but the main impact is that we can now avoid computing marginals at the extract-state. As a result, extract() and extract_*() become almost identical, and we can remove a lot of code in the next step. 