### PR TITLE
`sqrtm_to_upper_triangular` -> `triu_via_qr`

### DIFF
--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -69,11 +69,11 @@ class Solver:
         )
 
     def init(self, t, posterior, /, output_scale, num_steps) -> _State:
-        state_strategy = self.strategy.init(t, posterior)
-        error_estimate = jnp.empty_like(state_strategy.u)
+        error_estimate = self.strategy.init_error_estimate()
+        strategy_state = self.strategy.init(t, posterior)
         return _State(
             error_estimate=error_estimate,
-            strategy=state_strategy,
+            strategy=strategy_state,
             output_scale_prior=output_scale,
             output_scale_calibrated=output_scale,
             num_steps=num_steps,
@@ -269,7 +269,7 @@ class MLESolver(Solver):
             return fn_vmap(diffsqrtm, obs)
 
         x = obs.mahalanobis_norm(jnp.zeros_like(obs.mean)) / jnp.sqrt(obs.mean.size)
-        sum_updated = _sqrt_util.sqrt_sum_square(jnp.sqrt(n) * diffsqrtm, x)
+        sum_updated = _sqrt_util.sqrt_sum_square_scalar(jnp.sqrt(n) * diffsqrtm, x)
         return sum_updated / jnp.sqrt(n + 1)
 
     def extract(self, state: _State, /):

--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -69,11 +69,11 @@ class Solver:
         )
 
     def init(self, t, posterior, /, output_scale, num_steps) -> _State:
