### PR TITLE
Make clip/no-clip an argument to the controllers to reduce code duplication

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,17 +3,17 @@ default_language_version:
   python: python3
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: end-of-file-fixer
       - id: check-merge-conflict
   - repo: https://github.com/lyz-code/yamlfix/
-    rev: 1.16.0
+    rev: 1.17.0
     hooks:
       - id: yamlfix
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.5.7
+    rev: v0.6.9
     hooks:
       # Run the linter.
       - id: ruff
@@ -21,7 +21,7 @@ repos:
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.1
+    rev: v1.11.2
     hooks:
       - id: mypy
         args: [--ignore-missing-imports]

--- a/docs/benchmarks/hires/run_hires.py
+++ b/docs/benchmarks/hires/run_hires.py
@@ -94,7 +94,7 @@ def solver_probdiffeq(*, num_derivatives: int) -> Callable:
         ts1 = ivpsolvers.correction_ts1()
         strategy = ivpsolvers.strategy_filter(ibm, ts1)
         solver = ivpsolvers.solver_dynamic(strategy)
-        control = ivpsolve.control_proportional_integral_clipped()
+        control = ivpsolve.control_proportional_integral(clip=True)
         adaptive_solver = ivpsolve.adaptive(
             solver, atol=1e-2 * tol, rtol=tol, control=control
         )

--- a/docs/benchmarks/vanderpol/run_vanderpol.py
+++ b/docs/benchmarks/vanderpol/run_vanderpol.py
@@ -85,7 +85,7 @@ def solver_probdiffeq(*, num_derivatives: int) -> Callable:
         ts0_or_ts1 = ivpsolvers.correction_ts1(ode_order=2)
         strategy = ivpsolvers.strategy_filter(ibm, ts0_or_ts1)
         solver = ivpsolvers.solver_dynamic(strategy)
-        control = ivpsolve.control_proportional_integral_clipped()
+        control = ivpsolve.control_proportional_integral(clip=True)
         adaptive_solver = ivpsolve.adaptive(
             solver, atol=1e-3 * tol, rtol=tol, control=control
         )

--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -816,7 +816,7 @@ def _calibration_none() -> _Calibration:
     def init(prior):
         return prior
 
-    def update(_state, /, observed):  # noqa: ARG001
+    def update(_state, /, observed):
         raise NotImplementedError
 
     def extract(state, /):

--- a/tests/test_ivpsolve/test_fixed_grid_vs_save_every_step.py
+++ b/tests/test_ivpsolve/test_fixed_grid_vs_save_every_step.py
@@ -13,7 +13,7 @@ def test_fixed_grid_result_matches_adaptive_grid_result(ssm):
     ts0 = ivpsolvers.correction_ts0()
     strategy = ivpsolvers.strategy_filter(ibm, ts0)
     solver = ivpsolvers.solver_mle(strategy)
-    control = ivpsolve.control_integral_clipped()  # Any clipped controller will do.
+    control = ivpsolve.control_integral(clip=True)  # Any clipped controller will do.
     adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, control=control)
 
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), u0, num=2)

--- a/tests/test_ivpsolve/test_save_every_step.py
+++ b/tests/test_ivpsolve/test_save_every_step.py
@@ -14,7 +14,8 @@ def fixture_python_loop_solution(ssm):
     ts0 = ivpsolvers.correction_ts0()
     strategy = ivpsolvers.strategy_filter(ibm, ts0)
     solver = ivpsolvers.solver_mle(strategy)
-    adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2)
+    control = ivpsolve.control_proportional_integral(clip=True)
+    adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, control=control)
 
     dt0 = ivpsolve.dt0_adaptive(
         vf, u0, t0=t0, atol=1e-2, rtol=1e-2, error_contraction_rate=5


### PR DESCRIPTION
And add a test that covers `control_proportional_integral(clip=True)`


Note: this is not backwards-compatible because control_*_clipped() does not exist anymore.