### PR TITLE
Internal: Move error-scaling (by the error contraction rate) outside of the controller implementations

### DIFF
--- a/probdiffeq/backend/typing.py
+++ b/probdiffeq/backend/typing.py
@@ -4,7 +4,10 @@ from collections.abc import Sequence  # noqa: F401
 from typing import Any, Callable, Generic, Optional, TypeVar  # noqa: F401
 
 import jax
-from typing_extensions import TypeAlias  # typing.TypeAlias requires 3.10+
+from mypy_extensions import NamedArg  # noqa: F401
+
+# typing.TypeAlias requires 3.10+
+from typing_extensions import TypeAlias
 
 # Array
 Array: TypeAlias = jax.Array

--- a/probdiffeq/ivpsolve.py
+++ b/probdiffeq/ivpsolve.py
@@ -11,7 +11,7 @@ from probdiffeq.backend import (
     warnings,
 )
 from probdiffeq.backend import numpy as np
-from probdiffeq.backend.typing import Any, Callable
+from probdiffeq.backend.typing import Any, Callable, NamedArg
 
 
 @containers.dataclass
@@ -24,7 +24,10 @@ class _Controller:
     clip: Callable[[Any, float, float], Any]
     """(Optionally) clip the current step to not exceed t1."""
 
-    apply: Callable[[Any, float, float], Any]
+    apply: Callable[
+        [Any, NamedArg(float, "error_norm"), NamedArg(float, "error_contraction_rate")],
+        Any,
+    ]
     r"""Propose a time-step $\Delta t$."""
 
     extract: Callable[[Any], float]
