### PR TITLE
Dataclasses and Pytrees

### DIFF
--- a/probdiffeq/backend/containers.py
+++ b/probdiffeq/backend/containers.py
@@ -10,7 +10,7 @@ def dataclass_pytree_node(clz, /):
     return _register_pytree_node_dataclass(dataclass(frozen=True)(clz))
 
 
-# See https://github.com/google/jax/issues/2371
+# Very similar to https://github.com/google/jax/issues/2371
 def _register_pytree_node_dataclass(clz, /):
     def flatten(obj, /):
         return jax.tree_util.tree_flatten(dataclasses.asdict(obj))

--- a/probdiffeq/backend/containers.py
+++ b/probdiffeq/backend/containers.py
@@ -6,6 +6,10 @@ import jax
 dataclass = dataclasses.dataclass
 
 
+def dataclass_pytree_node(clz, /):
+    return _register_pytree_node_dataclass(dataclass(frozen=True)(clz))
+
+
 # See https://github.com/google/jax/issues/2371
 def _register_pytree_node_dataclass(clz, /):
     def flatten(obj, /):
@@ -16,7 +20,3 @@ def _register_pytree_node_dataclass(clz, /):
 
     jax.tree_util.register_pytree_node(clz, flatten, unflatten)
     return clz
-
-
-def dataclass_pytree_node(clz, /):
-    return _register_pytree_node_dataclass(dataclass(frozen=True)(clz))

--- a/probdiffeq/backend/containers.py
+++ b/probdiffeq/backend/containers.py
@@ -3,11 +3,10 @@ import dataclasses
 
 import jax
 
-dataclass = dataclasses.dataclass
 
-
+# Might have to combine with typing_extensions.dataclass_transform()
 def dataclass_pytree_node(clz, /):
-    return _register_pytree_node_dataclass(dataclass(frozen=True)(clz))
+    return _register_pytree_node_dataclass(dataclasses.dataclass(frozen=True)(clz))
 
 
 # Very similar to https://github.com/google/jax/issues/2371

--- a/probdiffeq/backend/containers.py
+++ b/probdiffeq/backend/containers.py
@@ -1,0 +1,22 @@
+"""Container types."""
+import dataclasses
+
+import jax
+
+dataclass = dataclasses.dataclass
+
+
+# See https://github.com/google/jax/issues/2371
+def _register_pytree_node_dataclass(clz, /):
+    def flatten(obj, /):
+        return jax.tree_util.tree_flatten(dataclasses.asdict(obj))
+
+    def unflatten(aux, children):
+        return clz(**aux.unflatten(children))
+
+    jax.tree_util.register_pytree_node(clz, flatten, unflatten)
+    return clz
+
+
+def dataclass_pytree_node(clz, /):
+    return _register_pytree_node_dataclass(dataclass(frozen=True)(clz))

--- a/tests/test_backend/__init__.py
+++ b/tests/test_backend/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for (very strictly) selected backend functionalities."""

--- a/tests/test_backend/test_containers.py
+++ b/tests/test_backend/test_containers.py
@@ -1,0 +1,32 @@
+"""Tests for specific containers."""
+
+import jax.numpy as jnp
+import jax.tree_util
+
+from probdiffeq.backend import containers
+
+
+def test_dataclass_tree():
+    @containers.dataclass
+    class MyClass:
+        a: float
+        b: float
+
+    @containers.dataclass_pytree_node
+    class MyPyTree:
+        a: float
+        b: float
+
+    # Traditional dataclasses are leaves
+    dataclass_instance = MyClass([2.0], (3.0, 4.0, 5.0, 6.0))
+    children, aux = jax.tree_util.tree_flatten(dataclass_instance)
+    assert len(children) == 1
+
+    # containers.dataclass_tree yields a pytree, which has two leaves (not one)
+    dataclass_pytree = MyPyTree([2.0], (3.0, 4.0, 5.0, 6.0))
+    children, aux = jax.tree_util.tree_flatten(dataclass_pytree)
+    assert len(children) > 1  # because MyClass has > 1 leaves (5 in this example)
+
+    # tree_unflatten works as well.
+    back = jax.tree_util.tree_unflatten(aux, children)
+    assert jax.tree_util.tree_all(jax.tree_map(jnp.allclose, back, dataclass_pytree))

--- a/tests/test_backend/test_containers.py
+++ b/tests/test_backend/test_containers.py
@@ -1,5 +1,7 @@
 """Tests for specific containers."""
 
+import dataclasses
+
 import jax.numpy as jnp
 import jax.tree_util
 
@@ -7,7 +9,7 @@ from probdiffeq.backend import containers
 
 
 def test_dataclass_tree():
-    @containers.dataclass
+    @dataclasses.dataclass
     class MyClass:
         a: float
         b: float


### PR DESCRIPTION
I got tired of importing NamedTuple from typing (!) all the time. I also got tired of registering custom pytrees that contain only children.

So I built a `dataclass_pytree_node` decorator to be used instead of dataclasses, which assume that all fields are arrays or valid containers, and registers the pytree as such. 

I did not apply it to more than one place, because there might be some typing-related refinements to be made for wider scale applications. This can happen next (and in parallel to other refactors). 