### PR TITLE
Removed `SmootherSol` and `FilterDist`

### DIFF
--- a/probdiffeq/strategies/_strategy.py
+++ b/probdiffeq/strategies/_strategy.py
@@ -12,27 +12,6 @@ S = TypeVar("S")
 P = TypeVar("P")
 """A type-variable to indicate strategy-solution ("posterior") types."""
 
-R = TypeVar("R")
-"""A type-variable to indicate random-variable types."""
-
-
-class Posterior(Generic[R]):
-    def __init__(self, rand: R, /):
-        self.rand = rand
-
-    def tree_flatten(self):
-        children = (self.rand,)
-        aux = ()
-        return children, aux
-
-    @classmethod
-    def tree_unflatten(cls, _aux, children):
-        (rand,) = children
-        return cls(rand)
-
-    def sample(self, key, *, shape):
-        raise NotImplementedError
-
 
 @jax.tree_util.register_pytree_node_class
 class Strategy(Generic[S, P]):

--- a/probdiffeq/strategies/filters.py
+++ b/probdiffeq/strategies/filters.py
@@ -39,7 +39,6 @@ class Filter(_strategy.Strategy[_FiState, Any]):
 
     def solution_from_tcoeffs(self, taylor_coefficients, /):
         sol = self.extrapolation.filter.solution_from_tcoeffs(taylor_coefficients)
-        # sol = FilterDist(sol)
         marginals = sol
         u = taylor_coefficients[0]
         return u, marginals, sol
@@ -53,8 +52,6 @@ class Filter(_strategy.Strategy[_FiState, Any]):
         t = posterior.t
         ssv = self.correction.extract(posterior.ssv, posterior.corr)
         solution = self.extrapolation.filter.extract(ssv, posterior.extra)
-
-        # solution = FilterDist(rv)  # type: ignore
         return t, solution
 
     def case_right_corner(

--- a/tests/test_equivalences/test_checkpoint_same_grid.py
+++ b/tests/test_equivalences/test_checkpoint_same_grid.py
@@ -66,8 +66,8 @@ def test_smoothing_checkpoint_equals_solver_state(ode_problem, smo, fp_smo, tol)
     assert jnp.allclose(fp_smo_sol.u, smo_sol.u, **tols)
     assert jnp.allclose(fp_smo_sol.marginals.mean, smo_sol.marginals.mean, **tols)
     assert jnp.allclose(
-        fp_smo_sol.posterior.rand.backward_model.noise.mean,
-        smo_sol.posterior.rand.backward_model.noise.mean,
+        fp_smo_sol.posterior.backward_model.noise.mean,
+        smo_sol.posterior.backward_model.noise.mean,
         **tols
     )
     assert jnp.allclose(fp_smo_sol.output_scale, smo_sol.output_scale, **tols)
@@ -81,6 +81,6 @@ def test_smoothing_checkpoint_equals_solver_state(ode_problem, smo, fp_smo, tol)
     l1 = smo_sol.marginals.cov_sqrtm_lower
     assert jnp.allclose(cov(l0), cov(l1), **tols)
 
-    l0 = fp_smo_sol.posterior.rand.backward_model.noise.cov_sqrtm_lower
-    l1 = smo_sol.posterior.rand.backward_model.noise.cov_sqrtm_lower
+    l0 = fp_smo_sol.posterior.backward_model.noise.cov_sqrtm_lower
+    l1 = smo_sol.posterior.backward_model.noise.cov_sqrtm_lower
     assert jnp.allclose(cov(l0), cov(l1), **tols)

--- a/tests/test_equivalences/test_mle_vs_calibrationfree.py
+++ b/tests/test_equivalences/test_mle_vs_calibrationfree.py
@@ -52,8 +52,8 @@ def test_mle_vs_calibrationfree(ode_problem, strategy_fn):
 
     # If we are smoothing, we also compare the backward models.
     if isinstance(strategy, smoothers.FixedPointSmoother):
-        rand_mle = solution_mle.posterior.rand
-        rand_free = solution_free.posterior.rand
+        rand_mle = solution_mle.posterior
+        rand_free = solution_free.posterior
         assert _tree_all_allclose(rand_mle.init, rand_free.init)
 
         bw_mle = rand_mle.backward_model


### PR DESCRIPTION
If we do a single if-else in ivpsolve.py, we can entirely remove both objects (plus their shared interface class).

I think this is worth it: the if-else is only to compute quantities that _I think_ a user wants to get. They do not actually define the solution at all. Let's do it this way to keep the source code (collocate.py, strategies, etc.) convenience-function-free! 