### PR TITLE
Internals: Make the constructors in ivpsolvers.py more functional

### DIFF
--- a/probdiffeq/ivpsolve.py
+++ b/probdiffeq/ivpsolve.py
@@ -351,14 +351,14 @@ class _AdaptiveIVPSolver:
 
 
 def _asolver_flatten(asolver):
-    children = (asolver.solver, asolver.atol, asolver.rtol, asolver.control)
-    aux = (asolver.norm_ord,)
+    children = (asolver.atol, asolver.rtol, asolver.control)
+    aux = (asolver.solver, asolver.norm_ord)
     return children, aux
 
 
 def _asolver_unflatten(aux, children):
-    solver, atol, rtol, control = children
-    (norm_ord,) = aux
+    atol, rtol, control = children
+    (solver, norm_ord) = aux
     return _AdaptiveIVPSolver(
         solver=solver, atol=atol, rtol=rtol, control=control, norm_ord=norm_ord
     )

--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -661,99 +661,134 @@ def prior_ibm_discrete(ts, *, num_derivatives, output_scale=None):
     return stats.MarkovSeq(init, conditionals)
 
 
-class _Correction(abc.ABC):
+@containers.dataclass
+class _Correction:
     """Correction model interface."""
 
-    def __init__(self, ode_order):
-        self.ode_order = ode_order
+    name: str
+    ode_order: int
 
-    @abc.abstractmethod
-    def init(self, x, /):
-        """Initialise the state from the solution."""
-        raise NotImplementedError
+    init: Callable
+    """Initialise the state from the solution."""
 
-    @abc.abstractmethod
-    def estimate_error(self, ssv, corr, /, vector_field, t):
-        """Perform all elements of the correction until the error estimate."""
-        raise NotImplementedError
+    estimate_error: Callable
+    """Perform all elements of the correction until the error estimate."""
 
-    @abc.abstractmethod
-    def complete(self, ssv, corr, /):
-        """Complete what has been left out by `estimate_error`."""
-        raise NotImplementedError
+    complete: Callable
+    """Complete what has been left out by `estimate_error`."""
 
-    @abc.abstractmethod
-    def extract(self, ssv, corr, /):
-        """Extract the solution from the state."""
-        raise NotImplementedError
+    extract: Callable
+    """Extract the solution from the state."""
 
 
-class _ODEConstraintTaylor(_Correction):
-    def __init__(self, ode_order, linearise_fun, string_repr):
-        super().__init__(ode_order=ode_order)
+def correction_ts0(*, ode_order=1) -> _Correction:
+    """Zeroth-order Taylor linearisation."""
+    return _correction_constraint_ode_taylor(
+        ode_order=ode_order,
+        linearise_fun=impl.linearise.ode_taylor_0th(ode_order=ode_order),
+        string_repr=f"<TS0 with ode_order={ode_order}>",
+    )
 
-        self.linearise = linearise_fun
-        self.string_repr = string_repr
 
-    def __repr__(self):
-        return self.string_repr
+def correction_ts1(*, ode_order=1) -> _Correction:
+    """First-order Taylor linearisation."""
+    return _correction_constraint_ode_taylor(
+        ode_order=ode_order,
+        linearise_fun=impl.linearise.ode_taylor_1st(ode_order=ode_order),
+        string_repr=f"<TS1 with ode_order={ode_order}>",
+    )
 
-    def init(self, ssv, /):
+
+def _correction_constraint_ode_taylor(
+    ode_order, linearise_fun, string_repr
+) -> _Correction:
+    def init(ssv, /):
         obs_like = impl.prototypes.observed()
         return ssv, obs_like
 
-    def estimate_error(self, hidden_state, _corr, /, vector_field, t):
+    def estimate_error(hidden_state, _corr, /, vector_field, t):
         def f_wrapped(s):
             return vector_field(*s, t=t)
 
-        A, b = self.linearise(f_wrapped, hidden_state.mean)
+        A, b = linearise_fun(f_wrapped, hidden_state.mean)
         observed = impl.transform.marginalise(hidden_state, (A, b))
 
         error_estimate = _estimate_error(observed)
         return error_estimate, observed, (A, b)
 
-    def complete(self, hidden_state, corr, /):
+    def complete(hidden_state, corr, /):
         A, b = corr
         observed, (_gain, corrected) = impl.transform.revert(hidden_state, (A, b))
         return corrected, observed
 
-    def extract(self, ssv, _corr, /):
+    def extract(ssv, _corr, /):
         return ssv
 
+    return _Correction(
+        ode_order=ode_order,
+        name=string_repr,
+        init=init,
+        estimate_error=estimate_error,
+        complete=complete,
+        extract=extract,
+    )
 
-class _ODEConstraintStatistical(_Correction):
-    def __init__(self, ode_order, linearise_fun, string_repr):
-        super().__init__(ode_order=ode_order)
 
