### PR TITLE
Extract standard normal functionality

### DIFF
--- a/probdiffeq/statespace/iso/extra.py
+++ b/probdiffeq/statespace/iso/extra.py
@@ -161,14 +161,6 @@ class _IBMSm(_extra.Extrapolation[variables.IsoSSV, Any]):
             dt=dt, scales=self.preconditioner_scales, powers=self.preconditioner_powers
         )
 
-    def standard_normal(self, ode_shape):
-        # Used for Runge-Kutta initialisation.
-        assert len(ode_shape) == 1
-        (d,) = ode_shape
-        m0 = jnp.zeros((self.num_derivatives + 1, d))
-        c0 = jnp.eye(self.num_derivatives + 1)
-        return variables.IsoNormalHiddenState(m0, c0)
-
     def promote_output_scale(self, output_scale):
         return output_scale
 
@@ -206,14 +198,6 @@ class _IBMFp(_extra.Extrapolation[variables.IsoSSV, Any]):
 
     def extract(self, ssv, ex, /):
         return _markov.MarkovSequence(init=ssv.hidden_state, backward_model=ex)
-
-    def standard_normal(self, ode_shape):
-        # Used for Runge-Kutta initialisation.
-        assert len(ode_shape) == 1
-        (d,) = ode_shape
-        m0 = jnp.zeros((self.num_derivatives + 1, d))
-        c0 = jnp.eye(self.num_derivatives + 1)
-        return variables.IsoNormalHiddenState(m0, c0)
 
     def promote_output_scale(self, output_scale):
         return output_scale

--- a/probdiffeq/statespace/iso/extra.py
+++ b/probdiffeq/statespace/iso/extra.py
@@ -81,14 +81,6 @@ class _IBMFi(_extra.Extrapolation[variables.IsoSSV, Any]):
         k = {"scales": self.preconditioner_scales, "powers": self.preconditioner_powers}
         return _ibm_util.preconditioner_diagonal(dt=dt, **k)
 
-    def standard_normal(self, ode_shape):
-        # Used for Runge-Kutta initialisation.
-        assert len(ode_shape) == 1
-        (d,) = ode_shape
-        m0 = jnp.zeros((self.num_derivatives + 1, d))
-        c0 = jnp.eye(self.num_derivatives + 1)
-        return variables.IsoNormalHiddenState(m0, c0)
-
     def promote_output_scale(self, output_scale):
         return output_scale
 

--- a/probdiffeq/statespace/iso/variables.py
+++ b/probdiffeq/statespace/iso/variables.py
@@ -7,6 +7,16 @@ from probdiffeq import _sqrt_util
 from probdiffeq.statespace import variables
 
 
+def standard_normal(*, num_derivatives, ode_shape):
+    # Used for Runge-Kutta initialisation.
+    assert len(ode_shape) == 1
+    (d,) = ode_shape
+
+    m0 = jnp.zeros((num_derivatives + 1, d))
+    c0 = jnp.eye(num_derivatives + 1)
+    return IsoNormalHiddenState(m0, c0)
+
+
 @jax.tree_util.register_pytree_node_class
 class IsoConditionalHiddenState(variables.Conditional):
     # Conditional between two hidden states and QOI

--- a/probdiffeq/statespace/iso/variables.py
+++ b/probdiffeq/statespace/iso/variables.py
@@ -3,12 +3,29 @@
 import jax
 import jax.numpy as jnp
 
-from probdiffeq import _sqrt_util
+from probdiffeq import _markov, _sqrt_util
 from probdiffeq.statespace import variables
 
 
+def unit_markov_sequence(**kwargs):
+    rv0 = standard_normal(**kwargs)
+    cond0 = identity_conditional(**kwargs)
+    return _markov.MarkovSequence(init=rv0, backward_model=cond0)
+
+
+def identity_conditional(*, num_derivatives, ode_shape):
+    assert len(ode_shape) == 1
+    (d,) = ode_shape
+
+    op = jnp.eye(num_derivatives + 1)
+
+    m0 = jnp.zeros((num_derivatives + 1, d))
+    c0 = jnp.zeros((num_derivatives + 1, num_derivatives + 1))
+    noise = IsoNormalHiddenState(m0, c0)
+    return IsoConditionalHiddenState(op, noise=noise)
+
+
 def standard_normal(*, num_derivatives, ode_shape):
-    # Used for Runge-Kutta initialisation.
     assert len(ode_shape) == 1
     (d,) = ode_shape
 

--- a/probdiffeq/statespace/iso/variables.py
+++ b/probdiffeq/statespace/iso/variables.py
@@ -7,13 +7,16 @@ from probdiffeq import _markov, _sqrt_util
 from probdiffeq.statespace import variables
 
 
