### PR TITLE
Update the pre-commit hook (and fix deprecations) to modernise the CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
   python: python3
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: end-of-file-fixer
       - id: check-merge-conflict
@@ -13,7 +13,7 @@ repos:
       - id: yamlfix
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.1.9
+    rev: v0.4.8
     hooks:
       # Run the linter.
       - id: ruff
@@ -21,7 +21,7 @@ repos:
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.10.0
     hooks:
       - id: mypy
         args: [--ignore-missing-imports]

--- a/docs/benchmarks/hires/run_hires.py
+++ b/docs/benchmarks/hires/run_hires.py
@@ -2,6 +2,7 @@
 
 See makefile for instructions.
 """
+
 import argparse
 import functools
 import os

--- a/docs/benchmarks/lotkavolterra/run_lotkavolterra.py
+++ b/docs/benchmarks/lotkavolterra/run_lotkavolterra.py
@@ -2,6 +2,7 @@
 
 See makefile for instructions.
 """
+
 import argparse
 import functools
 import os

--- a/docs/benchmarks/pleiades/run_pleiades.py
+++ b/docs/benchmarks/pleiades/run_pleiades.py
@@ -2,6 +2,7 @@
 
 See makefile for instructions.
 """
+
 import argparse
 import functools
 import os

--- a/docs/benchmarks/taylor_fitzhughnagumo/run_taylor_fitzhughnagumo.py
+++ b/docs/benchmarks/taylor_fitzhughnagumo/run_taylor_fitzhughnagumo.py
@@ -2,6 +2,7 @@
 
 See makefile for instructions.
 """
+
 import argparse
 import functools
 import os

--- a/docs/benchmarks/taylor_node/run_taylor_node.py
+++ b/docs/benchmarks/taylor_node/run_taylor_node.py
@@ -2,6 +2,7 @@
 
 See makefile for instructions.
 """
+
 import argparse
 import functools
 import os

--- a/docs/benchmarks/taylor_pleiades/run_taylor_pleiades.py
+++ b/docs/benchmarks/taylor_pleiades/run_taylor_pleiades.py
@@ -2,6 +2,7 @@
 
 See makefile for instructions.
 """
+
 import argparse
 import functools
 import os

--- a/docs/benchmarks/vanderpol/run_vanderpol.py
+++ b/docs/benchmarks/vanderpol/run_vanderpol.py
@@ -2,6 +2,7 @@
 
 See makefile for instructions.
 """
+
 import argparse
 import functools
 import os

--- a/docs/examples_parameter_estimation/neural_ode.py
+++ b/docs/examples_parameter_estimation/neural_ode.py
@@ -19,6 +19,7 @@
 
 # +
 """Train a neural ODE with ProbDiffEq and Optax."""
+
 import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt

--- a/docs/examples_solver_config/conditioning-on-zero-residual.py
+++ b/docs/examples_solver_config/conditioning-on-zero-residual.py
@@ -20,6 +20,7 @@
 
 # +
 """Demonstrate how probabilistic solvers work via conditioning on constraints."""
+
 import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt

--- a/probdiffeq/__init__.py
+++ b/probdiffeq/__init__.py
@@ -1,2 +1,3 @@
 """Probabilistic solvers for differential equations."""
+
 from probdiffeq._version import version as __version__  # noqa: F401

--- a/probdiffeq/adaptive.py
+++ b/probdiffeq/adaptive.py
@@ -1,4 +1,5 @@
 """Adaptive solvers for initial value problems (IVPs)."""
+
 from probdiffeq import controls
 from probdiffeq.backend import containers, control_flow, functools, linalg, tree_util
 from probdiffeq.backend import numpy as np

--- a/probdiffeq/backend/abc.py
+++ b/probdiffeq/backend/abc.py
@@ -1,6 +1,5 @@
 """Abstract base classes."""
 
-
 import abc
 
 

--- a/probdiffeq/backend/functools.py
+++ b/probdiffeq/backend/functools.py
@@ -1,4 +1,5 @@
 """Function transformation tools."""
+
 import functools
 
 import jax

--- a/probdiffeq/backend/ode.py
+++ b/probdiffeq/backend/ode.py
@@ -1,4 +1,5 @@
 """ODE stuff."""
+
 import diffeqzoo.ivps
 import diffrax
 import jax

--- a/probdiffeq/backend/testing.py
+++ b/probdiffeq/backend/testing.py
@@ -8,6 +8,7 @@ and without bundling them here, choices between
 have been very inconsistent.
 This is not good for extendability of the test suite.
 """
