### PR TITLE
Remove `init_error_estimate()`

### DIFF
--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -69,11 +69,11 @@ class Solver:
         )
 
     def init(self, t, posterior, /, output_scale, num_steps) -> _State:
-        error_estimate = self.strategy.init_error_estimate()
-        strategy_state = self.strategy.init(t, posterior)
+        state_strategy = self.strategy.init(t, posterior)
+        error_estimate = jnp.empty_like(state_strategy.u)
         return _State(
             error_estimate=error_estimate,
-            strategy=strategy_state,
+            strategy=state_strategy,
             output_scale_prior=output_scale,
             output_scale_calibrated=output_scale,
             num_steps=num_steps,
@@ -123,7 +123,7 @@ class Solver:
         return _interp.InterpRes(accepted=acc, solution=sol, previous=prev)
 
     def _interp_make_state(self, state_strategy, *, reference: _State) -> _State:
-        error_estimate = self.strategy.init_error_estimate()
+        error_estimate = jnp.empty_like(state_strategy.u)
         return _State(
             strategy=state_strategy,
             error_estimate=error_estimate,

--- a/probdiffeq/statespace/_extra.py
+++ b/probdiffeq/statespace/_extra.py
@@ -86,8 +86,5 @@ class Extrapolation(Generic[S, C]):
 
     # todo: bundle in an init() method:
 
-    def init_error_estimate(self) -> jax.Array:
-        raise NotImplementedError
-
     def smoother_init_conditional(self, ssv_proto):
         raise NotImplementedError

--- a/probdiffeq/statespace/blockdiag/extra.py
+++ b/probdiffeq/statespace/blockdiag/extra.py
@@ -82,10 +82,6 @@ class _BlockDiag(_extra.Extrapolation):
         return solution_fn(self.extra, ssv, extra)
 
     # todo: move to correction?
-    def init_error_estimate(self):
-        return jax.vmap(type(self.extra).init_error_estimate)(self.extra)
-
-    # todo: move to correction?
     def promote_output_scale(self, output_scale):
         # broadcast to shape (d,)
         output_scale = output_scale * jnp.ones(self.ode_shape)

--- a/probdiffeq/statespace/dense/extra.py
+++ b/probdiffeq/statespace/dense/extra.py
@@ -67,9 +67,6 @@ class _IBMFi(_extra.Extrapolation):
     def extract(self, ssv, _extra, /):
         return ssv.hidden_state
 
-    def init_error_estimate(self):
-        return jnp.zeros(self.ode_shape)  # the initialisation is error-free
-
     def begin(self, ssv, extra, /, dt):
         p, p_inv = self._assemble_preconditioner(dt=dt)
         m0_p = p_inv * ssv.hidden_state.mean
@@ -235,9 +232,6 @@ class _IBMSm(_extra.Extrapolation):
         ext = _vars.DenseSSV(u, rv, target_shape=self.target_shape)
         return ext, bw_model
 
-    def init_error_estimate(self):
-        return jnp.zeros(self.ode_shape)  # the initialisation is error-free
-
     # todo: remove smoother_init_conditional?
     def init_conditional(self, rv_proto):
         op = self._init_backward_transition()
@@ -321,9 +315,6 @@ class _IBMFp(_extra.Extrapolation):
         rv = ssv.hidden_state
         cond = extra
         return _markov.MarkovSequence(init=rv, backward_model=cond)
-
-    def init_error_estimate(self):
-        return jnp.zeros(self.ode_shape)  # the initialisation is error-free
 
     def begin(self, ssv, extra, /, dt):
         p, p_inv = self._assemble_preconditioner(dt=dt)

--- a/probdiffeq/statespace/iso/corr.py
+++ b/probdiffeq/statespace/iso/corr.py
@@ -38,7 +38,7 @@ class _IsoTaylorZerothOrder(_corr.Correction):
         mahalanobis_norm = obs.mahalanobis_norm(jnp.zeros_like(m1))
         output_scale = mahalanobis_norm / jnp.sqrt(bias.size)
 
-        error_estimate_unscaled = obs.marginal_std()
+        error_estimate_unscaled = obs.marginal_std() * jnp.ones_like(bias)
         error_estimate = error_estimate_unscaled * output_scale
         cache = (error_estimate, output_scale, (bias,))
         return x, cache

--- a/probdiffeq/statespace/iso/extra.py
+++ b/probdiffeq/statespace/iso/extra.py
@@ -87,10 +87,6 @@ class _IBMFi(_extra.Extrapolation[_vars.IsoSSV, Any]):
         c0 = jnp.eye(self.num_derivatives + 1)
         return _vars.IsoNormalHiddenState(m0, c0)
 
-    # Unnecessary?
-    def init_error_estimate(self):
-        return jnp.zeros(())  # the initialisation is error-free
-
     def promote_output_scale(self, output_scale):
         return output_scale
 
@@ -179,9 +175,6 @@ class _IBMSm(_extra.Extrapolation[_vars.IsoSSV, Any]):
         c0 = jnp.eye(self.num_derivatives + 1)
         return _vars.IsoNormalHiddenState(m0, c0)
 
-    def init_error_estimate(self):
-        return jnp.zeros(())  # the initialisation is error-free
-
     def promote_output_scale(self, output_scale):
         return output_scale
 
@@ -227,10 +220,6 @@ class _IBMFp(_extra.Extrapolation[_vars.IsoSSV, Any]):
         m0 = jnp.zeros((self.num_derivatives + 1, d))
         c0 = jnp.eye(self.num_derivatives + 1)
         return _vars.IsoNormalHiddenState(m0, c0)
-
-    # Unnecessary?
-    def init_error_estimate(self):
-        return jnp.zeros(())  # the initialisation is error-free
 
     def promote_output_scale(self, output_scale):
         return output_scale

--- a/probdiffeq/statespace/scalar/extra.py
+++ b/probdiffeq/statespace/scalar/extra.py
@@ -46,9 +46,6 @@ class _IBMFi(_extra.Extrapolation):
     def extract(self, ssv, extra, /):
         return ssv.hidden_state
 
-    def init_error_estimate(self):
-        return jnp.zeros(())
-
     def begin(self, ssv, extra, /, dt):
         p, p_inv = self._assemble_preconditioner(dt=dt)
         m0_p = p_inv * ssv.hidden_state.mean
@@ -122,9 +119,6 @@ class _IBMSm(_extra.Extrapolation):
 
     def extract(self, ssv, extra, /):
         return _markov.MarkovSequence(init=ssv.hidden_state, backward_model=extra)
-
-    def init_error_estimate(self):
-        return jnp.zeros(())
 
     def begin(self, ssv, extra, /, dt):
         p, p_inv = self._assemble_preconditioner(dt=dt)
@@ -229,9 +223,6 @@ class _IBMFp(_extra.Extrapolation):
 
     def extract(self, ssv, extra, /):
         return _markov.MarkovSequence(init=ssv.hidden_state, backward_model=extra)
-
-    def init_error_estimate(self):
-        return jnp.zeros(())
 
     def begin(self, ssv, extra, /, dt):
         p, p_inv = self._assemble_preconditioner(dt=dt)

--- a/probdiffeq/strategies/filters.py
+++ b/probdiffeq/strategies/filters.py
@@ -143,9 +143,6 @@ class Filter(_strategy.Strategy[_FiState, Any]):
         )
         return _FiState(t=state.t, ssv=ssv, extra=extra, corr=corr)
 
-    def init_error_estimate(self):
-        return self.extrapolation.filter.init_error_estimate()
-
     def promote_output_scale(self, *args, **kwargs):
         init_fn = self.extrapolation.filter.promote_output_scale
         return init_fn(*args, **kwargs)

--- a/probdiffeq/strategies/smoothers.py
+++ b/probdiffeq/strategies/smoothers.py
@@ -162,9 +162,6 @@ class Smoother(_strategy.Strategy):
         corr_like = jax.tree_util.tree_map(jnp.empty_like, s0.corr)
         return _SmState(t=t, ssv=ssv, extra=extra, corr=corr_like)
 
-    def init_error_estimate(self):
-        return self.extrapolation.smoother.init_error_estimate()
-
     def promote_output_scale(self, *args, **kwargs):
         init_fn = self.extrapolation.smoother.promote_output_scale
         return init_fn(*args, **kwargs)
@@ -327,9 +324,6 @@ class FixedPointSmoother(_strategy.Strategy):
             rv_proto=state.extra.noise
         )
         return _SmState(t=state.t, extra=extra_new, corr=state.corr, ssv=state.ssv)
-
-    def init_error_estimate(self):
-        return self.extrapolation.fixedpoint.init_error_estimate()
 
     def promote_output_scale(self, *args, **kwargs):
         init_fn = self.extrapolation.fixedpoint.promote_output_scale


### PR DESCRIPTION
If we accept that even the isotropic state-space models should have an `(d,)` shaped error estimate (which is reasonable), we can remove `init_error_estimate()` methods from solvers, strategies, and state-space model implementations.