### PR TITLE
Compulsory output scale in ibm_utils.system_matrices

### DIFF
--- a/probdiffeq/statespace/_ibm_util.py
+++ b/probdiffeq/statespace/_ibm_util.py
@@ -5,7 +5,7 @@ import jax.numpy as jnp
 
 
 # todo: make output_scale compulsory!
-def system_matrices_1d(*, num_derivatives, output_scale=1.0):
+def system_matrices_1d(num_derivatives, output_scale):
     """Construct the IBM system matrices."""
     x = jnp.arange(num_derivatives + 1)
 

--- a/probdiffeq/statespace/blockdiag/extra.py
+++ b/probdiffeq/statespace/blockdiag/extra.py
@@ -9,10 +9,8 @@ from probdiffeq.statespace.scalar import extra as scalar_extra
 
 def ibm_factory(ode_shape, num_derivatives):
     assert len(ode_shape) == 1
-    (n,) = ode_shape
-    factory = scalar_extra.ibm_factory(num_derivatives=num_derivatives)
-    params_stack = _tree_stack_duplicates(factory.args, n=n)
-    factory.args = params_stack
+    fun_vmap = jax.vmap(scalar_extra.ibm_factory, in_axes=(None, 0))
+    factory = fun_vmap(num_derivatives, jnp.ones(ode_shape))
     return _BlockDiagExtrapolationFactory(wraps=factory)
 
 

--- a/probdiffeq/statespace/dense/extra.py
+++ b/probdiffeq/statespace/dense/extra.py
@@ -12,7 +12,7 @@ def ibm_factory(ode_shape, num_derivatives):
     assert len(ode_shape) == 1
     (d,) = ode_shape
 
-    a, q_sqrtm = _ibm_util.system_matrices_1d(num_derivatives=num_derivatives)
+    a, q_sqrtm = _ibm_util.system_matrices_1d(num_derivatives, output_scale=1.0)
     precon_1d = _ibm_util.preconditioner_prepare(num_derivatives=num_derivatives)
 
     @jax.tree_util.Partial

--- a/probdiffeq/statespace/iso/extra.py
+++ b/probdiffeq/statespace/iso/extra.py
@@ -10,7 +10,7 @@ from probdiffeq.statespace.iso import variables
 
 
 def ibm_factory(num_derivatives) -> "_IsoExtrapolationFactory":
-    a, q_sqrtm = _ibm_util.system_matrices_1d(num_derivatives=num_derivatives)
+    a, q_sqrtm = _ibm_util.system_matrices_1d(num_derivatives, output_scale=1.0)
     precon = _ibm_util.preconditioner_prepare(num_derivatives=num_derivatives)
     return _IsoExtrapolationFactory(args=(a, q_sqrtm, precon))
 

--- a/probdiffeq/statespace/scalar/extra.py
+++ b/probdiffeq/statespace/scalar/extra.py
@@ -114,12 +114,11 @@ def extrapolate_precon(
     return marginal
 
 
-def ibm_factory(num_derivatives):
-    a, q_sqrtm = _ibm_util.system_matrices_1d(num_derivatives=num_derivatives)
+def ibm_factory(num_derivatives, output_scale=1.0):
+    a, q_sqrtm = _ibm_util.system_matrices_1d(num_derivatives, output_scale)
     precon = _ibm_util.preconditioner_prepare(num_derivatives=num_derivatives)
 
-    factory = _ScalarExtrapolationFactory(args=(a, q_sqrtm, precon))
-    return factory
+    return _ScalarExtrapolationFactory(args=(a, q_sqrtm, precon))
 
 
 class _ScalarExtrapolationFactory(extra.ExtrapolationFactory):
@@ -138,6 +137,13 @@ class _ScalarExtrapolationFactory(extra.ExtrapolationFactory):
 
     def fixedpoint(self):
         return _IBMFp(*self.args)
+
+
+jax.tree_util.register_pytree_node(
+    nodetype=_ScalarExtrapolationFactory,
+    flatten_func=lambda a: (a.args, ()),
+    unflatten_func=lambda a, b: _ScalarExtrapolationFactory(b),
+)
 
 
 class _IBMFi(extra.Extrapolation):


### PR DESCRIPTION
This simplifies the construction of blockdiagonal models as vmapped scalar models 