-def unit_markov_sequence(**kwargs):
+def unit_markov_sequence(**kwargs) -> _markov.MarkovSequence:
     rv0 = standard_normal(**kwargs)
     cond0 = identity_conditional(**kwargs)
     return _markov.MarkovSequence(init=rv0, backward_model=cond0)
 
 
-def identity_conditional(*, num_derivatives, ode_shape):
+# todo: once the fixedpoint smoother resets the backward model at initialisation,
+#  all init_conditional() functions can be removed and the relevant code snippets
+#  point to this function.
+def identity_conditional(*, num_derivatives, ode_shape) -> "IsoConditionalHiddenState":
     assert len(ode_shape) == 1
     (d,) = ode_shape
 
@@ -25,7 +28,7 @@ def identity_conditional(*, num_derivatives, ode_shape):
     return IsoConditionalHiddenState(op, noise=noise)
 
 
-def standard_normal(*, num_derivatives, ode_shape):
+def standard_normal(*, num_derivatives, ode_shape) -> "IsoNormalHiddenState":
     assert len(ode_shape) == 1
     (d,) = ode_shape
 

--- a/probdiffeq/taylor.py
+++ b/probdiffeq/taylor.py
@@ -183,10 +183,10 @@ def _runge_kutta_starter_fn(
     # Initialise
     ode_shape = initial_values[0].shape
     extrapolation = extra.ibm_iso(num_derivatives=num)
-    sol0 = variables.unit_markov_sequence(num_derivatives=num, ode_shape=ode_shape)
+    solution = variables.unit_markov_sequence(num_derivatives=num, ode_shape=ode_shape)
 
     # Estimate
-    u0_full = _fixed_point_smoother(extrapolation, sol0, ys=ys, dts=jnp.diff(ts))
+    u0_full = _fixed_point_smoother(extrapolation, solution, ys=ys, dts=jnp.diff(ts))
 
     # Turn the mean into a tuple of arrays and return
     taylor_coefficients = tuple(u0_full.mean)

--- a/probdiffeq/taylor.py
+++ b/probdiffeq/taylor.py
@@ -11,6 +11,7 @@ import jax.numpy as jnp
 from probdiffeq import _markov
 from probdiffeq.backend import containers
 from probdiffeq.statespace import recipes
+from probdiffeq.statespace.iso import variables
 
 
 @functools.partial(jax.jit, static_argnames=["vector_field", "num"])
@@ -182,8 +183,9 @@ def _runge_kutta_starter_fn(
     # Run fixed-point smoother
 
     # Initialise
+    ode_shape = initial_values[0].shape
     extrapolation, _corr = recipes.ts0_iso(num_derivatives=num)
-    rv0 = extrapolation.smoother.standard_normal(ode_shape=initial_values[0].shape)
+    rv0 = variables.standard_normal(num_derivatives=num, ode_shape=ode_shape)
     cond0 = extrapolation.smoother.init_conditional(rv_proto=rv0)
     sol0 = _markov.MarkovSequence(init=rv0, backward_model=cond0)
 

--- a/probdiffeq/taylor.py
+++ b/probdiffeq/taylor.py
@@ -8,10 +8,8 @@ import jax.experimental.jet
 import jax.experimental.ode
 import jax.numpy as jnp
 
-from probdiffeq import _markov
 from probdiffeq.backend import containers
-from probdiffeq.statespace import recipes
-from probdiffeq.statespace.iso import variables
+from probdiffeq.statespace.iso import extra, variables
 
 
 @functools.partial(jax.jit, static_argnames=["vector_field", "num"])
@@ -184,10 +182,8 @@ def _runge_kutta_starter_fn(
 
     # Initialise
     ode_shape = initial_values[0].shape
-    extrapolation, _corr = recipes.ts0_iso(num_derivatives=num)
-    rv0 = variables.standard_normal(num_derivatives=num, ode_shape=ode_shape)
-    cond0 = extrapolation.smoother.init_conditional(rv_proto=rv0)
-    sol0 = _markov.MarkovSequence(init=rv0, backward_model=cond0)
+    extrapolation = extra.ibm_iso(num_derivatives=num)
+    sol0 = variables.unit_markov_sequence(num_derivatives=num, ode_shape=ode_shape)
 
     # Estimate
     u0_full = _fixed_point_smoother(extrapolation, sol0, ys=ys, dts=jnp.diff(ts))


### PR DESCRIPTION
It is only used in a very specific context. So we separate it from the general part of the source. 