### PR TITLE
Calibration methods are bundles of init-update-extract schemes

### DIFF
--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -11,17 +11,17 @@ from probdiffeq.backend import containers
 
 def solver_mle(strategy, calibration):
     """Create a solver that calibrates the output scale via maximum-likelihood."""
-    return _MLESolver(strategy, calibration)
+    return _MLESolver(strategy, calibration.mle)
 
 
 def solver_dynamic(strategy, calibration):
     """Create a solver that calibrates the output scale dynamically."""
-    return _DynamicSolver(strategy, calibration)
+    return _DynamicSolver(strategy, calibration.dynamic)
 
 
 def solver_calibrationfree(strategy, calibration):
     """Create a solver that does not calibrate the output scale automatically."""
-    return _CalibrationFreeSolver(strategy, calibration)
+    return _CalibrationFreeSolver(strategy, calibration.free)
 
 
 class _State(containers.NamedTuple):

--- a/probdiffeq/statespace/_calib.py
+++ b/probdiffeq/statespace/_calib.py
@@ -1,7 +1,7 @@
 """Calibration API."""
 
 
-from typing import Any
+from typing import Callable
 
 from probdiffeq.backend import containers
 
@@ -9,5 +9,12 @@ from probdiffeq.backend import containers
 class Calib(containers.NamedTuple):
     # todo: no "apply" method yet. Maybe in the future.
 
-    init: Any
-    extract: Any
+    init: Callable
+    update: Callable
+    extract: Callable
+
+
+class CalibrationBundle(containers.NamedTuple):
+    mle: Calib
+    dynamic: Calib
+    free: Calib

--- a/probdiffeq/statespace/blockdiag/calib.py
+++ b/probdiffeq/statespace/blockdiag/calib.py
@@ -6,10 +6,23 @@ from probdiffeq.statespace import _calib
 
 
 def output_scale(output_scale_scalar, *, ode_shape):
+    """Construct (a buffet of) isotropic calibration strategies."""
+    mle = _blockdiag(output_scale_scalar.mle, ode_shape=ode_shape)
+    dynamic = _blockdiag(output_scale_scalar.dynamic, ode_shape=ode_shape)
+    free = _blockdiag(output_scale_scalar.free, ode_shape=ode_shape)
+
+    return _calib.CalibrationBundle(mle=mle, dynamic=dynamic, free=free)
+
+
+def _blockdiag(output_scale_scalar, *, ode_shape):
     @jax.tree_util.Partial
     def init(s, /):
         s_arr = s * jnp.ones(ode_shape)
         return jax.vmap(output_scale_scalar.init)(s_arr)
+
+    @jax.tree_util.Partial
+    def update(s, /):
+        return jax.vmap(output_scale_scalar.update)(s)
 
     @jax.tree_util.Partial
     def extract(s):
@@ -17,4 +30,4 @@ def output_scale(output_scale_scalar, *, ode_shape):
             return s[-1, :]
         return s
 
-    return _calib.Calib(init=init, extract=extract)
+    return _calib.Calib(init=init, update=update, extract=extract)

--- a/probdiffeq/statespace/dense/calib.py
+++ b/probdiffeq/statespace/dense/calib.py
@@ -6,10 +6,23 @@ from probdiffeq.statespace import _calib
 
 
 def output_scale():
+    """Construct (a buffet of) isotropic calibration strategies."""
+    mle = _output_scale_mle()
+    dynamic = _output_scale_dynamic()
+    free = _output_scale_free()
+
+    return _calib.CalibrationBundle(mle=mle, dynamic=dynamic, free=free)
+
+
+def _output_scale_mle():
     """Scalar output scale."""
 
     @jax.tree_util.Partial
     def init(s, /):
+        return s
+
+    @jax.tree_util.Partial
+    def update(s, /):
         return s
 
     @jax.tree_util.Partial
@@ -18,4 +31,44 @@ def output_scale():
             return s[-1]
         return s
 
-    return _calib.Calib(init=init, extract=extract)
+    return _calib.Calib(init=init, update=update, extract=extract)
+
+
+def _output_scale_dynamic():
+    """Scalar output scale."""
+
+    @jax.tree_util.Partial
+    def init(s, /):
+        return s
+
+    @jax.tree_util.Partial
+    def update(s, /):
+        return s
+
+    @jax.tree_util.Partial
+    def extract(s, /):
+        if s.ndim > 0:
+            return s[-1]
+        return s
+
+    return _calib.Calib(init=init, update=update, extract=extract)
+
+
+def _output_scale_free():
+    """Scalar output scale."""
+
+    @jax.tree_util.Partial
+    def init(s, /):
+        return s
+
+    @jax.tree_util.Partial
+    def update(s, /):
+        return s
+
+    @jax.tree_util.Partial
+    def extract(s, /):
+        if s.ndim > 0:
+            return s[-1]
+        return s
+
+    return _calib.Calib(init=init, update=update, extract=extract)