@@ -49,7 +52,7 @@ def control_proportional_integral(
     def init(dt: float, /) -> PIState:
         return PIState(dt, 1.0)
 
-    def apply(state: PIState, /, error_norm, error_contraction_rate) -> PIState:
+    def apply(state: PIState, /, *, error_norm, error_contraction_rate) -> PIState:
         dt_proposed, error_norm_prev = state
 
         # Construct the proportional-integral scale
@@ -92,7 +95,7 @@ def control_integral(
     def init(dt, /):
         return dt
 
-    def apply(dt, /, error_norm, error_contraction_rate):
+    def apply(dt, /, *, error_norm, error_contraction_rate):
         error_power = error_norm ** (-1.0 / error_contraction_rate)
         scale_factor_unclipped = safety * error_power
 

--- a/probdiffeq/ivpsolve.py
+++ b/probdiffeq/ivpsolve.py
@@ -55,18 +55,16 @@ def control_proportional_integral(
     def apply(state: PIState, /, *, error_norm, error_contraction_rate) -> PIState:
         dt_proposed, error_norm_prev = state
 
-        # Construct the proportional-integral scale
-        error_power = error_norm ** (1.0 / error_contraction_rate)
-        a1 = (1.0 / error_power) ** power_integral_unscaled
-        a2 = (error_norm_prev / error_power) ** power_proportional_unscaled
+        x = error_norm ** (-1 / error_contraction_rate)
+        x_prev = error_norm_prev ** (-1.0 / error_contraction_rate)
+        a1 = x**power_integral_unscaled
+        a2 = (x / x_prev) ** power_proportional_unscaled
         scale_factor_unclipped = safety * a1 * a2
 
-        # Clip to limit maximal changes
         scale_factor_clipped_min = np.minimum(scale_factor_unclipped, factor_max)
         scale_factor = np.maximum(factor_min, scale_factor_clipped_min)
         error_norm_prev = np.where(error_norm <= 1.0, error_norm, error_norm_prev)
 
-        # Apply the control
         dt_proposed = scale_factor * dt_proposed
         return PIState(dt_proposed, error_norm_prev)
 

--- a/probdiffeq/ivpsolve.py
+++ b/probdiffeq/ivpsolve.py
@@ -51,17 +51,19 @@ def control_proportional_integral(
 
     def apply(state: PIState, /, error_norm, error_contraction_rate) -> PIState:
         dt_proposed, error_norm_prev = state
-        n1 = power_integral_unscaled / error_contraction_rate
-        n2 = power_proportional_unscaled / error_contraction_rate
 
-        a1 = (1.0 / error_norm) ** n1
-        a2 = (error_norm_prev / error_norm) ** n2
+        # Construct the proportional-integral scale
+        error_power = error_norm ** (1.0 / error_contraction_rate)
+        a1 = (1.0 / error_power) ** power_integral_unscaled
+        a2 = (error_norm_prev / error_power) ** power_proportional_unscaled
         scale_factor_unclipped = safety * a1 * a2
 
+        # Clip to limit maximal changes
         scale_factor_clipped_min = np.minimum(scale_factor_unclipped, factor_max)
         scale_factor = np.maximum(factor_min, scale_factor_clipped_min)
         error_norm_prev = np.where(error_norm <= 1.0, error_norm, error_norm_prev)
 
+        # Apply the control
         dt_proposed = scale_factor * dt_proposed
         return PIState(dt_proposed, error_norm_prev)
 

--- a/probdiffeq/ivpsolve.py
+++ b/probdiffeq/ivpsolve.py
@@ -55,15 +55,14 @@ def control_proportional_integral(
     def apply(state: PIState, /, *, error_norm, error_contraction_rate) -> PIState:
         dt_proposed, error_norm_prev = state
 
-        x = error_norm ** (-1 / error_contraction_rate)
-        x_prev = error_norm_prev ** (-1.0 / error_contraction_rate)
+        x = error_norm ** (-1.0 / error_contraction_rate)
         a1 = x**power_integral_unscaled
-        a2 = (x / x_prev) ** power_proportional_unscaled
+        a2 = (x / error_norm_prev) ** power_proportional_unscaled
         scale_factor_unclipped = safety * a1 * a2
 
         scale_factor_clipped_min = np.minimum(scale_factor_unclipped, factor_max)
         scale_factor = np.maximum(factor_min, scale_factor_clipped_min)
-        error_norm_prev = np.where(error_norm <= 1.0, error_norm, error_norm_prev)
+        error_norm_prev = np.where(x >= 1.0, x, error_norm_prev)
 
         dt_proposed = scale_factor * dt_proposed
         return PIState(dt_proposed, error_norm_prev)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ doc = [
     "mkdocstrings-python",
     "mkdocstrings",
     "mkdocs-jupyter",
+    "mypy_extensions",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ test =[
     "diffeqzoo",
     "diffrax",
     "equinox",
+    "mypy_extensions",
 ]
 format-and-lint =[
     "pre-commit",

--- a/tests/test_ivpsolve/test_controllers.py
+++ b/tests/test_ivpsolve/test_controllers.py
@@ -1,0 +1,20 @@
+"""Test the controllers."""
+
+from probdiffeq import ivpsolve
+from probdiffeq.backend import numpy as np
+
+
+def test_equivalence_pi_vs_i(dt=0.1428, norm=3.142, rate=3):
+    ctrl_pi = ivpsolve.control_proportional_integral(
+        power_integral_unscaled=1.0, power_proportional_unscaled=0.0
+    )
+    ctrl_i = ivpsolve.control_integral()
+
+    x_pi = ctrl_pi.init(dt)
+    x_pi = ctrl_pi.apply(x_pi, norm, rate)
+    x_pi = ctrl_pi.extract(x_pi)
+
+    x_i = ctrl_i.init(dt)
+    x_i = ctrl_i.apply(x_i, norm, rate)
+    x_i = ctrl_i.extract(x_i)
+    assert np.allclose(x_i, x_pi)

--- a/tests/test_ivpsolve/test_controllers.py
+++ b/tests/test_ivpsolve/test_controllers.py
@@ -4,17 +4,19 @@ from probdiffeq import ivpsolve
 from probdiffeq.backend import numpy as np
 
 
-def test_equivalence_pi_vs_i(dt=0.1428, norm=3.142, rate=3):
+def test_equivalence_pi_vs_i(dt=0.1428, norm=3.142, rate=3, num_applies=4):
     ctrl_pi = ivpsolve.control_proportional_integral(
         power_integral_unscaled=1.0, power_proportional_unscaled=0.0
     )
     ctrl_i = ivpsolve.control_integral()
 
     x_pi = ctrl_pi.init(dt)
-    x_pi = ctrl_pi.apply(x_pi, norm, rate)
+    for _ in range(num_applies):
+        x_pi = ctrl_pi.apply(x_pi, norm, rate)
     x_pi = ctrl_pi.extract(x_pi)
 
     x_i = ctrl_i.init(dt)
-    x_i = ctrl_i.apply(x_i, norm, rate)
+    for _ in range(num_applies):
+        x_i = ctrl_i.apply(x_i, norm, rate)
     x_i = ctrl_i.extract(x_i)
     assert np.allclose(x_i, x_pi)

--- a/tests/test_ivpsolve/test_controllers.py
+++ b/tests/test_ivpsolve/test_controllers.py
@@ -12,11 +12,11 @@ def test_equivalence_pi_vs_i(dt=0.1428, norm=3.142, rate=3, num_applies=4):
 
     x_pi = ctrl_pi.init(dt)
     for _ in range(num_applies):
-        x_pi = ctrl_pi.apply(x_pi, norm, rate)
+        x_pi = ctrl_pi.apply(x_pi, error_norm=norm, error_contraction_rate=rate)
     x_pi = ctrl_pi.extract(x_pi)
 
     x_i = ctrl_i.init(dt)
     for _ in range(num_applies):
-        x_i = ctrl_i.apply(x_i, norm, rate)
+        x_i = ctrl_i.apply(x_i, error_norm=norm, error_contraction_rate=rate)
     x_i = ctrl_i.extract(x_i)
     assert np.allclose(x_i, x_pi)

--- a/tests/test_ivpsolve/test_controllers.py
+++ b/tests/test_ivpsolve/test_controllers.py
@@ -4,7 +4,7 @@ from probdiffeq import ivpsolve
 from probdiffeq.backend import numpy as np
 
 
-def test_equivalence_pi_vs_i(dt=0.1428, norm=3.142, rate=3, num_applies=4):
+def test_equivalence_pi_vs_i(dt=0.1428, error_power=3.142, num_applies=4):
     ctrl_pi = ivpsolve.control_proportional_integral(
         power_integral_unscaled=1.0, power_proportional_unscaled=0.0
     )
@@ -12,11 +12,11 @@ def test_equivalence_pi_vs_i(dt=0.1428, norm=3.142, rate=3, num_applies=4):
 
     x_pi = ctrl_pi.init(dt)
     for _ in range(num_applies):
-        x_pi = ctrl_pi.apply(x_pi, error_norm=norm, error_contraction_rate=rate)
+        x_pi = ctrl_pi.apply(x_pi, error_power=error_power)
     x_pi = ctrl_pi.extract(x_pi)
 
     x_i = ctrl_i.init(dt)
     for _ in range(num_applies):
-        x_i = ctrl_i.apply(x_i, error_norm=norm, error_contraction_rate=rate)
+        x_i = ctrl_i.apply(x_i, error_power=error_power)
     x_i = ctrl_i.extract(x_i)
     assert np.allclose(x_i, x_pi)


### PR DESCRIPTION
The controllers are functions of the error, but not the error estimate itself; rather, the error is normalised by atol, rtol, and a current estimate and scaled by the error contraction rate.

This PR applies the error-contraction-rate scaling inside adaptive.rejection_loop() instead of controller.apply(), which reduces the number of arguments of the latter. It also fits better with error normalisation, which already happens in the adaptive solver.

This change is internal. Users are not affected (unless they use the controllers for something non-probdiffeq related, which I find very unlikely)