### PR TITLE
Merge linting and formatting behaviour

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,9 +30,9 @@ jobs:
         run: |
           sudo apt-get install pandoc
           pip install --upgrade pip
-          pip install .[cpu,lint]
+          pip install .[cpu,format-and-lint]
       - name: Apply linter
-        run: make lint
+        run: make format-and-lint
   test:
     name: Test with ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,24 +8,20 @@ repos:
       - id: end-of-file-fixer
       - id: check-merge-conflict
   - repo: https://github.com/lyz-code/yamlfix/
-    rev: 1.13.0
+    rev: 1.16.0
     hooks:
       - id: yamlfix
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.1.3
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.1.8
     hooks:
+      # Run the linter.
       - id: ruff
-        args: [--quiet, .]
+        args: [--fix]
+      # Run the formatter.
       - id: ruff-format
-        args: [--quiet, --check, .]
-  - repo: https://github.com/mwouts/jupytext
-    rev: v1.15.2
-    hooks:
-      - id: jupytext
-        files: ^(docs/(benchmarks|examples_solver_config|examples_parameter_estimation|getting_started)/).+.ipynb
-        args: [--sync]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.6.1
+    rev: v1.7.1
     hooks:
       - id: mypy
         args: [--ignore-missing-imports]

--- a/makefile
+++ b/makefile
@@ -1,8 +1,4 @@
-
-format:
-	ruff format --quiet .
-
-lint:
+format-and-lint:
 	pre-commit run --all-files
 
 test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,14 +36,11 @@ test =[
     "diffrax",
     "equinox",
 ]
-lint =[
+format-and-lint =[
     "pre-commit",
 ]
-format =[
-    "ruff",
-    "jupytext",
-]
 example = [
+    "jupytext",
     "jupyter",
     "matplotlib",
     "jupytext",


### PR DESCRIPTION
They have been closely related via `ruff check . --fix` so from now on, formatting is linting and linting is formatting.

As a follow-up edit to #680, jupytext is not a linting dependency anymore but purely an example/doc dependency.