-        self.linearise = linearise_fun
-        self.string_repr = string_repr
+def correction_slr0(cubature_fun=cubature_third_order_spherical) -> _Correction:
+    """Zeroth-order statistical linear regression."""
+    linearise_fun = impl.linearise.ode_statistical_1st(cubature_fun)
+    return _correction_constraint_ode_statistical(
+        ode_order=1,
+        linearise_fun=linearise_fun,
+        string_repr=f"<SLR1 with ode_order={1}>",
+    )
 
-    def __repr__(self):
-        return self.string_repr
 
-    def init(self, ssv, /):
+def correction_slr1(cubature_fun=cubature_third_order_spherical) -> _Correction:
+    """First-order statistical linear regression."""
+    linearise_fun = impl.linearise.ode_statistical_0th(cubature_fun)
+    return _correction_constraint_ode_statistical(
+        ode_order=1,
+        linearise_fun=linearise_fun,
+        string_repr=f"<SLR0 with ode_order={1}>",
+    )
+
+
+def _correction_constraint_ode_statistical(
+    ode_order, linearise_fun, string_repr
+) -> _Correction:
+    def init(ssv, /):
         obs_like = impl.prototypes.observed()
         return ssv, obs_like
 
-    def estimate_error(self, hidden_state, _corr, /, vector_field, t):
+    def estimate_error(hidden_state, _corr, /, vector_field, t):
         f_wrapped = functools.partial(vector_field, t=t)
-        A, b = self.linearise(f_wrapped, hidden_state)
+        A, b = linearise_fun(f_wrapped, hidden_state)
         observed = impl.conditional.marginalise(hidden_state, (A, b))
 
         error_estimate = _estimate_error(observed)
         return error_estimate, observed, (A, b, f_wrapped)
 
-    def complete(self, hidden_state, corr, /):
+    def complete(hidden_state, corr, /):
         # Re-linearise (because the linearisation point changed)
         *_, f_wrapped = corr
-        A, b = self.linearise(f_wrapped, hidden_state)
+        A, b = linearise_fun(f_wrapped, hidden_state)
 
         # Condition
         observed, (_gain, corrected) = impl.conditional.revert(hidden_state, (A, b))
         return corrected, observed
 
-    def extract(self, hidden_state, _corr, /):
+    def extract(hidden_state, _corr, /):
         return hidden_state
+
+    return _Correction(
+        ode_order=ode_order,
+        name=string_repr,
+        init=init,
+        estimate_error=estimate_error,
+        complete=complete,
+        extract=extract,
+    )
 
 
 def _estimate_error(observed, /):
@@ -764,48 +799,6 @@ def _estimate_error(observed, /):
     output_scale = impl.stats.mahalanobis_norm_relative(zero_data, rv=observed)
     error_estimate_unscaled = np.squeeze(impl.stats.standard_deviation(observed))
     return output_scale * error_estimate_unscaled
-
-
-def correction_ts0(*, ode_order=1) -> _ODEConstraintTaylor:
-    """Zeroth-order Taylor linearisation."""
-    return _ODEConstraintTaylor(
-        ode_order=ode_order,
-        linearise_fun=impl.linearise.ode_taylor_0th(ode_order=ode_order),
-        string_repr=f"<TS0 with ode_order={ode_order}>",
-    )
-
-
-def correction_ts1(*, ode_order=1) -> _ODEConstraintTaylor:
-    """First-order Taylor linearisation."""
-    return _ODEConstraintTaylor(
-        ode_order=ode_order,
-        linearise_fun=impl.linearise.ode_taylor_1st(ode_order=ode_order),
-        string_repr=f"<TS1 with ode_order={ode_order}>",
-    )
-
-
-def correction_slr0(
-    cubature_fun=cubature_third_order_spherical,
-) -> _ODEConstraintStatistical:
-    """Zeroth-order statistical linear regression."""
-    linearise_fun = impl.linearise.ode_statistical_1st(cubature_fun)
-    return _ODEConstraintStatistical(
-        ode_order=1,
-        linearise_fun=linearise_fun,
-        string_repr=f"<SLR1 with ode_order={1}>",
-    )
-
-
-def correction_slr1(
-    cubature_fun=cubature_third_order_spherical,
-) -> _ODEConstraintStatistical:
-    """First-order statistical linear regression."""
-    linearise_fun = impl.linearise.ode_statistical_0th(cubature_fun)
-    return _ODEConstraintStatistical(
-        ode_order=1,
-        linearise_fun=linearise_fun,
-        string_repr=f"<SLR0 with ode_order={1}>",
-    )
 
 
 _T = TypeVar("_T")

--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -801,12 +801,8 @@ def _estimate_error(observed, /):
     return output_scale * error_estimate_unscaled
 
 
-_T = TypeVar("_T")
-"""A type-variable for state-types."""
-
-
 @containers.dataclass
-class _IVPSolver(Generic[_T]):
+class _IVPSolver:
     """IVP solver."""
 
     strategy: _Strategy

--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -3,7 +3,7 @@
 from probdiffeq import stats
 from probdiffeq.backend import abc, containers, functools, special, tree_util
 from probdiffeq.backend import numpy as np
-from probdiffeq.backend.typing import Any, Array, Generic, TypeVar
+from probdiffeq.backend.typing import Any, Array, Callable, Generic, TypeVar
 from probdiffeq.impl import impl
 
 T = TypeVar("T")