-        error_estimate = self.strategy.init_error_estimate()
-        strategy_state = self.strategy.init(t, posterior)
+        state_strategy = self.strategy.init(t, posterior)
+        error_estimate = jnp.empty_like(state_strategy.u)
         return _State(
             error_estimate=error_estimate,
-            strategy=strategy_state,
+            strategy=state_strategy,
             output_scale_prior=output_scale,
             output_scale_calibrated=output_scale,
             num_steps=num_steps,

--- a/probdiffeq/statespace/dense/corr.py
+++ b/probdiffeq/statespace/dense/corr.py
@@ -100,7 +100,7 @@ class _DenseTaylorZerothOrder(_corr.Correction):
         fx = self.linearise_fn(fn=f_wrapped, m=m0)
 
         b = m1 - fx
-        l_obs_raw = _sqrt_util.sqrtm_to_upper_triangular(R=cov_sqrtm_lower.T).T
+        l_obs_raw = _sqrt_util.triu_via_qr(cov_sqrtm_lower.T).T
         observed = variables.DenseNormal(b, l_obs_raw, target_shape=None)
 
         mahalanobis_norm = observed.mahalanobis_norm(jnp.zeros_like(b))
@@ -184,7 +184,7 @@ class _DenseTaylorFirstOrder(_corr.Correction):
         cov_sqrtm_lower = jvp_fn_vect(ssv.hidden_state.cov_sqrtm_lower)
 
         # Gather the observed variable
-        l_obs_raw = _sqrt_util.sqrtm_to_upper_triangular(R=cov_sqrtm_lower.T).T
+        l_obs_raw = _sqrt_util.triu_via_qr(cov_sqrtm_lower.T).T
         observed = variables.DenseNormal(b, l_obs_raw, target_shape=None)
 
         # Extract the output scale and the error estimate
@@ -279,7 +279,7 @@ class _DenseStatisticalZerothOrder(_corr.Correction):
         # Compute the linearisation point
         m_0 = self.e0(ssv.hidden_state.mean)
         r_0 = self.e0_vect(ssv.hidden_state.cov_sqrtm_lower).T
-        r_0_square = _sqrt_util.sqrtm_to_upper_triangular(R=r_0)
+        r_0_square = _sqrt_util.triu_via_qr(r_0)
         lin_pt = variables.DenseNormal(m_0, r_0_square.T, target_shape=ssv.target_shape)
 
         # todo: higher-order ODEs
@@ -316,7 +316,7 @@ class _DenseStatisticalZerothOrder(_corr.Correction):
         r_1 = self.e1_vect(ssv.hidden_state.cov_sqrtm_lower).T
 
         # Extract the linearisation point
-        r_0_square = _sqrt_util.sqrtm_to_upper_triangular(R=r_0)
+        r_0_square = _sqrt_util.triu_via_qr(r_0)
         lin_pt = variables.DenseNormal(m_0, r_0_square.T, target_shape=ssv.target_shape)
 
         # Apply statistical linear regression to the ODE vector field
@@ -388,7 +388,7 @@ class _DenseStatisticalFirstOrder(_corr.Correction):
         # Compute the linearisation point
         m_0 = self.e0(ssv.hidden_state.mean)
         r_0 = self.e0_vect(ssv.hidden_state.cov_sqrtm_lower).T
-        r_0_square = _sqrt_util.sqrtm_to_upper_triangular(R=r_0)
+        r_0_square = _sqrt_util.triu_via_qr(r_0)
         lin_pt = variables.DenseNormal(m_0, r_0_square.T, target_shape=ssv.target_shape)
 
         # todo: higher-order ODEs
@@ -425,7 +425,7 @@ class _DenseStatisticalFirstOrder(_corr.Correction):
         r_1 = self.e1_vect(ssv.hidden_state.cov_sqrtm_lower).T
 
         # Extract the linearisation point
-        r_0_square = _sqrt_util.sqrtm_to_upper_triangular(R=r_0)
+        r_0_square = _sqrt_util.triu_via_qr(r_0)
         lin_pt = variables.DenseNormal(m_0, r_0_square.T, target_shape=ssv.target_shape)
 
         # Apply statistical linear regression to the ODE vector field

--- a/probdiffeq/statespace/dense/variables.py
+++ b/probdiffeq/statespace/dense/variables.py
@@ -127,9 +127,7 @@ class DenseSSV(variables.SSV):
         cov_sqrtm_lower_nonsquare = self._select_derivative_vect(
             self.hidden_state.cov_sqrtm_lower, n
         )
-        cov_sqrtm_lower = _sqrt_util.sqrtm_to_upper_triangular(
-            R=cov_sqrtm_lower_nonsquare.T
-        ).T
+        cov_sqrtm_lower = _sqrt_util.triu_via_qr(cov_sqrtm_lower_nonsquare.T).T
         return DenseNormal(mean, cov_sqrtm_lower, target_shape=None)
 
     def _select_derivative_vect(self, x, i):
@@ -233,9 +231,7 @@ class DenseNormal(variables.Normal):
         cov_sqrtm_lower_nonsquare = self._select_derivative_vect(
             self.cov_sqrtm_lower, n
         )
-        cov_sqrtm_lower = _sqrt_util.sqrtm_to_upper_triangular(
-            R=cov_sqrtm_lower_nonsquare.T
-        ).T
+        cov_sqrtm_lower = _sqrt_util.triu_via_qr(cov_sqrtm_lower_nonsquare.T).T
         return DenseNormal(mean, cov_sqrtm_lower, target_shape=None)
 
     def _select_derivative_vect(self, x, i):

--- a/probdiffeq/statespace/iso/corr.py
+++ b/probdiffeq/statespace/iso/corr.py
@@ -29,9 +29,7 @@ class _IsoTaylorZerothOrder(_corr.Correction):
         bias = m1 - vector_field(*m0, t=t, p=p)
         cov_sqrtm_lower = x.hidden_state.cov_sqrtm_lower[self.ode_order, ...]
 
-        l_obs_nonscalar = _sqrt_util.sqrtm_to_upper_triangular(
-            R=cov_sqrtm_lower[:, None]
-        )
+        l_obs_nonscalar = _sqrt_util.triu_via_qr(cov_sqrtm_lower[:, None])
         l_obs = jnp.reshape(l_obs_nonscalar, ())
         obs = variables.IsoNormalQOI(bias, l_obs)
 
@@ -50,7 +48,7 @@ class _IsoTaylorZerothOrder(_corr.Correction):
         l_ext = x.hidden_state.cov_sqrtm_lower
         l_obs = l_ext[self.ode_order, ...]
 
-        l_obs_nonscalar = _sqrt_util.sqrtm_to_upper_triangular(R=l_obs[:, None])
+        l_obs_nonscalar = _sqrt_util.triu_via_qr(l_obs[:, None])
         l_obs_scalar = jnp.reshape(l_obs_nonscalar, ())
 
         observed = variables.IsoNormalQOI(mean=bias, cov_sqrtm_lower=l_obs_scalar)

--- a/probdiffeq/statespace/iso/variables.py
+++ b/probdiffeq/statespace/iso/variables.py
@@ -101,7 +101,7 @@ class IsoSSV(variables.SSV):
         mean = self.hidden_state.mean[n, :]
         cov_sqrtm_lower_nonsquare = self.hidden_state.cov_sqrtm_lower[n, :]
         R = cov_sqrtm_lower_nonsquare[:, None]
-        cov_sqrtm_lower_square = _sqrt_util.sqrtm_to_upper_triangular(R=R)
+        cov_sqrtm_lower_square = _sqrt_util.triu_via_qr(R)
         cov_sqrtm_lower = jnp.reshape(cov_sqrtm_lower_square, ())
         return IsoNormalQOI(mean=mean, cov_sqrtm_lower=cov_sqrtm_lower)
 
@@ -135,7 +135,7 @@ class IsoNormalHiddenState(variables.Normal):
         mean = self.mean[n, :]
         cov_sqrtm_lower_nonsquare = self.cov_sqrtm_lower[n, :]
         R = cov_sqrtm_lower_nonsquare[:, None]
-        cov_sqrtm_lower_square = _sqrt_util.sqrtm_to_upper_triangular(R=R)
+        cov_sqrtm_lower_square = _sqrt_util.triu_via_qr(R)
         cov_sqrtm_lower = jnp.reshape(cov_sqrtm_lower_square, ())
         return IsoNormalQOI(mean=mean, cov_sqrtm_lower=cov_sqrtm_lower)
 

--- a/probdiffeq/statespace/scalar/corr.py
+++ b/probdiffeq/statespace/scalar/corr.py
@@ -37,7 +37,7 @@ class _TaylorZerothOrder(_corr.Correction):
     def marginalise_observation(self, fx, m1, x):
         b = m1 - fx
         cov_sqrtm_lower = x.cov_sqrtm_lower[self.ode_order, :]
-        l_obs_raw = _sqrt_util.sqrtm_to_upper_triangular(R=cov_sqrtm_lower[:, None])
+        l_obs_raw = _sqrt_util.triu_via_qr(cov_sqrtm_lower[:, None])
         l_obs = jnp.reshape(l_obs_raw, ())
         observed = variables.NormalQOI(b, l_obs)
         cache = (b,)
@@ -154,7 +154,7 @@ class StatisticalFirstOrder(_corr.Correction):
     def transform_sigma_points(self, rv: variables.NormalHiddenState):
         # Extract square-root of covariance (-> std-dev.)
         L0_nonsq = rv.cov_sqrtm_lower[0, :]
-        r_marg1_x_mat = _sqrt_util.sqrtm_to_upper_triangular(R=L0_nonsq[:, None])
+        r_marg1_x_mat = _sqrt_util.triu_via_qr(L0_nonsq[:, None])
         r_marg1_x = jnp.reshape(r_marg1_x_mat, ())
 
         # Multiply and shift the unit-points

--- a/probdiffeq/statespace/scalar/variables.py
+++ b/probdiffeq/statespace/scalar/variables.py
@@ -164,9 +164,7 @@ class SSV(variables.SSV):
 
         mean = self.hidden_state.mean[n]
         cov_sqrtm_lower_nonsquare = self.hidden_state.cov_sqrtm_lower[n, :]
-        cov_sqrtm_lower = _sqrt_util.sqrtm_to_upper_triangular(
-            R=cov_sqrtm_lower_nonsquare[:, None]
-        ).T
+        cov_sqrtm_lower = _sqrt_util.triu_via_qr(cov_sqrtm_lower_nonsquare[:, None]).T
         return NormalQOI(mean=mean, cov_sqrtm_lower=jnp.reshape(cov_sqrtm_lower, ()))
 
 
@@ -201,9 +199,7 @@ class NormalHiddenState(variables.Normal):
 
         mean = self.mean[n]
         cov_sqrtm_lower_nonsquare = self.cov_sqrtm_lower[n, :]
-        cov_sqrtm_lower = _sqrt_util.sqrtm_to_upper_triangular(
-            R=cov_sqrtm_lower_nonsquare[:, None]
-        ).T
+        cov_sqrtm_lower = _sqrt_util.triu_via_qr(cov_sqrtm_lower_nonsquare[:, None]).T
         return NormalQOI(mean=mean, cov_sqrtm_lower=jnp.reshape(cov_sqrtm_lower, ()))
 
     def extract_qoi_from_sample(self, u, /):

--- a/tests/test_sqrt_util.py
+++ b/tests/test_sqrt_util.py
@@ -55,12 +55,12 @@ def _some_array(shape):
     return jnp.arange(1.0, 1.0 + prod(shape)).reshape(shape)
 
 
-def test_sqrt_sum_square():
+def test_sqrt_sum_square_scalar():
     a = 3.0
     b = 4.0
     c = 5.0
     expected = jnp.sqrt(a**2 + b**2 + c**2)
-    received = _sqrt_util.sqrt_sum_square(a, b, c)
+    received = _sqrt_util.sqrt_sum_square_scalar(a, b, c)
     assert jnp.allclose(expected, received)
 
 
@@ -69,4 +69,4 @@ def test_sqrt_sum_square_error():
     b = 4.0 * jnp.eye(2)
     c = 5.0 * jnp.eye(2)
     with testing.raises(ValueError, match="scalar"):
-        _ = _sqrt_util.sqrt_sum_square(a, b, c)
+        _ = _sqrt_util.sqrt_sum_square_scalar(a, b, c)


### PR DESCRIPTION
Renamed `sqrtm_to_upper...` to `triu_via_qr`, which is more aligned with what it does ("triangularise").

Don't call it "triangularise" because

* "triu" encodes "upper triangular" (Numpy terminology)
* I try to avoid choosing British vs American spellings
* I like the `via_qr` because it describes to complexity of the operation. 