### PR TITLE
Merge backward-models in fixedpoint.complete()

### DIFF
--- a/probdiffeq/statespace/dense/extra.py
+++ b/probdiffeq/statespace/dense/extra.py
@@ -345,7 +345,7 @@ class _IBMFp(_extra.Extrapolation):
         return p, p_inv
 
     def complete(self, ssv, extra, /, output_scale):
-        _, m_ext_p, m0_p, p, p_inv, l0 = extra
+        bw0, m_ext_p, m0_p, p, p_inv, l0 = extra
         # todo: move this to cache? it may be modified by correction models
         m_ext = ssv.hidden_state.mean
 
@@ -372,6 +372,7 @@ class _IBMFp(_extra.Extrapolation):
         bw_model = variables.DenseConditional(
             g_bw, noise=backward_noise, target_shape=self.target_shape
         )
+        bw_model = bw0.merge_with_incoming_conditional(bw_model)
         rv = variables.DenseNormal(
             mean=m_ext, cov_sqrtm_lower=l_ext, target_shape=self.target_shape
         )

--- a/probdiffeq/statespace/dense/variables.py
+++ b/probdiffeq/statespace/dense/variables.py
@@ -245,3 +245,8 @@ class DenseNormal(variables.Normal):
     def _select_derivative(self, x, i):
         x_reshaped = jnp.reshape(x, self.target_shape, order="F")
         return x_reshaped[i, ...]
+
+    def cov_dense(self):
+        if self.cov_sqrtm_lower.ndim > 2:
+            return jax.vmap(DenseNormal.cov_dense)(self)
+        return self.cov_sqrtm_lower @ self.cov_sqrtm_lower.T

--- a/probdiffeq/statespace/iso/variables.py
+++ b/probdiffeq/statespace/iso/variables.py
@@ -172,6 +172,11 @@ class IsoNormalHiddenState(variables.Normal):
     def extract_qoi_from_sample(self, u, /):
         return u[..., 0, :]
 
+    def cov_dense(self):
+        if self.cov_sqrtm_lower.ndim > 2:
+            return jax.vmap(IsoNormalHiddenState.cov_dense)(self)
+        return self.cov_sqrtm_lower @ self.cov_sqrtm_lower.T
+
 
 @jax.tree_util.register_pytree_node_class
 class IsoNormalQOI(variables.Normal):

--- a/probdiffeq/statespace/scalar/variables.py
+++ b/probdiffeq/statespace/scalar/variables.py
@@ -206,3 +206,9 @@ class NormalHiddenState(variables.Normal):
         if u.ndim == 1:
             return u[0]
         return jax.vmap(self.extract_qoi_from_sample)(u)
+
+    def cov_dense(self):
+        if self.cov_sqrtm_lower.ndim > 2:
+            return jax.vmap(NormalHiddenState.cov_dense)(self)
+
+        return self.cov_sqrtm_lower @ self.cov_sqrtm_lower.T

--- a/probdiffeq/strategies/smoothers.py
+++ b/probdiffeq/strategies/smoothers.py
@@ -177,8 +177,6 @@ class FixedPointSmoother(_strategy.Strategy):
         ssv, extra = self.extrapolation.fixedpoint.complete(
             state.ssv, state.extra, output_scale=output_scale
         )
-        bw_model, *_ = state.extra
-        extra = bw_model.merge_with_incoming_conditional(extra)
         ssv, corr = self.correction.complete(
             ssv, state.corr, vector_field=vector_field, t=state.t, p=parameters
         )
@@ -245,14 +243,11 @@ class FixedPointSmoother(_strategy.Strategy):
         prev_t = self._duplicate_with_unit_backward_model(e_t)
         e_1 = self._extrapolate(s0=prev_t, output_scale=output_scale, t=s1.t)
 