--- a/probdiffeq/statespace/iso/calib.py
+++ b/probdiffeq/statespace/iso/calib.py
@@ -5,8 +5,23 @@ from probdiffeq.statespace import _calib
 
 
 def output_scale():
+    """Construct (a buffet of) isotropic calibration strategies."""
+    mle = _output_scale_mle()
+    dynamic = _output_scale_dynamic()
+    free = _output_scale_free()
+
+    return _calib.CalibrationBundle(mle=mle, dynamic=dynamic, free=free)
+
+
+def _output_scale_mle():
+    """Construct an MLE calibration routine."""
+
     @jax.tree_util.Partial
     def init(s, /):
+        return s
+
+    @jax.tree_util.Partial
+    def update(s, /):  # todo: make correct
         return s
 
     @jax.tree_util.Partial
@@ -15,4 +30,44 @@ def output_scale():
             return s[-1]
         return s
 
-    return _calib.Calib(init=init, extract=extract)
+    return _calib.Calib(init=init, update=update, extract=extract)
+
+
+def _output_scale_dynamic():
+    """Construct a dynamic calibration routine."""
+
+    @jax.tree_util.Partial
+    def init(s, /):
+        return s
+
+    @jax.tree_util.Partial
+    def update(s, /):  # todo: make correct
+        return s
+
+    @jax.tree_util.Partial
+    def extract(s):
+        if s.ndim > 0:
+            return s[-1]
+        return s
+
+    return _calib.Calib(init=init, update=update, extract=extract)
+
+
+def _output_scale_free():
+    """Construct a calibration routine that does not actually do anything."""
+
+    @jax.tree_util.Partial
+    def init(s, /):
+        return s
+
+    @jax.tree_util.Partial
+    def update(s, /):  # todo: make correct
+        return s
+
+    @jax.tree_util.Partial
+    def extract(s):
+        if s.ndim > 0:
+            return s[-1]
+        return s
+
+    return _calib.Calib(init=init, update=update, extract=extract)

--- a/probdiffeq/statespace/scalar/calib.py
+++ b/probdiffeq/statespace/scalar/calib.py
@@ -5,8 +5,21 @@ from probdiffeq.statespace import _calib
 
 
 def output_scale():
+    """Construct (a buffet of) isotropic calibration strategies."""
+    mle = _output_scale_mle()
+    dynamic = _output_scale_dynamic()
+    free = _output_scale_free()
+
+    return _calib.CalibrationBundle(mle=mle, dynamic=dynamic, free=free)
+
+
+def _output_scale_mle():
     @jax.tree_util.Partial
     def init(s, /):
+        return s
+
+    @jax.tree_util.Partial
+    def update(s, /):
         return s
 
     @jax.tree_util.Partial
@@ -15,4 +28,40 @@ def output_scale():
             return s[-1]
         return s
 
-    return _calib.Calib(init=init, extract=extract)
+    return _calib.Calib(init=init, update=update, extract=extract)
+
+
+def _output_scale_dynamic():
+    @jax.tree_util.Partial
+    def init(s, /):
+        return s
+
+    @jax.tree_util.Partial
+    def update(s, /):
+        return s
+
+    @jax.tree_util.Partial
+    def extract(s):
+        if s.ndim > 0:
+            return s[-1]
+        return s
+
+    return _calib.Calib(init=init, update=update, extract=extract)
+
+
+def _output_scale_free():
+    @jax.tree_util.Partial
+    def init(s, /):
+        return s
+
+    @jax.tree_util.Partial
+    def update(s, /):
+        return s
+
+    @jax.tree_util.Partial
+    def extract(s):
+        if s.ndim > 0:
+            return s[-1]
+        return s
+
+    return _calib.Calib(init=init, update=update, extract=extract)


### PR DESCRIPTION
This allows a few code simplifications down the road:
* Running mean estimate can be handled by implementations (which removes the strange autobatching hack)
* output scale prior/calibrated distinction vanishes -- it becomes some state-type in calibration

Maybe solvers simplify so drastically that they almost become a single method soon. Who knows. 