### PR TITLE
Nested dataclasses

### DIFF
--- a/probdiffeq/backend/containers.py
+++ b/probdiffeq/backend/containers.py
@@ -2,10 +2,13 @@
 
 import jax_dataclasses
 
-# jax_dataclasses is the only implementation that can handle
-# nested dataclasses properly. We need A LOT OF nested dataclasses.
-# chex.dataclasses did not manage, flax.dataclasses came with some
-# warnings that I did not want to introduce, and tjax required
-# a very recent JAX version, which I found a bit of a harsh
-# dependency restriction for such a small feature.
+# jax_dataclasses is one of few dataclass implementations that can handle
+# nested dataclasses properly.
+# We need A LOT OF nested dataclasses.
+#
+# What about the others?
+# chex.dataclasses requires keyword-only initialisation
+# tjax requires a very recent JAX version (which appears unnecessary for using it here)
+# flax.struct.dataclass works, and jax_dataclasses.pytree_dataclass works.
+# I prefer the jax_dataclasses dependency because it is a much smaller dependency.#
 dataclass_pytree_node = jax_dataclasses.pytree_dataclass

--- a/probdiffeq/backend/containers.py
+++ b/probdiffeq/backend/containers.py
@@ -1,21 +1,11 @@
 """Container types."""
-import dataclasses
 
-import jax
+import jax_dataclasses
 
-
-# Might have to combine with typing_extensions.dataclass_transform()
-def dataclass_pytree_node(clz, /):
-    return _register_pytree_node_dataclass(dataclasses.dataclass(frozen=True)(clz))
-
-
-# Very similar to https://github.com/google/jax/issues/2371
-def _register_pytree_node_dataclass(clz, /):
-    def flatten(obj, /):
-        return jax.tree_util.tree_flatten(dataclasses.asdict(obj))
-
-    def unflatten(aux, children):
-        return clz(**aux.unflatten(children))
-
-    jax.tree_util.register_pytree_node(clz, flatten, unflatten)
-    return clz
+# jax_dataclasses is the only implementation that can handle
+# nested dataclasses properly. We need A LOT OF nested dataclasses.
+# chex.dataclasses did not manage, flax.dataclasses came with some
+# warnings that I did not want to introduce, and tjax required
+# a very recent JAX version, which I found a bit of a harsh
+# dependency restriction for such a small feature.
+dataclass_pytree_node = jax_dataclasses.pytree_dataclass

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,8 @@ long_description_content_type = text/markdown
 [options]
 packages = find:
 python_requires = >=3.8
-
+install_requires =
+    jax_dataclasses
 
 [options.extras_require]
 cpu =

--- a/tests/test_backend/test_containers.py
+++ b/tests/test_backend/test_containers.py
@@ -1,6 +1,7 @@
 """Tests for specific containers."""
 
 import dataclasses
+from typing import Any
 
 import jax.numpy as jnp
 import jax.tree_util
@@ -8,17 +9,19 @@ import jax.tree_util
 from probdiffeq.backend import containers
 
 
+@dataclasses.dataclass
+class MyClass:
+    a: Any
+    b: Any
+
+
+@containers.dataclass_pytree_node
+class MyPyTree:
+    a: Any
+    b: Any
+
+
 def test_dataclass_tree():
-    @dataclasses.dataclass
-    class MyClass:
-        a: float
-        b: float
-
-    @containers.dataclass_pytree_node
-    class MyPyTree:
-        a: float
-        b: float
-
     # Traditional dataclasses are leaves
     dataclass_instance = MyClass([2.0], (3.0, 4.0, 5.0, 6.0))
     children, aux = jax.tree_util.tree_flatten(dataclass_instance)
@@ -32,3 +35,12 @@ def test_dataclass_tree():
     # tree_unflatten works as well.
     back = jax.tree_util.tree_unflatten(aux, children)
     assert jax.tree_util.tree_all(jax.tree_map(jnp.allclose, back, dataclass_pytree))
+
+
+def test_dataclass_nested():
+    """Tree-flattening and unflattening for nested data classes must be as expected."""
+    tree2 = MyPyTree(1, MyPyTree(2, 3))
+    children, aux = jax.tree_util.tree_flatten(tree2)
+    tree = jax.tree_util.tree_unflatten(aux, children)
+    assert tree.a == 1
+    assert tree.b == MyPyTree(2, 3)

--- a/tests/test_backend/test_containers.py
+++ b/tests/test_backend/test_containers.py
@@ -39,7 +39,7 @@ def test_dataclass_tree():
 
 def test_dataclass_nested():
     """Tree-flattening and unflattening for nested data classes must be as expected."""
-    tree2 = MyPyTree(1, MyPyTree(2, 3))
+    tree2 = MyPyTree(1, MyPyTree(a=2, b=3))
     children, aux = jax.tree_util.tree_flatten(tree2)
     tree = jax.tree_util.tree_unflatten(aux, children)
     assert tree.a == 1


### PR DESCRIPTION
Replaces the dataclass implementation with a wrapped dependency. 

The current implementation cannot handle nested data classes, which is why tests in #578 fail. 