### PR TITLE
Move discrete filters to `util` to separate them from the ODE solver strategies

### DIFF
--- a/docs/api_docs/solvers/strategies/discrete.md
+++ b/docs/api_docs/solvers/strategies/discrete.md
@@ -1,1 +1,0 @@
-::: probdiffeq.solvers.strategies.discrete

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,7 +104,6 @@ nav:
               - filters: api_docs/solvers/strategies/filters.md
               - smoothers: api_docs/solvers/strategies/smoothers.md
               - fixedpoint: api_docs/solvers/strategies/fixedpoint.md
-              - discrete: api_docs/solvers/strategies/discrete.md
           - calibrated: api_docs/solvers/calibrated.md
           - uncalibrated: api_docs/solvers/uncalibrated.md
           - solution: api_docs/solvers/solution.md

--- a/probdiffeq/solvers/solution.py
+++ b/probdiffeq/solvers/solution.py
@@ -8,7 +8,7 @@ from probdiffeq.backend import functools, tree_util
 from probdiffeq.backend import numpy as np
 from probdiffeq.impl import impl
 from probdiffeq.solvers import markov
-from probdiffeq.solvers.strategies import discrete
+from probdiffeq.util import filter_util
 
 # TODO: the functions in here should only depend on posteriors / strategies!
 
@@ -157,8 +157,8 @@ def log_marginal_likelihood(u, /, *, standard_deviation, posterior):
     rv = tree_util.tree_map(lambda s: s[-1, ...], posterior.init)
 
     # Run the reverse Kalman filter
-    estimator = discrete.kalmanfilter_with_marginal_likelihood()
-    (_corrected, _num_data, logpdf), _ = discrete.estimate_rev(
+    estimator = filter_util.kalmanfilter_with_marginal_likelihood()
+    (_corrected, _num_data, logpdf), _ = filter_util.estimate_rev(
         u,
         init=rv,
         prior_transitions=posterior.conditional,

--- a/probdiffeq/taylor/estim.py
+++ b/probdiffeq/taylor/estim.py
@@ -3,7 +3,7 @@ r"""Taylor-expand the solution of an initial value problem (IVP)."""
 from probdiffeq.backend import functools, ode
 from probdiffeq.backend import numpy as np
 from probdiffeq.impl import impl
-from probdiffeq.solvers.strategies import discrete
+from probdiffeq.util import filter_util
 
 
 def make_runge_kutta_starter(dt, *, atol=1e-12, rtol=1e-10):
@@ -41,7 +41,7 @@ def _runge_kutta_starter(vf, initial_values, /, num: int, t, dt0, atol, rtol):
     ys = ode.odeint_and_save_at(vf, initial_values, save_at=ts, atol=atol, rtol=rtol)
 
     # Initial condition
-    estimator = discrete.fixedpointsmoother_precon()
+    estimator = filter_util.fixedpointsmoother_precon()
     rv_t0 = impl.ssm_util.standard_normal(num + 1, 1.0)
     conditional_t0 = impl.ssm_util.identity_conditional(num + 1)
     init = (rv_t0, conditional_t0)
@@ -58,7 +58,7 @@ def _runge_kutta_starter(vf, initial_values, /, num: int, t, dt0, atol, rtol):
     models = model_fun(0, 1e-7 * np.ones_like(ts))
 
     # Run the preconditioned fixedpoint smoother
-    (corrected, conditional), _ = discrete.estimate_fwd(
+    (corrected, conditional), _ = filter_util.estimate_fwd(
         ys,
         init=init,
         prior_transitions=ibm_transitions,

--- a/probdiffeq/util/filter_util.py
+++ b/probdiffeq/util/filter_util.py
@@ -1,4 +1,7 @@
-"""Discrete filtering and smoothing."""
+"""Filtering utilities.
+
+Mostly **discrete** filtering and smoothing.
+"""
 
 from probdiffeq.backend import containers, control_flow, tree_util
 from probdiffeq.backend.typing import Any


### PR DESCRIPTION
This prepares some of the reordering in #747 