@@ -41,43 +41,306 @@ class _InterpRes(Generic[R]):
     """
 
 
-class _ExtrapolationImpl(abc.ABC, Generic[T, R, S]):
+@containers.dataclass
+class _ExtrapolationImpl(Generic[T, R, S]):
     """Extrapolation model interface."""
 
-    @abc.abstractmethod
-    def initial_condition(self, tcoeffs, /) -> T:
-        """Compute an initial condition from a set of Taylor coefficients."""
-        raise NotImplementedError
+    num_derivatives: int
+    """The number of derivatives in the state-space model."""
 
-    @abc.abstractmethod
-    def init(self, solution: T, /) -> tuple[R, S]:
-        """Initialise a state from a solution."""
-        raise NotImplementedError
+    initial_condition: Callable
+    """Compute an initial condition from a set of Taylor coefficients."""
 
-    @abc.abstractmethod
-    def begin(self, state: R, aux: S, /, dt) -> tuple[R, S]:
-        """Begin the extrapolation."""
-        raise NotImplementedError
+    init: Callable
+    """Initialise a state from a solution."""
 
-    @abc.abstractmethod
-    def complete(self, state: R, aux: S, /, output_scale) -> tuple[R, S]:
-        """Complete the extrapolation."""
-        raise NotImplementedError
+    begin: Callable
+    """Begin the extrapolation."""
 
-    @abc.abstractmethod
-    def extract(self, state: R, aux: S, /) -> T:
-        """Extract a solution from a state."""
-        raise NotImplementedError
+    complete: Callable
+    """Complete the extrapolation."""
 
-    @abc.abstractmethod
-    def interpolate(self, state_t0, marginal_t1, *, dt0, dt1, output_scale):
-        """Interpolate."""
-        raise NotImplementedError
+    extract: Callable
+    """Extract a solution from a state."""
 
-    @abc.abstractmethod
-    def interpolate_at_t1(self, state: R, aux: S, /) -> _InterpRes:
-        """Process the state at checkpoint t=t_n."""
-        raise NotImplementedError
+    interpolate: Callable
+    """Interpolate."""
+
+    interpolate_at_t1: Callable
+    """Process the state at checkpoint t=t_n."""
+
+
+def _extrapolation_impl_precon_smoother(
+    discretise, num_derivatives
+) -> _ExtrapolationImpl:
+    def initial_condition(tcoeffs, /):
+        rv = impl.normal.from_tcoeffs(tcoeffs, num_derivatives)
+        cond = impl.conditional.identity(len(tcoeffs))
+        return stats.MarkovSeq(init=rv, conditional=cond)
+
+    def init(sol: stats.MarkovSeq, /):
+        return sol.init, sol.conditional
+
+    def begin(rv, _extra, /, dt):
+        cond, (p, p_inv) = discretise(dt)
+
+        rv_p = impl.normal.preconditioner_apply(rv, p_inv)
+
+        m_p = impl.stats.mean(rv_p)
+        extrapolated_p = impl.conditional.apply(m_p, cond)
+
+        extrapolated = impl.normal.preconditioner_apply(extrapolated_p, p)
+        cache = (cond, (p, p_inv), rv_p)
+        return extrapolated, cache
+
+    def complete(_ssv, extra, /, output_scale):
+        cond, (p, p_inv), rv_p = extra
+
+        # Extrapolate the Cholesky factor (re-extrapolate the mean for simplicity)
+        A, noise = cond
+        noise = impl.stats.rescale_cholesky(noise, output_scale)
+        extrapolated_p, cond_p = impl.conditional.revert(rv_p, (A, noise))
+        extrapolated = impl.normal.preconditioner_apply(extrapolated_p, p)
+        cond = impl.conditional.preconditioner_apply(cond_p, p, p_inv)
+
+        # Gather and return
+        return extrapolated, cond
+
+    def extract(hidden_state, extra, /):
+        return stats.MarkovSeq(init=hidden_state, conditional=extra)
+
+    def interpolate(state_t0, marginal_t1, *, dt0, dt1, output_scale):
+        """Interpolate.
+
+        A smoother interpolates by_
+        * Extrapolating from t0 to t, which gives the "filtering" marginal
+          and the backward transition from t to t0.
+        * Extrapolating from t to t1, which gives another "filtering" marginal
+          and the backward transition from t1 to t.
+        * Applying the new t1-to-t backward transition to compute the interpolation.
+          This intermediate result is informed about its "right-hand side" datum.
+
+        Subsequent interpolations continue from the value at 't'.
+        Subsequent IVP solver steps continue from the value at 't1'.
+        """
+        # Extrapolate from t0 to t, and from t to t1. This yields all building blocks.
+        extrapolated_t = _extrapolate(*state_t0, dt0, output_scale)
+        extrapolated_t1 = _extrapolate(*extrapolated_t, dt1, output_scale)
+
+        # Marginalise from t1 to t to obtain the interpolated solution.
+        conditional_t1_to_t = extrapolated_t1[1]
+        rv_at_t = impl.conditional.marginalise(marginal_t1, conditional_t1_to_t)
+        solution_at_t = (rv_at_t, extrapolated_t[1])
+
+        # The state at t1 gets a new backward model; it must remember how to
+        # get back to t, not to t0.
+        solution_at_t1 = (marginal_t1, conditional_t1_to_t)
+
+        return _InterpRes(
+            step_from=solution_at_t1,
+            interpolated=solution_at_t,
+            interp_from=solution_at_t,
+        )
+
+    def _extrapolate(state, extra, /, dt, output_scale):
+        begun = begin(state, extra, dt=dt)
+        return complete(*begun, output_scale=output_scale)
+
+    def interpolate_at_t1(rv, extra, /):
+        return _InterpRes((rv, extra), (rv, extra), (rv, extra))
+
+    return _ExtrapolationImpl(
+        num_derivatives=num_derivatives,
+        initial_condition=initial_condition,
+        init=init,
+        begin=begin,
+        complete=complete,
+        extract=extract,
+        interpolate=interpolate,
+        interpolate_at_t1=interpolate_at_t1,
+    )
+
+
+def _extrapolation_impl_precon_fixedpoint(
+    discretise, num_derivatives
+) -> _ExtrapolationImpl:
+    def initial_condition(tcoeffs, /):
+        rv = impl.normal.from_tcoeffs(tcoeffs, num_derivatives)
+        cond = impl.conditional.identity(len(tcoeffs))
+        return stats.MarkovSeq(init=rv, conditional=cond)
+
+    def init(sol: stats.MarkovSeq, /):
+        return sol.init, sol.conditional
+
+    def begin(rv, extra, /, dt):
+        cond, (p, p_inv) = discretise(dt)
+
+        rv_p = impl.normal.preconditioner_apply(rv, p_inv)
+
+        m_ext_p = impl.stats.mean(rv_p)
+        extrapolated_p = impl.conditional.apply(m_ext_p, cond)
+
+        extrapolated = impl.normal.preconditioner_apply(extrapolated_p, p)
+        cache = (cond, (p, p_inv), rv_p, extra)
+        return extrapolated, cache
+
+    def extract(hidden_state, extra, /):
+        return stats.MarkovSeq(init=hidden_state, conditional=extra)
+
+    def complete(_rv, extra, /, output_scale):
+        cond, (p, p_inv), rv_p, bw0 = extra
+
+        # Extrapolate the Cholesky factor (re-extrapolate the mean for simplicity)
+        A, noise = cond
+        noise = impl.stats.rescale_cholesky(noise, output_scale)
+        extrapolated_p, cond_p = impl.conditional.revert(rv_p, (A, noise))
+        extrapolated = impl.normal.preconditioner_apply(extrapolated_p, p)
+        cond = impl.conditional.preconditioner_apply(cond_p, p, p_inv)
+
+        # Merge conditionals
+        cond = impl.conditional.merge(bw0, cond)
+
+        # Gather and return
+        return extrapolated, cond
+
+    def interpolate(state_t0, marginal_t1, *, dt0, dt1, output_scale):
+        """Interpolate.
+
+        A fixed-point smoother interpolates by
+
+        * Extrapolating from t0 to t, which gives the "filtering" marginal
+          and the backward transition from t to t0.
+        * Extrapolating from t to t1, which gives another "filtering" marginal
+          and the backward transition from t1 to t.
+        * Applying the t1-to-t backward transition to compute the interpolation result.
+          This intermediate result is informed about its "right-hand side" datum.
+
+        The difference to smoother-interpolation is quite subtle:
+
+        * The backward transition of the solution at 't' is merged with that at 't0'.
+          The reason is that the backward transition at 't0' knows
+          "how to get to the quantity of interest",
+          and this is precisely what we want to interpolate.
+        * Subsequent interpolations do not continue from the value at 't', but
+          from a very similar value where the backward transition
+          is replaced with an identity. The reason is that the interpolated solution
+          becomes the new quantity of interest, and subsequent interpolations
+          need to learn how to get here.
+        * Subsequent solver steps do not continue from the value at 't1',
+          but the value at 't1' where the backward model is replaced by
+          the 't1-to-t' backward model. The reason is similar to the above:
+          future steps need to know "how to get back to the quantity of interest",
+          which is the interpolated solution.
+
+        These distinctions are precisely why we need three fields
+        in every interpolation result:
+            the solution,
+            the continue-interpolation-from-here,
+            and the continue-stepping-from-here.
+        All three are different for fixed point smoothers.
+        (Really, I try removing one of them monthly and
+        then don't understand why tests fail.)
+        """
+        # Extrapolate from t0 to t, and from t to t1. This yields all building blocks.
+        extrapolated_t = _extrapolate(*state_t0, dt0, output_scale)
+        conditional_id = impl.conditional.identity(num_derivatives + 1)
+        previous_new = (extrapolated_t[0], conditional_id)
+        extrapolated_t1 = _extrapolate(*previous_new, dt1, output_scale)
+
+        # Marginalise from t1 to t to obtain the interpolated solution.
+        conditional_t1_to_t = extrapolated_t1[1]
+        rv_at_t = impl.conditional.marginalise(marginal_t1, conditional_t1_to_t)
+
+        # Return the right combination of marginals and conditionals.
+        return _InterpRes(
+            step_from=(marginal_t1, conditional_t1_to_t),
+            interpolated=(rv_at_t, extrapolated_t[1]),
+            interp_from=previous_new,
+        )
+
+    def _extrapolate(state, extra, /, dt, output_scale):
+        begun = begin(state, extra, dt=dt)
+        return complete(*begun, output_scale=output_scale)
+
+    def interpolate_at_t1(rv, extra, /):
+        cond_identity = impl.conditional.identity(num_derivatives + 1)
+        return _InterpRes((rv, cond_identity), (rv, extra), (rv, cond_identity))
+
+    return _ExtrapolationImpl(
+        num_derivatives=num_derivatives,
+        init=init,
+        initial_condition=initial_condition,
+        begin=begin,
+        extract=extract,
+        complete=complete,
+        interpolate=interpolate,
+        interpolate_at_t1=interpolate_at_t1,
+    )
+
+
+def _extrapolation_impl_precon_filter(
+    discretise, num_derivatives
+) -> _ExtrapolationImpl:
+    def init(sol, /):
+        return sol, None
+
+    def initial_condition(tcoeffs, /):
+        return impl.normal.from_tcoeffs(tcoeffs, num_derivatives)
+
+    def begin(rv, _extra, /, dt):
+        cond, (p, p_inv) = discretise(dt)
+
+        rv_p = impl.normal.preconditioner_apply(rv, p_inv)
+
+        m_ext_p = impl.stats.mean(rv_p)
+        extrapolated_p = impl.conditional.apply(m_ext_p, cond)
+
+        extrapolated = impl.normal.preconditioner_apply(extrapolated_p, p)
+        cache = (cond, (p, p_inv), rv_p)
+        return extrapolated, cache
+
+    def extract(hidden_state, _extra, /):
+        return hidden_state
+
+    def complete(_ssv, extra, /, output_scale):
+        cond, (p, p_inv), rv_p = extra
+
+        # Extrapolate the Cholesky factor (re-extrapolate the mean for simplicity)
+        A, noise = cond
+        noise = impl.stats.rescale_cholesky(noise, output_scale)
+        extrapolated_p = impl.conditional.marginalise(rv_p, (A, noise))
+        extrapolated = impl.normal.preconditioner_apply(extrapolated_p, p)
+
+        # Gather and return
+        return extrapolated, None
+
+    def interpolate(state_t0, marginal_t1, dt0, dt1, output_scale):
+        # todo: by ditching marginal_t1 and dt1, this function _extrapolates
+        #  (no *inter*polation happening)
+        del dt1
+
+        hidden, extra = state_t0
+        hidden, extra = begin(hidden, extra, dt=dt0)
+        hidden, extra = complete(hidden, extra, output_scale=output_scale)
+
+        # Consistent state-types in interpolation result.
+        interp = (hidden, extra)
+        step_from = (marginal_t1, None)
+        return _InterpRes(step_from=step_from, interpolated=interp, interp_from=interp)
+
+    def interpolate_at_t1(rv, extra, /):
+        return _InterpRes((rv, extra), (rv, extra), (rv, extra))
+
+    return _ExtrapolationImpl(
+        num_derivatives=num_derivatives,
+        init=init,
+        initial_condition=initial_condition,
+        begin=begin,
+        extract=extract,
+        complete=complete,
+        interpolate=interpolate,
+        interpolate_at_t1=interpolate_at_t1,
+    )
 
 
 class _StrategyState(containers.NamedTuple):
@@ -246,7 +509,7 @@ tree_util.register_pytree_node(_Strategy, _tree_flatten, _tree_unflatten)
 
 def strategy_smoother(prior, correction, /) -> _Strategy:
     """Construct a smoother."""
-    extrapolation_impl = _PreconSmoother(*prior)
+    extrapolation_impl = _extrapolation_impl_precon_smoother(*prior)
     return _Strategy(
         extrapolation_impl,
         correction,
@@ -257,91 +520,9 @@ def strategy_smoother(prior, correction, /) -> _Strategy:
     )
 
 
-class _PreconSmoother(_ExtrapolationImpl):
-    def __init__(self, discretise, num_derivatives):
-        self.discretise = discretise
-        self.num_derivatives = num_derivatives
-
-    def initial_condition(self, tcoeffs, /):
-        rv = impl.normal.from_tcoeffs(tcoeffs, self.num_derivatives)
-        cond = impl.conditional.identity(len(tcoeffs))
-        return stats.MarkovSeq(init=rv, conditional=cond)
-
-    def init(self, sol: stats.MarkovSeq, /):
-        return sol.init, sol.conditional
-
-    def extract(self, hidden_state, extra, /):
-        return stats.MarkovSeq(init=hidden_state, conditional=extra)
-
-    def begin(self, rv, _extra, /, dt):
-        cond, (p, p_inv) = self.discretise(dt)
-
-        rv_p = impl.normal.preconditioner_apply(rv, p_inv)
-
-        m_p = impl.stats.mean(rv_p)
-        extrapolated_p = impl.conditional.apply(m_p, cond)
-
-        extrapolated = impl.normal.preconditioner_apply(extrapolated_p, p)
-        cache = (cond, (p, p_inv), rv_p)
-        return extrapolated, cache
-
-    def complete(self, _ssv, extra, /, output_scale):
-        cond, (p, p_inv), rv_p = extra
-
-        # Extrapolate the Cholesky factor (re-extrapolate the mean for simplicity)
-        A, noise = cond
-        noise = impl.stats.rescale_cholesky(noise, output_scale)
-        extrapolated_p, cond_p = impl.conditional.revert(rv_p, (A, noise))
-        extrapolated = impl.normal.preconditioner_apply(extrapolated_p, p)
-        cond = impl.conditional.preconditioner_apply(cond_p, p, p_inv)
-
-        # Gather and return
-        return extrapolated, cond
-
-    def interpolate(self, state_t0, marginal_t1, *, dt0, dt1, output_scale):
-        """Interpolate.
-
-        A smoother interpolates by_
-        * Extrapolating from t0 to t, which gives the "filtering" marginal
-          and the backward transition from t to t0.
-        * Extrapolating from t to t1, which gives another "filtering" marginal
-          and the backward transition from t1 to t.
-        * Applying the new t1-to-t backward transition to compute the interpolation.
-          This intermediate result is informed about its "right-hand side" datum.
-
-        Subsequent interpolations continue from the value at 't'.
-        Subsequent IVP solver steps continue from the value at 't1'.
-        """
-        # Extrapolate from t0 to t, and from t to t1. This yields all building blocks.
-        extrapolated_t = self._extrapolate(*state_t0, dt0, output_scale)
-        extrapolated_t1 = self._extrapolate(*extrapolated_t, dt1, output_scale)
-
-        # Marginalise from t1 to t to obtain the interpolated solution.
-        conditional_t1_to_t = extrapolated_t1[1]
-        rv_at_t = impl.conditional.marginalise(marginal_t1, conditional_t1_to_t)
-        solution_at_t = (rv_at_t, extrapolated_t[1])
-
-        # The state at t1 gets a new backward model; it must remember how to
-        # get back to t, not to t0.
-        solution_at_t1 = (marginal_t1, conditional_t1_to_t)
-
-        return _InterpRes(
-            step_from=solution_at_t1,
-            interpolated=solution_at_t,
-            interp_from=solution_at_t,
-        )
-
-    def _extrapolate(self, state, extra, /, dt, output_scale):
-        begun = self.begin(state, extra, dt=dt)
-        return self.complete(*begun, output_scale=output_scale)
-
-    def interpolate_at_t1(self, rv, extra, /):
-        return _InterpRes((rv, extra), (rv, extra), (rv, extra))
-
-
 def strategy_fixedpoint(prior, correction, /) -> _Strategy:
     """Construct a fixedpoint-smoother."""
-    extrapolation_impl = _PreconFixedPoint(*prior)
+    extrapolation_impl = _extrapolation_impl_precon_fixedpoint(*prior)
     return _Strategy(
         extrapolation_impl,
         correction,
@@ -352,118 +533,9 @@ def strategy_fixedpoint(prior, correction, /) -> _Strategy:
     )
 
 
-class _PreconFixedPoint(_ExtrapolationImpl):
-    def __init__(self, discretise, num_derivatives):
-        self.discretise = discretise
-        self.num_derivatives = num_derivatives
-
-    def initial_condition(self, tcoeffs, /):
-        rv = impl.normal.from_tcoeffs(tcoeffs, self.num_derivatives)
-        cond = impl.conditional.identity(len(tcoeffs))
-        return stats.MarkovSeq(init=rv, conditional=cond)
-
-    def init(self, sol: stats.MarkovSeq, /):
-        return sol.init, sol.conditional
-
-    def extract(self, hidden_state, extra, /):
-        return stats.MarkovSeq(init=hidden_state, conditional=extra)
-
-    def begin(self, rv, extra, /, dt):
-        cond, (p, p_inv) = self.discretise(dt)
-
-        rv_p = impl.normal.preconditioner_apply(rv, p_inv)
-
-        m_ext_p = impl.stats.mean(rv_p)
-        extrapolated_p = impl.conditional.apply(m_ext_p, cond)
-
-        extrapolated = impl.normal.preconditioner_apply(extrapolated_p, p)
-        cache = (cond, (p, p_inv), rv_p, extra)
-        return extrapolated, cache
-
-    def complete(self, _rv, extra, /, output_scale):
-        cond, (p, p_inv), rv_p, bw0 = extra
-
-        # Extrapolate the Cholesky factor (re-extrapolate the mean for simplicity)
-        A, noise = cond
-        noise = impl.stats.rescale_cholesky(noise, output_scale)
-        extrapolated_p, cond_p = impl.conditional.revert(rv_p, (A, noise))
-        extrapolated = impl.normal.preconditioner_apply(extrapolated_p, p)
-        cond = impl.conditional.preconditioner_apply(cond_p, p, p_inv)
-
-        # Merge conditionals
-        cond = impl.conditional.merge(bw0, cond)
-
-        # Gather and return
-        return extrapolated, cond
-
-    def interpolate(self, state_t0, marginal_t1, *, dt0, dt1, output_scale):
-        """Interpolate.
-
-        A fixed-point smoother interpolates by
-
-        * Extrapolating from t0 to t, which gives the "filtering" marginal
-          and the backward transition from t to t0.
-        * Extrapolating from t to t1, which gives another "filtering" marginal
-          and the backward transition from t1 to t.
-        * Applying the t1-to-t backward transition to compute the interpolation result.
-          This intermediate result is informed about its "right-hand side" datum.
-
-        The difference to smoother-interpolation is quite subtle:
-
-        * The backward transition of the solution at 't' is merged with that at 't0'.
-          The reason is that the backward transition at 't0' knows
-          "how to get to the quantity of interest",
-          and this is precisely what we want to interpolate.
-        * Subsequent interpolations do not continue from the value at 't', but
-          from a very similar value where the backward transition
-          is replaced with an identity. The reason is that the interpolated solution
-          becomes the new quantity of interest, and subsequent interpolations
-          need to learn how to get here.
-        * Subsequent solver steps do not continue from the value at 't1',
-          but the value at 't1' where the backward model is replaced by
-          the 't1-to-t' backward model. The reason is similar to the above:
-          future steps need to know "how to get back to the quantity of interest",
-          which is the interpolated solution.
-
-        These distinctions are precisely why we need three fields
-        in every interpolation result:
-            the solution,
-            the continue-interpolation-from-here,
-            and the continue-stepping-from-here.
-        All three are different for fixed point smoothers.
-        (Really, I try removing one of them monthly and
-        then don't understand why tests fail.)
-        """
-        # Extrapolate from t0 to t, and from t to t1. This yields all building blocks.
-        extrapolated_t = self._extrapolate(*state_t0, dt0, output_scale)
-        conditional_id = impl.conditional.identity(self.num_derivatives + 1)
-        previous_new = (extrapolated_t[0], conditional_id)
-        extrapolated_t1 = self._extrapolate(*previous_new, dt1, output_scale)
-
-        # Marginalise from t1 to t to obtain the interpolated solution.
-        conditional_t1_to_t = extrapolated_t1[1]
-        rv_at_t = impl.conditional.marginalise(marginal_t1, conditional_t1_to_t)
-
-        # Return the right combination of marginals and conditionals.
-        return _InterpRes(
-            step_from=(marginal_t1, conditional_t1_to_t),
-            interpolated=(rv_at_t, extrapolated_t[1]),
-            interp_from=previous_new,
-        )
-
-    def _extrapolate(self, state, extra, /, dt, output_scale):
-        begun = self.begin(state, extra, dt=dt)
-        return self.complete(*begun, output_scale=output_scale)
-
-    # todo: rename to prepare_future_steps?
-    def interpolate_at_t1(self, rv, extra, /):
-        cond_identity = impl.conditional.identity(self.num_derivatives + 1)
-        return _InterpRes((rv, cond_identity), (rv, extra), (rv, cond_identity))
-
-
 def strategy_filter(prior, correction, /) -> _Strategy:
     """Construct a filter."""
-    extrapolation_impl = _PreconFilter(*prior)
+    extrapolation_impl = _extrapolation_impl_precon_filter(*prior)
     return _Strategy(
         extrapolation_impl,
         correction,
@@ -472,64 +544,6 @@ def strategy_filter(prior, correction, /) -> _Strategy:
         is_suitable_for_offgrid_marginals=True,
         is_suitable_for_save_every_step=True,
     )
-
-
-class _PreconFilter(_ExtrapolationImpl):
-    def __init__(self, discretise, num_derivatives):
-        # todo: move sol_from_tcoeffs out of this module
-        #  (and then we can ditch self.num_derivatives)
-        self.discretise = discretise
-        self.num_derivatives = num_derivatives
-
-    def initial_condition(self, tcoeffs, /):
-        return impl.normal.from_tcoeffs(tcoeffs, self.num_derivatives)
-
-    def init(self, sol, /):
-        return sol, None
-
-    def extract(self, hidden_state, _extra, /):
-        return hidden_state
-
-    def begin(self, rv, _extra, /, dt):
-        cond, (p, p_inv) = self.discretise(dt)
-
-        rv_p = impl.normal.preconditioner_apply(rv, p_inv)
-
-        m_ext_p = impl.stats.mean(rv_p)
-        extrapolated_p = impl.conditional.apply(m_ext_p, cond)
-
-        extrapolated = impl.normal.preconditioner_apply(extrapolated_p, p)
-        cache = (cond, (p, p_inv), rv_p)
-        return extrapolated, cache
-
-    def complete(self, _ssv, extra, /, output_scale):
-        cond, (p, p_inv), rv_p = extra
-
-        # Extrapolate the Cholesky factor (re-extrapolate the mean for simplicity)
-        A, noise = cond
-        noise = impl.stats.rescale_cholesky(noise, output_scale)
-        extrapolated_p = impl.conditional.marginalise(rv_p, (A, noise))
-        extrapolated = impl.normal.preconditioner_apply(extrapolated_p, p)
-
-        # Gather and return
-        return extrapolated, None
-
-    def interpolate(self, state_t0, marginal_t1, dt0, dt1, output_scale):
-        # todo: by ditching marginal_t1 and dt1, this function _extrapolates
-        #  (no *inter*polation happening)
-        del dt1
-
-        hidden, extra = state_t0
-        hidden, extra = self.begin(hidden, extra, dt=dt0)
-        hidden, extra = self.complete(hidden, extra, output_scale=output_scale)
-
-        # Consistent state-types in interpolation result.
-        interp = (hidden, extra)
-        step_from = (marginal_t1, None)
-        return _InterpRes(step_from=step_from, interpolated=interp, interp_from=interp)
-
-    def interpolate_at_t1(self, rv, extra, /):
-        return _InterpRes((rv, extra), (rv, extra), (rv, extra))
 
 
 class _PositiveCubatureRule(containers.NamedTuple):

--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -42,7 +42,7 @@ class _InterpRes(Generic[R]):
 
 
 @containers.dataclass
-class _ExtrapolationImpl(Generic[T, R, S]):
+class _ExtraImpl(Generic[T, R, S]):
     """Extrapolation model interface."""
 
     num_derivatives: int
@@ -70,9 +70,7 @@ class _ExtrapolationImpl(Generic[T, R, S]):
     """Process the state at checkpoint t=t_n."""
 
 
-def _extrapolation_impl_precon_smoother(
-    discretise, num_derivatives
-) -> _ExtrapolationImpl:
+def _extrapolation_impl_precon_smoother(discretise, num_derivatives) -> _ExtraImpl:
     def initial_condition(tcoeffs, /):
         rv = impl.normal.from_tcoeffs(tcoeffs, num_derivatives)
         cond = impl.conditional.identity(len(tcoeffs))
@@ -149,7 +147,7 @@ def _extrapolation_impl_precon_smoother(
     def interpolate_at_t1(rv, extra, /):
         return _InterpRes((rv, extra), (rv, extra), (rv, extra))
 
-    return _ExtrapolationImpl(
+    return _ExtraImpl(
         num_derivatives=num_derivatives,
         initial_condition=initial_condition,
         init=init,
@@ -161,9 +159,7 @@ def _extrapolation_impl_precon_smoother(
     )
 
 
-def _extrapolation_impl_precon_fixedpoint(
-    discretise, num_derivatives
-) -> _ExtrapolationImpl:
+def _extrapolation_impl_precon_fixedpoint(discretise, num_derivatives) -> _ExtraImpl:
     def initial_condition(tcoeffs, /):
         rv = impl.normal.from_tcoeffs(tcoeffs, num_derivatives)
         cond = impl.conditional.identity(len(tcoeffs))
@@ -266,7 +262,7 @@ def _extrapolation_impl_precon_fixedpoint(
         cond_identity = impl.conditional.identity(num_derivatives + 1)
         return _InterpRes((rv, cond_identity), (rv, extra), (rv, cond_identity))
 
-    return _ExtrapolationImpl(
+    return _ExtraImpl(
         num_derivatives=num_derivatives,
         init=init,
         initial_condition=initial_condition,
@@ -278,9 +274,7 @@ def _extrapolation_impl_precon_fixedpoint(
     )
 
 
-def _extrapolation_impl_precon_filter(
-    discretise, num_derivatives
-) -> _ExtrapolationImpl:
+def _extrapolation_impl_precon_filter(discretise, num_derivatives) -> _ExtraImpl:
     def init(sol, /):
         return sol, None
 
@@ -331,7 +325,7 @@ def _extrapolation_impl_precon_filter(
     def interpolate_at_t1(rv, extra, /):
         return _InterpRes((rv, extra), (rv, extra), (rv, extra))
 
-    return _ExtrapolationImpl(
+    return _ExtraImpl(
         num_derivatives=num_derivatives,
         init=init,
         initial_condition=initial_condition,
@@ -355,7 +349,7 @@ class _Strategy:
 
     def __init__(
         self,
-        extrapolation: _ExtrapolationImpl,
+        extrapolation: _ExtraImpl,
         correction,
         *,
         string_repr,


### PR DESCRIPTION
Why? The current code is a wil mix of object-oriented (corrections), functional (cubature rules), and half/half (solvers). This mix of styles is problematic because it prevents restructuring of the functionality. However, this restructuring will eventually be needed.  For example, there is massive code-duplication between solvers, strategies, and extrapolation-implementations. But this is a future discussion.

What?
The ABC's become dataclasses, and all implementations of these ABC's become constructor functions.

How?
All docstrings remain. All user-facing code remains. All functionality remains. 

Other changes included:
- IVP solvers are not registered as pytrees anymore, because they only combine integers, strings, and callables.