+
 import jax.numpy as jnp
 import jax.tree_util
 import pytest

--- a/probdiffeq/backend/warnings.py
+++ b/probdiffeq/backend/warnings.py
@@ -1,4 +1,5 @@
 """Warnings."""
+
 import warnings
 
 

--- a/probdiffeq/impl/__init__.py
+++ b/probdiffeq/impl/__init__.py
@@ -1,4 +1,5 @@
 """State-space model implementations."""
+
 from probdiffeq.impl import _impl
 
 impl = _impl.Impl()

--- a/probdiffeq/impl/_conditional.py
+++ b/probdiffeq/impl/_conditional.py
@@ -1,4 +1,5 @@
 """Conditionals."""
+
 from probdiffeq.backend import abc
 
 

--- a/probdiffeq/impl/_impl.py
+++ b/probdiffeq/impl/_impl.py
@@ -1,4 +1,5 @@
 """State-space model impl."""
+
 import warnings
 
 from probdiffeq.backend import abc

--- a/probdiffeq/impl/blockdiag/_conditional.py
+++ b/probdiffeq/impl/blockdiag/_conditional.py
@@ -1,4 +1,5 @@
 """Conditional implementation."""
+
 from probdiffeq.backend import functools
 from probdiffeq.backend import numpy as np
 from probdiffeq.impl import _conditional

--- a/probdiffeq/impl/blockdiag/_linearise.py
+++ b/probdiffeq/impl/blockdiag/_linearise.py
@@ -1,4 +1,5 @@
 """Linearisation."""
+
 from probdiffeq.impl import _linearise
 from probdiffeq.util import linop_util
 

--- a/probdiffeq/impl/blockdiag/_ssm_util.py
+++ b/probdiffeq/impl/blockdiag/_ssm_util.py
@@ -1,4 +1,5 @@
 """State-space model utilities."""
+
 from probdiffeq.backend import functools
 from probdiffeq.backend import numpy as np
 from probdiffeq.impl import _ssm_util

--- a/probdiffeq/impl/blockdiag/_transform.py
+++ b/probdiffeq/impl/blockdiag/_transform.py
@@ -1,4 +1,5 @@
 """Random-variable transformation."""
+
 from probdiffeq.backend import functools
 from probdiffeq.backend import numpy as np
 from probdiffeq.impl import _transform

--- a/probdiffeq/impl/blockdiag/factorised_impl.py
+++ b/probdiffeq/impl/blockdiag/factorised_impl.py
@@ -1,4 +1,5 @@
 """Factorisations."""