-        # Read backward models and condense qoi-to-t
-        bw_t1_to_t, bw_t_to_t0, bw_t0_to_qoi = e_1.extra, e_t.extra, s0.extra
-        bw_t_to_qoi = bw_t0_to_qoi.merge_with_incoming_conditional(bw_t_to_t0)
-
         # Marginalise from t1 to t:
         # turn an extrapolation- ("e_t") into an interpolation-result ("i_t")
         # Note how we use the bw_to_to_qoi backward model!
         # (Which is different for the non-fixed-point smoother)
+        bw_t1_to_t, bw_t_to_qoi = e_1.extra, e_t.extra
         rv_t = bw_t1_to_t.marginalise(s1.ssv.hidden_state)
         mseq_t = _markov.MarkovSequence(init=rv_t, backward_model=bw_t_to_qoi)
         ssv_t, _ = self.extrapolation.fixedpoint.init(mseq_t)
@@ -278,6 +273,7 @@ class FixedPointSmoother(_strategy.Strategy):
         ssv, extra = self.extrapolation.fixedpoint.complete(
             ssv, extra, output_scale=output_scale
         )
+
         corr_like = jax.tree_util.tree_map(jnp.empty_like, s0.corr)
         return _SmState(t=t, ssv=ssv, extra=extra, corr=corr_like)
 

--- a/probdiffeq/taylor.py
+++ b/probdiffeq/taylor.py
@@ -213,7 +213,7 @@ def _fixed_point_smoother(extrapolation, solution, ys, dts):
 
 def _fixedpoint_init(solution, y, *, extrapolation) -> _FpState:
     # State-space variables
-    ssv, extra = extrapolation.smoother.init(solution)
+    ssv, extra = extrapolation.fixedpoint.init(solution)
 
     # Initial data point
     _, cond_cor = ssv.observe_qoi(observation_std=0.0)
@@ -233,9 +233,8 @@ def _fixedpoint_step(carry: _FpState, x, *, extrapolation) -> Tuple[_FpState, No
     y, dt = x
 
     # Extrapolate (with fixed-point-style merging)
-    ssv, extra = extrapolation.smoother.begin(ssv, extra_old, dt=dt)
-    ssv, extra_new = extrapolation.smoother.complete(ssv, extra, output_scale=1.0)
-    extra = extra_old.merge_with_incoming_conditional(extra_new)  # sqrt-fp-smoother!
+    ssv, extra = extrapolation.fixedpoint.begin(ssv, extra_old, dt=dt)
+    ssv, extra = extrapolation.fixedpoint.complete(ssv, extra, output_scale=1.0)
 
     # Correct
     _, cond_cor = ssv.observe_qoi(observation_std=0.0)

--- a/tests/test_equivalences/test_checkpoint_different_grid.py
+++ b/tests/test_equivalences/test_checkpoint_different_grid.py
@@ -3,7 +3,7 @@
 import jax
 import jax.numpy as jnp
 
-from probdiffeq import ivpsolve, ivpsolvers, solution, test_util
+from probdiffeq import ivpsolve, solution, test_util
 from probdiffeq.backend import testing
 from probdiffeq.statespace import recipes
 from probdiffeq.strategies import smoothers
@@ -73,15 +73,9 @@ def test_smoothing_checkpoint_equals_solver_state(ode_problem, impl_fn, k):
     assert jnp.allclose(fixedpoint_smo_sol.marginals.mean, dense.mean)
 
     # covariances are equal, but cov_sqrtm_lower might not be
-
-    @jax.vmap
-    @jax.vmap
-    def cov(x):
-        return x @ x.T
-
-    l0 = fixedpoint_smo_sol.marginals.cov_sqrtm_lower
-    l1 = dense.cov_sqrtm_lower
-    assert jnp.allclose(cov(l0), cov(l1))
+    c0 = fixedpoint_smo_sol.marginals.cov_dense()
+    c1 = dense.cov_dense()
+    assert jnp.allclose(c0, c1)
 
 
 def _tree_all_allclose(tree1, tree2, **kwargs):


### PR DESCRIPTION
Also include test-coverage for checkpoint_different* tests, and introduce a cov_dense() method to RVs (doing this on the outside was tedious one to many times)