+
 from probdiffeq.impl import _impl
 from probdiffeq.impl.blockdiag import (
     _conditional,

--- a/probdiffeq/impl/dense/_conditional.py
+++ b/probdiffeq/impl/dense/_conditional.py
@@ -1,4 +1,5 @@
 """Conditional implementation."""
+
 from probdiffeq.impl import _conditional
 from probdiffeq.impl.dense import _normal
 from probdiffeq.util import cholesky_util, cond_util

--- a/probdiffeq/impl/dense/_linearise.py
+++ b/probdiffeq/impl/dense/_linearise.py
@@ -1,6 +1,5 @@
 """Linearisation."""
 
-
 from probdiffeq.backend import functools
 from probdiffeq.backend import numpy as np
 from probdiffeq.impl import _linearise

--- a/probdiffeq/impl/dense/_transform.py
+++ b/probdiffeq/impl/dense/_transform.py
@@ -1,4 +1,5 @@
 """Random variable transformations."""
+
 from probdiffeq.backend import containers
 from probdiffeq.backend.typing import Array, Callable
 from probdiffeq.impl import _transform

--- a/probdiffeq/impl/dense/factorised_impl.py
+++ b/probdiffeq/impl/dense/factorised_impl.py
@@ -1,4 +1,5 @@
 """API for dense factorisations."""
+
 from probdiffeq.impl import _impl
 from probdiffeq.impl.dense import (
     _conditional,

--- a/probdiffeq/impl/isotropic/_linearise.py
+++ b/probdiffeq/impl/isotropic/_linearise.py
@@ -1,4 +1,5 @@
 """Linearisation."""
+
 from probdiffeq.impl import _linearise
 from probdiffeq.util import linop_util
 

--- a/probdiffeq/impl/isotropic/_ssm_util.py
+++ b/probdiffeq/impl/isotropic/_ssm_util.py
@@ -1,4 +1,5 @@
 """State-space model utilities."""
+
 from probdiffeq.backend import numpy as np
 from probdiffeq.impl import _ssm_util
 from probdiffeq.impl.isotropic import _normal

--- a/probdiffeq/impl/isotropic/factorised_impl.py
+++ b/probdiffeq/impl/isotropic/factorised_impl.py
@@ -1,4 +1,5 @@
 """Isotropic factorisation."""
+
 from probdiffeq.impl import _impl
 from probdiffeq.impl.isotropic import (
     _conditional,

--- a/probdiffeq/impl/scalar/_conditional.py
+++ b/probdiffeq/impl/scalar/_conditional.py
@@ -1,4 +1,5 @@
 """Conditionals."""
+
 from probdiffeq.backend import linalg
 from probdiffeq.backend import numpy as np
 from probdiffeq.impl import _conditional

--- a/probdiffeq/impl/scalar/_hidden_model.py
+++ b/probdiffeq/impl/scalar/_hidden_model.py
@@ -1,4 +1,5 @@
 """Hidden state-space model implementation."""
+
 from probdiffeq.backend import functools
 from probdiffeq.backend import numpy as np
 from probdiffeq.impl import _hidden_model

--- a/probdiffeq/impl/scalar/_linearise.py
+++ b/probdiffeq/impl/scalar/_linearise.py
@@ -1,4 +1,5 @@
 """Linearisation."""
+
 from probdiffeq.impl import _linearise
 
 

--- a/probdiffeq/impl/scalar/_ssm_util.py
+++ b/probdiffeq/impl/scalar/_ssm_util.py
@@ -1,4 +1,5 @@
 """SSM utilities."""
+
 from probdiffeq.backend import numpy as np
 from probdiffeq.impl import _ssm_util
 from probdiffeq.impl.scalar import _normal

--- a/probdiffeq/impl/scalar/_stats.py
+++ b/probdiffeq/impl/scalar/_stats.py
@@ -1,4 +1,5 @@
 """Random variable implementation."""
+
 from probdiffeq.backend import functools, linalg
 from probdiffeq.backend import numpy as np
 from probdiffeq.impl import _stats

--- a/probdiffeq/impl/scalar/_transform.py
+++ b/probdiffeq/impl/scalar/_transform.py
@@ -1,4 +1,5 @@
 """Random variable transformations."""
+
 from probdiffeq.backend import numpy as np
 from probdiffeq.impl import _transform
 from probdiffeq.impl.scalar import _normal

--- a/probdiffeq/impl/scalar/factorised_impl.py
+++ b/probdiffeq/impl/scalar/factorised_impl.py
@@ -1,4 +1,5 @@
 """Scalar factorisation."""
+
 from probdiffeq.impl import _impl
 from probdiffeq.impl.scalar import (
     _conditional,

--- a/probdiffeq/solvers/_solver.py
+++ b/probdiffeq/solvers/_solver.py
@@ -1,6 +1,5 @@
 """IVP-solver API."""
 
-
 from probdiffeq import _interp
 from probdiffeq.backend import abc
 from probdiffeq.backend import numpy as np

--- a/probdiffeq/solvers/calibrated.py
+++ b/probdiffeq/solvers/calibrated.py
@@ -1,4 +1,5 @@
 """Calibrated IVP solvers."""
+
 from probdiffeq import _interp
 from probdiffeq.backend import abc, tree_util
 from probdiffeq.impl import impl

--- a/probdiffeq/solvers/strategies/components/cubature.py
+++ b/probdiffeq/solvers/strategies/components/cubature.py
@@ -1,6 +1,5 @@
 """Cubature rules."""
 
-
 from probdiffeq.backend import containers, special, tree_util
 from probdiffeq.backend import numpy as np
 from probdiffeq.backend.typing import Array

--- a/probdiffeq/solvers/strategies/components/priors.py
+++ b/probdiffeq/solvers/strategies/components/priors.py
@@ -1,6 +1,5 @@
 """Prior models."""
 
-
 from probdiffeq.backend import functools
 from probdiffeq.backend import numpy as np
 from probdiffeq.impl import impl

--- a/probdiffeq/taylor/autodiff.py
+++ b/probdiffeq/taylor/autodiff.py
@@ -1,6 +1,5 @@
 r"""Taylor-expand the solution of an initial value problem (IVP)."""
 
-
 from probdiffeq.backend import control_flow, functools, itertools, tree_util
 from probdiffeq.backend import numpy as np
 from probdiffeq.backend.typing import Array, Callable

--- a/probdiffeq/taylor/estim.py
+++ b/probdiffeq/taylor/estim.py
@@ -1,6 +1,5 @@
 r"""Taylor-expand the solution of an initial value problem (IVP)."""
 
-
 from probdiffeq.backend import functools, ode
 from probdiffeq.backend import numpy as np
 from probdiffeq.impl import impl

--- a/probdiffeq/timestep.py
+++ b/probdiffeq/timestep.py
@@ -1,6 +1,5 @@
 """Time-stepping utilities."""
 
-
 from probdiffeq.backend import linalg
 from probdiffeq.backend import numpy as np
 

--- a/probdiffeq/util/cond_util.py
+++ b/probdiffeq/util/cond_util.py
@@ -1,4 +1,5 @@
 """Conditional-utilities."""
+
 from probdiffeq.backend import containers
 from probdiffeq.backend.typing import Any, Array
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,12 @@ exclude_also = [
 
 [tool.ruff]
 include = ["**.py", "**/pyproject.toml", "**.ipynb"]
+# Same as Black.
+line-length = 88
+indent-width = 4
+
 # See: https://beta.ruff.rs/docs/rules/
+[tool.ruff.lint]
 select = [
     # pycodestyle (warning, error)
     "W",
@@ -151,9 +156,20 @@ ignore = [
     # Magic methods don't need a docstring:
     "D105",
 ]
-# Same as Black.
-line-length = 88
-indent-width = 4
+
+[tool.ruff.lint.isort]
+split-on-trailing-comma = false
+
+[tool.ruff.lint.per-file-ignores]
+# Auxiliary functions and tests don't need docstring-enforcement:
+"probdiffeq/util/*" = ["D102", "D103"]
+"probdiffeq/impl/*" = ["D102"]
+"probdiffeq/backend/*" = ["D103"]
+"tests/*" = ["D103"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
 
 [tool.ruff.format]
 # Use `\n` line endings for all files
@@ -161,16 +177,3 @@ line-ending = "lf"
 # Prefer single quotes over double quotes.
 quote-style = "double"
 skip-magic-trailing-comma = true
-
-[tool.ruff.isort]
-split-on-trailing-comma = false
-
-[tool.ruff.per-file-ignores]
-# Auxiliary functions and tests don't need docstring-enforcement:
-"probdiffeq/util/*" = ["D102", "D103"]
-"probdiffeq/impl/*" = ["D102"]
-"probdiffeq/backend/*" = ["D103"]
-"tests/*" = ["D103"]
-
-[tool.ruff.pydocstyle]
-convention = "numpy"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,5 @@
 """Tests."""
+
 import os
 
 from tests.setup import setup

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -1,6 +1,5 @@
 """Test-setup."""
 
-
 from probdiffeq.backend import config, ode, warnings
 from probdiffeq.backend import numpy as np
 from probdiffeq.impl import impl

--- a/tests/test_impl/test_logpdfs.py
+++ b/tests/test_impl/test_logpdfs.py
@@ -3,7 +3,6 @@
 Necessary because the implementation has been faulty in the past. Never again.
 """
 
-
 from probdiffeq.backend import functools, stats
 from probdiffeq.backend import numpy as np
 from probdiffeq.impl import impl

--- a/tests/test_ivpsolve/test_fixed_grid_vs_save_every_step.py
+++ b/tests/test_ivpsolve/test_fixed_grid_vs_save_every_step.py
@@ -1,6 +1,5 @@
 """Compare solve_fixed_grid to solve_and_save_every_step."""
 
-
 from probdiffeq import adaptive, controls, ivpsolve
 from probdiffeq.backend import numpy as np
 from probdiffeq.backend import testing

--- a/tests/test_ivpsolve/test_save_at_vs_save_every_step.py
+++ b/tests/test_ivpsolve/test_save_at_vs_save_every_step.py
@@ -1,4 +1,5 @@
 """Assert that solve_and_save_at is consistent with solve_with_python_loop()."""
+
 from probdiffeq import adaptive, ivpsolve
 from probdiffeq.backend import functools, testing, tree_util
 from probdiffeq.backend import numpy as np

--- a/tests/test_ivpsolve/test_solution_object.py
+++ b/tests/test_ivpsolve/test_solution_object.py
@@ -1,4 +1,5 @@
 """Tests for interaction with the solution object."""
+
 from probdiffeq import adaptive, ivpsolve
 from probdiffeq.backend import functools, testing
 from probdiffeq.backend import numpy as np

--- a/tests/test_ivpsolve/test_terminal_values_vs_save_every_step.py
+++ b/tests/test_ivpsolve/test_terminal_values_vs_save_every_step.py
@@ -1,6 +1,5 @@
 """Compare simulate_terminal_values to solve_and_save_every_step."""
 
-
 from probdiffeq import adaptive, ivpsolve
 from probdiffeq.backend import numpy as np
 from probdiffeq.backend import testing, tree_util

--- a/tests/test_solvers/test_calibrated/test_dynamic_calibration_on_exponential.py
+++ b/tests/test_solvers/test_calibrated/test_dynamic_calibration_on_exponential.py
@@ -4,6 +4,7 @@ Specifically, we solve a linear function with exponentially increasing output-sc
 This is difficult for the MLE- and calibration-free solver,
 but not for the dynamic solver.
 """
+
 from probdiffeq import ivpsolve
 from probdiffeq.backend import linalg
 from probdiffeq.backend import numpy as np

--- a/tests/test_solvers/test_calibrated/test_mle_calibration_vs_calibrationfree.py
+++ b/tests/test_solvers/test_calibrated/test_mle_calibration_vs_calibrationfree.py
@@ -4,6 +4,7 @@ The posterior of the MLE solver is the same as for the calibration-free solver.
 The output scale is different.
 After applying solution.calibrate(), the posterior is different.
 """
+
 from probdiffeq import adaptive, ivpsolve, timestep
 from probdiffeq.backend import numpy as np
 from probdiffeq.backend import testing

--- a/tests/test_solvers/test_misc/test_warnings_for_wrong_strategies.py
+++ b/tests/test_solvers/test_misc/test_warnings_for_wrong_strategies.py
@@ -1,4 +1,5 @@
 """Some strategies don't work with all solution routines."""
+
 from probdiffeq import adaptive, ivpsolve
 from probdiffeq.backend import numpy as np
 from probdiffeq.backend import testing

--- a/tests/test_solvers/test_solution/test_log_marginal_likelihood.py
+++ b/tests/test_solvers/test_solution/test_log_marginal_likelihood.py
@@ -1,4 +1,5 @@
 """Tests for log-marginal-likelihood functionality."""
+
 from probdiffeq import adaptive, ivpsolve
 from probdiffeq.backend import numpy as np
 from probdiffeq.backend import testing, tree_util

--- a/tests/test_solvers/test_solution/test_log_marginal_likelihood_terminal_values.py
+++ b/tests/test_solvers/test_solution/test_log_marginal_likelihood_terminal_values.py
@@ -1,4 +1,5 @@
 """Tests for marginal log likelihood functionality (terminal values)."""
+
 from probdiffeq import adaptive, ivpsolve
 from probdiffeq.backend import numpy as np
 from probdiffeq.backend import testing

--- a/tests/test_solvers/test_solution/test_offgrid_marginals.py
+++ b/tests/test_solvers/test_solution/test_offgrid_marginals.py
@@ -1,4 +1,5 @@
 """Tests for IVP solvers."""
+
 from probdiffeq import ivpsolve
 from probdiffeq.backend import numpy as np
 from probdiffeq.impl import impl

--- a/tests/test_solvers/test_strategies/test_cubature/test_equivalence.py
+++ b/tests/test_solvers/test_strategies/test_cubature/test_equivalence.py
@@ -1,4 +1,5 @@
 """Test equivalences between cubature rules."""
+
 from probdiffeq.backend import numpy as np
 from probdiffeq.solvers.strategies.components import cubature
 

--- a/tests/test_solvers/test_strategies/test_smoother_vs_fixedpoint_equivalence.py
+++ b/tests/test_solvers/test_strategies/test_smoother_vs_fixedpoint_equivalence.py
@@ -2,6 +2,7 @@
 
 That is, when called with correct adaptive- and checkpoint-setups.
 """
+
 from probdiffeq import adaptive, ivpsolve
 from probdiffeq.backend import functools, testing, tree_util
 from probdiffeq.backend import numpy as np

--- a/tests/test_taylor/test_exact_first_order.py
+++ b/tests/test_taylor/test_exact_first_order.py
@@ -1,6 +1,5 @@
 """Test the exactness of differentiation-based routines on first-order problems."""
 
-
 from probdiffeq.backend import numpy as np
 from probdiffeq.backend import ode, testing
 from probdiffeq.taylor import autodiff

--- a/tests/test_taylor/test_exact_higher_order.py
+++ b/tests/test_taylor/test_exact_higher_order.py
@@ -1,6 +1,5 @@
 """Test the exactness of differentiation-based routines on first-order problems."""
 
-
 from probdiffeq.backend import numpy as np
 from probdiffeq.backend import ode, testing
 from probdiffeq.taylor import autodiff

--- a/tests/test_util/test_cholesky_util.py
+++ b/tests/test_util/test_cholesky_util.py
@@ -2,6 +2,7 @@
 
 These are so crucial and annoying to debug that they need their own test set.
 """
+
 from math import prod
 
 from probdiffeq.backend import functools, linalg, testing, tree_util


### PR DESCRIPTION
Some of the linter-dependencies (especially ruff!) have gone through significant changes since the most recent `pre-commit autoupdate`.