### PR TITLE
Separate strategies from priors and corrections

### DIFF
--- a/docs/benchmarks/hires/run_hires.py
+++ b/docs/benchmarks/hires/run_hires.py
@@ -88,8 +88,8 @@ def solver_probdiffeq(*, num_derivatives: int) -> Callable:
         tcoeffs = taylor.odejet_padded_scan(vf_auto, (u0,), num=num_derivatives)
         ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact="dense")
         ts1 = ivpsolvers.correction_ts1(ssm=ssm)
-        strategy = ivpsolvers.strategy_filter(ibm, ts1, ssm=ssm)
-        solver = ivpsolvers.solver_dynamic(strategy, ssm=ssm)
+        strategy = ivpsolvers.strategy_filter(ssm=ssm)
+        solver = ivpsolvers.solver_dynamic(strategy, prior=ibm, correction=ts1, ssm=ssm)
         control = ivpsolve.control_proportional_integral(clip=True)
         adaptive_solver = ivpsolve.adaptive(
             solver, atol=1e-2 * tol, rtol=tol, control=control, ssm=ssm

--- a/docs/benchmarks/lotkavolterra/run_lotkavolterra.py
+++ b/docs/benchmarks/lotkavolterra/run_lotkavolterra.py
@@ -81,8 +81,9 @@ def solver_probdiffeq(num_derivatives: int, implementation, correction) -> Calla
         tcoeffs = taylor.odejet_padded_scan(vf_auto, (u0,), num=num_derivatives)
 
         ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=implementation)
-        strategy = ivpsolvers.strategy_filter(ibm, correction(ssm=ssm), ssm=ssm)
-        solver = ivpsolvers.solver_mle(strategy, ssm=ssm)
+        strategy = ivpsolvers.strategy_filter(ssm=ssm)
+        corr = correction(ssm=ssm)
+        solver = ivpsolvers.solver_mle(strategy, prior=ibm, correction=corr, ssm=ssm)
         control = ivpsolve.control_proportional_integral()
         adaptive_solver = ivpsolve.adaptive(
             solver, atol=1e-2 * tol, rtol=tol, control=control, ssm=ssm

--- a/docs/benchmarks/pleiades/run_pleiades.py
+++ b/docs/benchmarks/pleiades/run_pleiades.py
@@ -101,8 +101,10 @@ def solver_probdiffeq(*, num_derivatives: int, correction_fun) -> Callable:
 
         ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact="isotropic")
         ts0_or_ts1 = correction_fun(ssm=ssm, ode_order=2)
-        strategy = ivpsolvers.strategy_filter(ibm, ts0_or_ts1, ssm=ssm)
-        solver = ivpsolvers.solver_dynamic(strategy, ssm=ssm)
+        strategy = ivpsolvers.strategy_filter(ssm=ssm)
+        solver = ivpsolvers.solver_dynamic(
+            strategy, prior=ibm, correction=ts0_or_ts1, ssm=ssm
+        )
         control = ivpsolve.control_proportional_integral()
         adaptive_solver = ivpsolve.adaptive(
             solver, atol=1e-3 * tol, rtol=tol, control=control, ssm=ssm

--- a/docs/benchmarks/vanderpol/run_vanderpol.py
+++ b/docs/benchmarks/vanderpol/run_vanderpol.py
@@ -80,9 +80,11 @@ def solver_probdiffeq(*, num_derivatives: int) -> Callable:
 
         ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact="dense")
         ts0_or_ts1 = ivpsolvers.correction_ts1(ode_order=2, ssm=ssm)
-        strategy = ivpsolvers.strategy_filter(ibm, ts0_or_ts1, ssm=ssm)
+        strategy = ivpsolvers.strategy_filter(ssm=ssm)
 
-        solver = ivpsolvers.solver_dynamic(strategy, ssm=ssm)
+        solver = ivpsolvers.solver_dynamic(
+            strategy, prior=ibm, correction=ts0_or_ts1, ssm=ssm
+        )
         control = ivpsolve.control_proportional_integral(clip=True)
         adaptive_solver = ivpsolve.adaptive(
             solver, atol=1e-3 * tol, rtol=tol, control=control, ssm=ssm

--- a/docs/examples_misc/use_equinox_bounded_while_loop.py
+++ b/docs/examples_misc/use_equinox_bounded_while_loop.py
@@ -65,7 +65,7 @@ def solution_routine():
     ts0 = ivpsolvers.correction_ts0(ode_order=1, ssm=ssm)
 
     strategy = ivpsolvers.strategy_fixedpoint(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy)
+    solver = ivpsolvers.solver(strategy, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, ssm=ssm)
     init = solver.initial_condition()
 

--- a/docs/examples_misc/use_equinox_bounded_while_loop.py
+++ b/docs/examples_misc/use_equinox_bounded_while_loop.py
@@ -64,8 +64,8 @@ def solution_routine():
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact="isotropic")
     ts0 = ivpsolvers.correction_ts0(ode_order=1, ssm=ssm)
 
-    strategy = ivpsolvers.strategy_fixedpoint(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_fixedpoint(ssm=ssm)
+    solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, ssm=ssm)
     init = solver.initial_condition()
 

--- a/docs/examples_parameter_estimation/neural_ode.py
+++ b/docs/examples_parameter_estimation/neural_ode.py
@@ -70,8 +70,8 @@ def build_loss_fn(vf, initial_values, solver, *, standard_deviation=1e-2):
         tcoeffs = (*initial_values, vf(*initial_values, t=t0, p=parameters))
         ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact="isotropic")
         ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-        strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-        solver_ts0 = ivpsolvers.solver(strategy, ssm=ssm)
+        strategy = ivpsolvers.strategy_smoother(ssm=ssm)
+        solver_ts0 = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
         init = solver_ts0.initial_condition()
 
         sol = ivpsolve.solve_fixed_grid(
@@ -128,8 +128,8 @@ def vf(y, *, t, p):
 tcoeffs = (u0, vf(u0, t=t0, p=f_args))
 ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, output_scale=1.0, ssm_fact="isotropic")
 ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-solver_ts0 = ivpsolvers.solver(strategy, ssm=ssm)
+strategy = ivpsolvers.strategy_smoother(ssm=ssm)
+solver_ts0 = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
 init = solver_ts0.initial_condition()
 
 # +
@@ -168,8 +168,8 @@ plt.plot(sol.t, data, "-", linewidth=5, alpha=0.5, label="Data")
 tcoeffs = (u0, vf(u0, t=t0, p=f_args))
 ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, output_scale=1.0, ssm_fact="isotropic")
 ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-solver_ts0 = ivpsolvers.solver(strategy, ssm=ssm)
+strategy = ivpsolvers.strategy_smoother(ssm=ssm)
+solver_ts0 = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
 init = solver_ts0.initial_condition()
 
 sol = ivpsolve.solve_fixed_grid(
@@ -182,8 +182,8 @@ plt.plot(sol.t, sol.u[0], ".-", label="Final guess")
 tcoeffs = (u0, vf(u0, t=t0, p=f_args))
 ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, output_scale=1.0, ssm_fact="isotropic")
 ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-solver_ts0 = ivpsolvers.solver(strategy, ssm=ssm)
+strategy = ivpsolvers.strategy_smoother(ssm=ssm)
+solver_ts0 = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
 init = solver_ts0.initial_condition()
 
 sol = ivpsolve.solve_fixed_grid(

--- a/docs/examples_parameter_estimation/neural_ode.py
+++ b/docs/examples_parameter_estimation/neural_ode.py
@@ -71,7 +71,7 @@ def build_loss_fn(vf, initial_values, solver, *, standard_deviation=1e-2):
         ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact="isotropic")
         ts0 = ivpsolvers.correction_ts0(ssm=ssm)
         strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-        solver_ts0 = ivpsolvers.solver(strategy)
+        solver_ts0 = ivpsolvers.solver(strategy, ssm=ssm)
         init = solver_ts0.initial_condition()
 
         sol = ivpsolve.solve_fixed_grid(
@@ -129,7 +129,7 @@ tcoeffs = (u0, vf(u0, t=t0, p=f_args))
 ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, output_scale=1.0, ssm_fact="isotropic")
 ts0 = ivpsolvers.correction_ts0(ssm=ssm)
 strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-solver_ts0 = ivpsolvers.solver(strategy)
+solver_ts0 = ivpsolvers.solver(strategy, ssm=ssm)
 init = solver_ts0.initial_condition()
 
 # +
@@ -169,7 +169,7 @@ tcoeffs = (u0, vf(u0, t=t0, p=f_args))
 ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, output_scale=1.0, ssm_fact="isotropic")
 ts0 = ivpsolvers.correction_ts0(ssm=ssm)
 strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-solver_ts0 = ivpsolvers.solver(strategy)
+solver_ts0 = ivpsolvers.solver(strategy, ssm=ssm)
 init = solver_ts0.initial_condition()
 
 sol = ivpsolve.solve_fixed_grid(
@@ -183,7 +183,7 @@ tcoeffs = (u0, vf(u0, t=t0, p=f_args))
 ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, output_scale=1.0, ssm_fact="isotropic")
 ts0 = ivpsolvers.correction_ts0(ssm=ssm)
 strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-solver_ts0 = ivpsolvers.solver(strategy)
+solver_ts0 = ivpsolvers.solver(strategy, ssm=ssm)
 init = solver_ts0.initial_condition()
 
 sol = ivpsolve.solve_fixed_grid(

--- a/docs/examples_parameter_estimation/physics_enhanced_regression_1.py
+++ b/docs/examples_parameter_estimation/physics_enhanced_regression_1.py
@@ -72,8 +72,8 @@ def solve(p):
         tcoeffs, output_scale=output_scale, ssm_fact="isotropic"
     )
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_smoother(ssm=ssm)
+    solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
 
     init = solver.initial_condition()
     return ivpsolve.solve_fixed_grid(

--- a/docs/examples_parameter_estimation/physics_enhanced_regression_1.py
+++ b/docs/examples_parameter_estimation/physics_enhanced_regression_1.py
@@ -73,7 +73,7 @@ def solve(p):
     )
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy)
+    solver = ivpsolvers.solver(strategy, ssm=ssm)
 
     init = solver.initial_condition()
     return ivpsolve.solve_fixed_grid(

--- a/docs/examples_parameter_estimation/physics_enhanced_regression_2.py
+++ b/docs/examples_parameter_estimation/physics_enhanced_regression_2.py
@@ -192,7 +192,7 @@ def solve_fixed(theta, *, ts):
     )
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_filter(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy)
+    solver = ivpsolvers.solver(strategy, ssm=ssm)
     init = solver.initial_condition()
     sol = ivpsolve.solve_fixed_grid(vf, init, grid=ts, solver=solver, ssm=ssm)
     return sol[-1]
@@ -209,7 +209,7 @@ def solve_adaptive(theta, *, save_at):
     )
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_filter(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy)
+    solver = ivpsolvers.solver(strategy, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, ssm=ssm)
 
     init = solver.initial_condition()

--- a/docs/examples_parameter_estimation/physics_enhanced_regression_2.py
+++ b/docs/examples_parameter_estimation/physics_enhanced_regression_2.py
@@ -191,8 +191,8 @@ def solve_fixed(theta, *, ts):
         tcoeffs, output_scale=output_scale, ssm_fact="isotropic"
     )
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_filter(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_filter(ssm=ssm)
+    solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     init = solver.initial_condition()
     sol = ivpsolve.solve_fixed_grid(vf, init, grid=ts, solver=solver, ssm=ssm)
     return sol[-1]
@@ -208,8 +208,8 @@ def solve_adaptive(theta, *, save_at):
         tcoeffs, output_scale=output_scale, ssm_fact="isotropic"
     )
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_filter(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_filter(ssm=ssm)
+    solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, ssm=ssm)
 
     init = solver.initial_condition()

--- a/docs/examples_quickstart/easy_example.py
+++ b/docs/examples_quickstart/easy_example.py
@@ -55,11 +55,11 @@ t0, t1 = 0.0, 1.0
 # Set up a state-space model
 tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), (u0,), num=4)
 ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact="dense")
+ts0 = ivpsolvers.correction_ts1(ode_order=1, ssm=ssm)
+strategy = ivpsolvers.strategy_smoother(ssm=ssm)
 
 # Build a solver
-ts0 = ivpsolvers.correction_ts1(ode_order=1, ssm=ssm)
-strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-solver = ivpsolvers.solver_mle(strategy, ssm=ssm)
+solver = ivpsolvers.solver_mle(strategy, prior=ibm, correction=ts0, ssm=ssm)
 adaptive_solver = ivpsolve.adaptive(solver, ssm=ssm)
 # -
 

--- a/docs/examples_solver_config/conditioning-on-zero-residual.py
+++ b/docs/examples_solver_config/conditioning-on-zero-residual.py
@@ -79,7 +79,8 @@ markov_seq_tcoeffs = stats.MarkovSeq(init_tcoeffs, transitions)
 
 ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, output_scale=1.0, ssm_fact="dense")
 slr1 = ivpsolvers.correction_ts1(ssm=ssm)
-solver = ivpsolvers.solver(ivpsolvers.strategy_fixedpoint(ibm, slr1, ssm=ssm))
+strategy = ivpsolvers.strategy_fixedpoint(ibm, slr1, ssm=ssm)
+solver = ivpsolvers.solver(strategy, ssm=ssm)
 adaptive_solver = ivpsolve.adaptive(solver, atol=1e-1, rtol=1e-2, ssm=ssm)
 
 dt0 = ivpsolve.dt0(lambda y: vector_field(y, t=t0), (u0,))

--- a/docs/examples_solver_config/conditioning-on-zero-residual.py
+++ b/docs/examples_solver_config/conditioning-on-zero-residual.py
@@ -78,9 +78,9 @@ markov_seq_tcoeffs = stats.MarkovSeq(init_tcoeffs, transitions)
 # Compute the posterior
 
 ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, output_scale=1.0, ssm_fact="dense")
-slr1 = ivpsolvers.correction_ts1(ssm=ssm)
-strategy = ivpsolvers.strategy_fixedpoint(ibm, slr1, ssm=ssm)
-solver = ivpsolvers.solver(strategy, ssm=ssm)
+ts1 = ivpsolvers.correction_ts1(ssm=ssm)
+strategy = ivpsolvers.strategy_fixedpoint(ssm=ssm)
+solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts1, ssm=ssm)
 adaptive_solver = ivpsolve.adaptive(solver, atol=1e-1, rtol=1e-2, ssm=ssm)
 
 dt0 = ivpsolve.dt0(lambda y: vector_field(y, t=t0), (u0,))

--- a/docs/examples_solver_config/dynamic_output_scales.py
+++ b/docs/examples_solver_config/dynamic_output_scales.py
@@ -72,9 +72,9 @@ num_derivatives = 1
 tcoeffs = (u0, vf(u0, t=t0))
 ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, output_scale=1.0, ssm_fact="dense")
 ts1 = ivpsolvers.correction_ts1(ssm=ssm)
-strategy = ivpsolvers.strategy_filter(ibm, ts1, ssm=ssm)
-dynamic = ivpsolvers.solver_dynamic(strategy, ssm=ssm)
-mle = ivpsolvers.solver_mle(strategy, ssm=ssm)
+strategy = ivpsolvers.strategy_filter(ssm=ssm)
+dynamic = ivpsolvers.solver_dynamic(strategy, prior=ibm, correction=ts1, ssm=ssm)
+mle = ivpsolvers.solver_mle(strategy, prior=ibm, correction=ts1, ssm=ssm)
 
 # +
 t0, t1 = 0.0, 3.0

--- a/docs/examples_solver_config/posterior_uncertainties.py
+++ b/docs/examples_solver_config/posterior_uncertainties.py
@@ -61,7 +61,8 @@ def vf(*ys, t):  # noqa: ARG001
 tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), (u0,), num=4)
 ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, output_scale=1.0, ssm_fact="isotropic")
 ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-solver = ivpsolvers.solver_mle(ivpsolvers.strategy_filter(ibm, ts0, ssm=ssm), ssm=ssm)
+strategy = ivpsolvers.strategy_filter(ssm=ssm)
+solver = ivpsolvers.solver_mle(strategy, prior=ibm, correction=ts0, ssm=ssm)
 adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
 
 ts = jnp.linspace(t0, t0 + 2.0, endpoint=True, num=500)
@@ -115,9 +116,8 @@ plt.show()
 # +
 ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, output_scale=1.0, ssm_fact="isotropic")
 ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-solver = ivpsolvers.solver_mle(
-    ivpsolvers.strategy_fixedpoint(ibm, ts0, ssm=ssm), ssm=ssm
-)
+strategy = ivpsolvers.strategy_fixedpoint(ssm=ssm)
+solver = ivpsolvers.solver_mle(strategy, prior=ibm, correction=ts0, ssm=ssm)
 adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
 
 ts = jnp.linspace(t0, t0 + 2.0, endpoint=True, num=500)

--- a/docs/examples_solver_config/second_order_problems.py
+++ b/docs/examples_solver_config/second_order_problems.py
@@ -52,8 +52,8 @@ def vf_1(y, t):  # noqa: ARG001
 tcoeffs = taylor.odejet_padded_scan(lambda y: vf_1(y, t=t0), (u0,), num=4)
 ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, output_scale=1.0, ssm_fact="isotropic")
 ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-strategy = ivpsolvers.strategy_filter(ibm, ts0, ssm=ssm)
-solver_1st = ivpsolvers.solver_mle(strategy, ssm=ssm)
+strategy = ivpsolvers.strategy_filter(ssm=ssm)
+solver_1st = ivpsolvers.solver_mle(strategy, prior=ibm, correction=ts0, ssm=ssm)
 adaptive_solver_1st = ivpsolve.adaptive(solver_1st, atol=1e-5, rtol=1e-5, ssm=ssm)
 
 
@@ -86,8 +86,8 @@ def vf_2(y, dy, t):  # noqa: ARG001
 tcoeffs = taylor.odejet_padded_scan(lambda *ys: vf_2(*ys, t=t0), (u0, du0), num=3)
 ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, output_scale=1.0, ssm_fact="isotropic")
 ts0 = ivpsolvers.correction_ts0(ode_order=2, ssm=ssm)
-strategy = ivpsolvers.strategy_filter(ibm, ts0, ssm=ssm)
-solver_2nd = ivpsolvers.solver_mle(strategy, ssm=ssm)
+strategy = ivpsolvers.strategy_filter(ssm=ssm)
+solver_2nd = ivpsolvers.solver_mle(strategy, prior=ibm, correction=ts0, ssm=ssm)
 adaptive_solver_2nd = ivpsolve.adaptive(solver_2nd, atol=1e-5, rtol=1e-5, ssm=ssm)
 
 

--- a/docs/examples_solver_config/taylor_coefficients.py
+++ b/docs/examples_solver_config/taylor_coefficients.py
@@ -64,8 +64,8 @@ def solve(tc):
     """Solve the ODE."""
     prior, ssm = ivpsolvers.prior_ibm(tc, ssm_fact="dense")
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_fixedpoint(prior, ts0, ssm=ssm)
-    solver = ivpsolvers.solver_mle(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_fixedpoint(ssm=ssm)
+    solver = ivpsolvers.solver_mle(strategy, prior=prior, correction=ts0, ssm=ssm)
     init = solver.initial_condition()
 
     ts = jnp.linspace(t0, t1, endpoint=True, num=10)

--- a/probdiffeq/ivpsolve.py
+++ b/probdiffeq/ivpsolve.py
@@ -205,8 +205,8 @@ class _AdaSolver:
                 dt=self.control.extract(state_control),
             )
             # Normalise the error
-            u_proposed = self.ssm.stats.qoi(state_proposed.strategy.hidden)[0]
-            u_step_from = self.ssm.stats.qoi(state_proposed.strategy.hidden)[0]
+            u_proposed = self.ssm.stats.qoi(state_proposed.hidden)[0]
+            u_step_from = self.ssm.stats.qoi(state_proposed.hidden)[0]
             u = np.maximum(np.abs(u_proposed), np.abs(u_step_from))
             error_power = _error_scale_and_normalize(error_estimate, u=u)
 

--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -696,16 +696,16 @@ class _Strategy:
 
 def strategy_smoother(prior, correction: _Correction, /, ssm) -> _Strategy:
     """Construct a smoother."""
-    extrapolation = _ExtraImplSmoother(prior=prior, name="Smoother", ssm=ssm)
-    strategy = _Strategy(
-        extrapolation=extrapolation,
+    extrapolation = _ExtraImplSmoother(
         prior=prior,
+        name="Smoother",
         ssm=ssm,
         is_suitable_for_save_at=False,
         is_suitable_for_save_every_step=True,
         is_suitable_for_offgrid_marginals=True,
     )
-    return strategy, correction
+    strategy = _Strategy()
+    return strategy, correction, extrapolation, prior
 
 
 def strategy_fixedpoint(prior, correction: _Correction, /, ssm) -> _Strategy:

--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -586,16 +586,15 @@ def strategy_smoother(*, ssm):
     )
 
 
-def strategy_fixedpoint(prior, correction: _Correction, /, ssm):
+def strategy_fixedpoint(*, ssm):
     """Construct a fixedpoint-smoother."""
-    extrapolation = _ExtraImplFixedPoint(
+    return _ExtraImplFixedPoint(
         name="Fixed-point smoother",
         ssm=ssm,
         is_suitable_for_save_at=True,
         is_suitable_for_save_every_step=False,
         is_suitable_for_offgrid_marginals=False,
     )
-    return correction, extrapolation, prior
 
 
 def strategy_filter(*, ssm):
@@ -822,9 +821,8 @@ def _calibration_running_mean(*, ssm) -> _Calibration:
     return _Calibration(init=init, update=update, extract=extract)
 
 
-def solver_dynamic(inputs, *, ssm):
+def solver_dynamic(extrapolation, *, correction, prior, ssm):
     """Create a solver that calibrates the output scale dynamically."""
-    correction, extrapolation, prior = inputs
 
     def step_dynamic(state, /, *, dt, vector_field, calibration):
         prior_discretized = prior.discretize(dt)

--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -577,7 +577,6 @@ def _estimate_error(observed, /, *, ssm):
 
 # TODO = (
 #     "Next up: "
-#     "Then slowly migrate the strategy-state attributes to the solver state. "
 #     "Then update the signature of strategy_* functions "
 #     "by removing correction, prior, and so on and fix all tests"
 #  )
@@ -840,9 +839,7 @@ def solver_dynamic(inputs, *, ssm):
     def step_dynamic(state, /, *, dt, vector_field, calibration):
         prior_discretized = prior.discretize(dt)
         hidden, extra = extrapolation.begin(
-            state.strategy.hidden,
-            state.strategy.aux_extra,
-            prior_discretized=prior_discretized,
+            state.hidden, state.aux_extra, prior_discretized=prior_discretized
         )
         t = state.t + dt
         error, observed, corr = correction.estimate_error(

--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -594,8 +594,7 @@ def strategy_smoother(prior, correction: _Correction, /, ssm):
         is_suitable_for_save_every_step=True,
         is_suitable_for_offgrid_marginals=True,
     )
-    strategy = None
-    return strategy, correction, extrapolation, prior
+    return correction, extrapolation, prior
 
 
 def strategy_fixedpoint(prior, correction: _Correction, /, ssm):
@@ -607,8 +606,7 @@ def strategy_fixedpoint(prior, correction: _Correction, /, ssm):
         is_suitable_for_save_every_step=False,
         is_suitable_for_offgrid_marginals=False,
     )
-    strategy = None
-    return strategy, correction, extrapolation, prior
+    return correction, extrapolation, prior
 
 
 def strategy_filter(prior, correction: _Correction, /, *, ssm):
@@ -620,8 +618,7 @@ def strategy_filter(prior, correction: _Correction, /, *, ssm):
         is_suitable_for_save_every_step=True,
         is_suitable_for_offgrid_marginals=True,
     )
-    strategy = None
-    return strategy, correction, extrapolation, prior
+    return correction, extrapolation, prior
 
 
 @containers.dataclass
@@ -806,7 +803,7 @@ def solver_mle(inputs, *, ssm):
     Warning: needs to be combined with a call to stats.calibrate()
     after solving if the MLE-calibration shall be *used*.
     """
-    strategy, correction, extrapolation, prior = inputs
+    correction, extrapolation, prior = inputs
 
     def step_mle(state, /, *, dt, vector_field, calibration):
         output_scale_prior, _calibrated = calibration.extract(state.output_scale)
@@ -875,7 +872,7 @@ def _calibration_running_mean(*, ssm) -> _Calibration:
 
 def solver_dynamic(inputs, *, ssm):
     """Create a solver that calibrates the output scale dynamically."""
-    strategy, correction, extrapolation, prior = inputs
+    correction, extrapolation, prior = inputs
 
     def step_dynamic(state, /, *, dt, vector_field, calibration):
         prior_discretized = prior.discretize(dt)
@@ -929,7 +926,7 @@ def _calibration_most_recent(*, ssm) -> _Calibration:
 
 def solver(inputs, /, *, ssm):
     """Create a solver that does not calibrate the output scale automatically."""
-    strategy, correction, extrapolation, prior = inputs
+    correction, extrapolation, prior = inputs
 
     def step(state: _SolverState, *, vector_field, dt, calibration):
         del calibration  # unused

--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -592,10 +592,6 @@ class _Strategy:
         rv, corr = correction.init(rv)
         return _StrategyState(t=t, hidden=rv, aux_extra=extra, aux_corr=corr)
 
-    def initial_condition(self, *, extrapolation, prior):
-        """Construct an initial condition from a set of Taylor coefficients."""
-        return extrapolation.initial_condition(prior=prior)
-
     def begin(
         self,
         state: _StrategyState,
@@ -879,9 +875,7 @@ class _ProbabilisticSolver:
 
     def initial_condition(self):
         """Construct an initial condition."""
-        posterior = self.strategy.initial_condition(
-            prior=self.prior, extrapolation=self.extrapolation
-        )
+        posterior = self.extrapolation.initial_condition(prior=self.prior)
         return posterior, self.prior.output_scale
 
 

--- a/tests/test_ivpsolve/test_fixed_grid_vs_save_every_step.py
+++ b/tests/test_ivpsolve/test_fixed_grid_vs_save_every_step.py
@@ -18,8 +18,8 @@ def test_fixed_grid_result_matches_adaptive_grid_result(fact):
 
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_filter(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver_mle(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_filter(ssm=ssm)
+    solver = ivpsolvers.solver_mle(strategy, prior=ibm, correction=ts0, ssm=ssm)
 
     control = ivpsolve.control_integral(clip=True)  # Any clipped controller will do.
     asolver = ivpsolve.adaptive(solver, ssm=ssm, atol=1e-2, rtol=1e-2, control=control)

--- a/tests/test_ivpsolve/test_save_at_vs_save_every_step.py
+++ b/tests/test_ivpsolve/test_save_at_vs_save_every_step.py
@@ -16,7 +16,7 @@ def test_save_at_result_matches_interpolated_adaptive_result(fact):
 
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_filter(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy)
+    solver = ivpsolvers.solver(strategy, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
 
     init = solver.initial_condition()

--- a/tests/test_ivpsolve/test_save_at_vs_save_every_step.py
+++ b/tests/test_ivpsolve/test_save_at_vs_save_every_step.py
@@ -13,10 +13,9 @@ def test_save_at_result_matches_interpolated_adaptive_result(fact):
     # Generate a solver
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), u0, num=2)
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
-
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_filter(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_filter(ssm=ssm)
+    solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
 
     init = solver.initial_condition()

--- a/tests/test_ivpsolve/test_save_every_step.py
+++ b/tests/test_ivpsolve/test_save_every_step.py
@@ -24,8 +24,8 @@ def python_loop_solution(ivp, *, fact, strategy_fun):
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
 
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = strategy_fun(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver_mle(strategy, ssm=ssm)
+    strategy = strategy_fun(ssm=ssm)
+    solver = ivpsolvers.solver_mle(strategy, prior=ibm, correction=ts0, ssm=ssm)
 
     # clip=False because we need to test adaptive-step-interpolation
     #  for smoothers

--- a/tests/test_ivpsolve/test_solution_object.py
+++ b/tests/test_ivpsolve/test_solution_object.py
@@ -24,8 +24,8 @@ def fixture_approximate_solution(fact):
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
 
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_filter(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver_mle(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_filter(ssm=ssm)
+    solver = ivpsolvers.solver_mle(strategy, prior=ibm, correction=ts0, ssm=ssm)
     asolver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
 
     init = solver.initial_condition()
@@ -88,8 +88,8 @@ def fixture_approximate_solution_batched(fact):
         ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
 
         ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-        strategy = ivpsolvers.strategy_filter(ibm, ts0, ssm=ssm)
-        solver = ivpsolvers.solver_mle(strategy, ssm=ssm)
+        strategy = ivpsolvers.strategy_filter(ssm=ssm)
+        solver = ivpsolvers.solver_mle(strategy, prior=ibm, correction=ts0, ssm=ssm)
         adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
 
         initcond = solver.initial_condition()

--- a/tests/test_ivpsolve/test_terminal_values_vs_save_every_step.py
+++ b/tests/test_ivpsolve/test_terminal_values_vs_save_every_step.py
@@ -14,8 +14,8 @@ def test_terminal_values_identical(fact):
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
 
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_filter(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver_mle(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_filter(ssm=ssm)
+    solver = ivpsolvers.solver_mle(strategy, prior=ibm, correction=ts0, ssm=ssm)
     asolver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
 
     init = solver.initial_condition()

--- a/tests/test_ivpsolvers/test_calibration_dynamic_vs_mle.py
+++ b/tests/test_ivpsolvers/test_calibration_dynamic_vs_mle.py
@@ -16,8 +16,8 @@ def test_exponential_approximated_well(fact):
 
     ibm, ssm = ivpsolvers.prior_ibm((*u0, vf(*u0, t=t0)), ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_filter(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver_dynamic(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_filter(ssm=ssm)
+    solver = ivpsolvers.solver_dynamic(strategy, prior=ibm, correction=ts0, ssm=ssm)
 
     init = solver.initial_condition()
 

--- a/tests/test_ivpsolvers/test_calibration_mle_vs_none.py
+++ b/tests/test_ivpsolvers/test_calibration_mle_vs_none.py
@@ -21,8 +21,8 @@ def case_solve_fixed_grid(fact):
     kwargs = {"grid": np.linspace(t0, t1, endpoint=True, num=5), "ssm": ssm}
 
     def solver_to_solution(solver_fun, strategy_fun):
-        strategy = strategy_fun(ibm, ts0, ssm=ssm)
-        solver = solver_fun(strategy, ssm=ssm)
+        strategy = strategy_fun(ssm=ssm)
+        solver = solver_fun(strategy, prior=ibm, correction=ts0, ssm=ssm)
         init = solver.initial_condition()
         return ivpsolve.solve_fixed_grid(vf, init, solver=solver, **kwargs)
 
@@ -44,8 +44,8 @@ def case_solve_adaptive_save_at(fact):
     kwargs = {"save_at": save_at, "dt0": dt0, "ssm": ssm}
 
     def solver_to_solution(solver_fun, strategy_fun):
-        strategy = strategy_fun(ibm, ts0, ssm=ssm)
-        solver = solver_fun(strategy, ssm=ssm)
+        strategy = strategy_fun(ssm=ssm)
+        solver = solver_fun(strategy, prior=ibm, correction=ts0, ssm=ssm)
 
         init = solver.initial_condition()
         adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
@@ -69,8 +69,8 @@ def case_solve_adaptive_save_every_step(fact):
     kwargs = {"t0": t0, "t1": t1, "dt0": dt0, "ssm": ssm}
 
     def solver_to_solution(solver_fun, strategy_fun):
-        strategy = strategy_fun(ibm, ts0, ssm=ssm)
-        solver = solver_fun(strategy, ssm=ssm)
+        strategy = strategy_fun(ssm=ssm)
+        solver = solver_fun(strategy, prior=ibm, correction=ts0, ssm=ssm)
 
         init = solver.initial_condition()
         adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
@@ -94,8 +94,8 @@ def case_simulate_terminal_values(fact):
     kwargs = {"t0": t0, "t1": t1, "dt0": dt0, "ssm": ssm}
 
     def solver_to_solution(solver_fun, strategy_fun):
-        strategy = strategy_fun(ibm, ts0, ssm=ssm)
-        solver = solver_fun(strategy, ssm=ssm)
+        strategy = strategy_fun(ssm=ssm)
+        solver = solver_fun(strategy, prior=ibm, correction=ts0, ssm=ssm)
 
         init = solver.initial_condition()
         adaptive_solver = ivpsolve.adaptive(solver, ssm=ssm, atol=1e-2, rtol=1e-2)

--- a/tests/test_ivpsolvers/test_calibration_mle_vs_none.py
+++ b/tests/test_ivpsolvers/test_calibration_mle_vs_none.py
@@ -6,8 +6,8 @@ After applying stats.calibrate(), the posterior is different.
 """
 
 from probdiffeq import ivpsolve, ivpsolvers, stats, taylor
-from probdiffeq.backend import functools, ode, testing
 from probdiffeq.backend import numpy as np
+from probdiffeq.backend import ode, testing
 
 
 @testing.case()
@@ -22,7 +22,7 @@ def case_solve_fixed_grid(fact):
 
     def solver_to_solution(solver_fun, strategy_fun):
         strategy = strategy_fun(ibm, ts0, ssm=ssm)
-        solver = solver_fun(strategy)
+        solver = solver_fun(strategy, ssm=ssm)
         init = solver.initial_condition()
         return ivpsolve.solve_fixed_grid(vf, init, solver=solver, **kwargs)
 
@@ -45,7 +45,7 @@ def case_solve_adaptive_save_at(fact):
 
     def solver_to_solution(solver_fun, strategy_fun):
         strategy = strategy_fun(ibm, ts0, ssm=ssm)
-        solver = solver_fun(strategy)
+        solver = solver_fun(strategy, ssm=ssm)
 
         init = solver.initial_condition()
         adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
@@ -70,7 +70,7 @@ def case_solve_adaptive_save_every_step(fact):
 
     def solver_to_solution(solver_fun, strategy_fun):
         strategy = strategy_fun(ibm, ts0, ssm=ssm)
-        solver = solver_fun(strategy)
+        solver = solver_fun(strategy, ssm=ssm)
 
         init = solver.initial_condition()
         adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
@@ -95,7 +95,7 @@ def case_simulate_terminal_values(fact):
 
     def solver_to_solution(solver_fun, strategy_fun):
         strategy = strategy_fun(ibm, ts0, ssm=ssm)
-        solver = solver_fun(strategy)
+        solver = solver_fun(strategy, ssm=ssm)
 
         init = solver.initial_condition()
         adaptive_solver = ivpsolve.adaptive(solver, ssm=ssm, atol=1e-2, rtol=1e-2)
@@ -114,7 +114,7 @@ def case_simulate_terminal_values(fact):
 def fixture_uncalibrated_and_mle_solution(solver_to_solution, strategy_fun):
     solve, ssm = solver_to_solution
     uncalib = solve(ivpsolvers.solver, strategy_fun)
-    mle = solve(functools.partial(ivpsolvers.solver_mle, ssm=ssm), strategy_fun)
+    mle = solve(ivpsolvers.solver_mle, strategy_fun)
     return (uncalib, mle), ssm
 
 

--- a/tests/test_ivpsolvers/test_corrections.py
+++ b/tests/test_ivpsolvers/test_corrections.py
@@ -46,8 +46,8 @@ def fixture_solution(correction_impl, fact):
     except NotImplementedError:
         testing.skip(reason="This type of linearisation has not been implemented.")
 
-    strategy = ivpsolvers.strategy_filter(ibm, corr, ssm=ssm)
-    solver = ivpsolvers.solver_mle(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_filter(ssm=ssm)
+    solver = ivpsolvers.solver_mle(strategy, prior=ibm, correction=corr, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
 
     adaptive_kwargs = {"adaptive_solver": adaptive_solver, "dt0": 0.1, "ssm": ssm}

--- a/tests/test_ivpsolvers/test_strategy_smoother_vs_filter.py
+++ b/tests/test_ivpsolvers/test_strategy_smoother_vs_filter.py
@@ -20,8 +20,8 @@ def fixture_filter_solution(solver_setup):
     tcoeffs = solver_setup["tcoeffs"]
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=solver_setup["fact"])
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_filter(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_filter(ssm=ssm)
+    solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
 
     init = solver.initial_condition()
     return ivpsolve.solve_fixed_grid(
@@ -34,8 +34,8 @@ def fixture_smoother_solution(solver_setup):
     tcoeffs = solver_setup["tcoeffs"]
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=solver_setup["fact"])
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_smoother(ssm=ssm)
+    solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
 
     init = solver.initial_condition()
     return ivpsolve.solve_fixed_grid(

--- a/tests/test_ivpsolvers/test_strategy_smoother_vs_filter.py
+++ b/tests/test_ivpsolvers/test_strategy_smoother_vs_filter.py
@@ -21,7 +21,7 @@ def fixture_filter_solution(solver_setup):
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=solver_setup["fact"])
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_filter(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy)
+    solver = ivpsolvers.solver(strategy, ssm=ssm)
 
     init = solver.initial_condition()
     return ivpsolve.solve_fixed_grid(
@@ -35,7 +35,7 @@ def fixture_smoother_solution(solver_setup):
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=solver_setup["fact"])
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy)
+    solver = ivpsolvers.solver(strategy, ssm=ssm)
 
     init = solver.initial_condition()
     return ivpsolve.solve_fixed_grid(

--- a/tests/test_ivpsolvers/test_strategy_smoother_vs_fixedpoint.py
+++ b/tests/test_ivpsolvers/test_strategy_smoother_vs_fixedpoint.py
@@ -23,7 +23,7 @@ def fixture_solution_smoother(solver_setup):
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy)
+    solver = ivpsolvers.solver(strategy, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, atol=1e-3, rtol=1e-3, ssm=ssm)
 
     init = solver.initial_condition()
@@ -44,7 +44,7 @@ def test_fixedpoint_smoother_equivalent_same_grid(solver_setup, solution_smoothe
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_fixedpoint(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy)
+    solver = ivpsolvers.solver(strategy, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, atol=1e-3, rtol=1e-3, ssm=ssm)
 
     save_at = solution_smoother.t
@@ -70,7 +70,7 @@ def test_fixedpoint_smoother_equivalent_different_grid(solver_setup, solution_sm
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-    solver_smoother = ivpsolvers.solver(strategy)
+    solver_smoother = ivpsolvers.solver(strategy, ssm=ssm)
 
     # Compute the offgrid-marginals
     ts = np.linspace(save_at[0], save_at[-1], num=7, endpoint=True)
@@ -83,7 +83,7 @@ def test_fixedpoint_smoother_equivalent_different_grid(solver_setup, solution_sm
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_fixedpoint(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy)
+    solver = ivpsolvers.solver(strategy, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, atol=1e-3, rtol=1e-3, ssm=ssm)
     init = solver.initial_condition()
 

--- a/tests/test_ivpsolvers/test_strategy_smoother_vs_fixedpoint.py
+++ b/tests/test_ivpsolvers/test_strategy_smoother_vs_fixedpoint.py
@@ -22,8 +22,8 @@ def fixture_solution_smoother(solver_setup):
     tcoeffs, fact = solver_setup["tcoeffs"], solver_setup["fact"]
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_smoother(ssm=ssm)
+    solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, atol=1e-3, rtol=1e-3, ssm=ssm)
 
     init = solver.initial_condition()
@@ -43,8 +43,8 @@ def test_fixedpoint_smoother_equivalent_same_grid(solver_setup, solution_smoothe
     tcoeffs, fact = solver_setup["tcoeffs"], solver_setup["fact"]
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_fixedpoint(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_fixedpoint(ssm=ssm)
+    solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, atol=1e-3, rtol=1e-3, ssm=ssm)
 
     save_at = solution_smoother.t
@@ -69,8 +69,8 @@ def test_fixedpoint_smoother_equivalent_different_grid(solver_setup, solution_sm
     tcoeffs, fact = solver_setup["tcoeffs"], solver_setup["fact"]
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-    solver_smoother = ivpsolvers.solver(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_smoother(ssm=ssm)
+    solver_smoother = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
 
     # Compute the offgrid-marginals
     ts = np.linspace(save_at[0], save_at[-1], num=7, endpoint=True)
@@ -82,8 +82,8 @@ def test_fixedpoint_smoother_equivalent_different_grid(solver_setup, solution_sm
     tcoeffs, fact = solver_setup["tcoeffs"], solver_setup["fact"]
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_fixedpoint(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_fixedpoint(ssm=ssm)
+    solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, atol=1e-3, rtol=1e-3, ssm=ssm)
     init = solver.initial_condition()
 

--- a/tests/test_ivpsolvers/test_strategy_warnings_for_wrong_strategies.py
+++ b/tests/test_ivpsolvers/test_strategy_warnings_for_wrong_strategies.py
@@ -14,7 +14,7 @@ def test_warning_for_fixedpoint_in_save_every_step_mode(fact):
 
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_fixedpoint(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy)
+    solver = ivpsolvers.solver(strategy, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
 
     init = solver.initial_condition()
@@ -33,7 +33,7 @@ def test_warning_for_smoother_in_save_at_mode(fact):
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy)
+    solver = ivpsolvers.solver(strategy, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
 
     init = solver.initial_condition()

--- a/tests/test_ivpsolvers/test_strategy_warnings_for_wrong_strategies.py
+++ b/tests/test_ivpsolvers/test_strategy_warnings_for_wrong_strategies.py
@@ -13,8 +13,8 @@ def test_warning_for_fixedpoint_in_save_every_step_mode(fact):
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
 
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_fixedpoint(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_fixedpoint(ssm=ssm)
+    solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
 
     init = solver.initial_condition()
@@ -32,8 +32,8 @@ def test_warning_for_smoother_in_save_at_mode(fact):
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), (u0,), num=2)
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_smoother(ssm=ssm)
+    solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
 
     init = solver.initial_condition()

--- a/tests/test_stats/test_log_marginal_likelihood.py
+++ b/tests/test_stats/test_log_marginal_likelihood.py
@@ -15,7 +15,7 @@ def fixture_solution(fact):
 
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_fixedpoint(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy)
+    solver = ivpsolvers.solver(strategy, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
 
     init = solver.initial_condition()
@@ -97,7 +97,7 @@ def test_raises_error_for_filter(fact):
 
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_filter(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy)
+    solver = ivpsolvers.solver(strategy, ssm=ssm)
 
     grid = np.linspace(t0, t1, num=3)
     init = solver.initial_condition()

--- a/tests/test_stats/test_log_marginal_likelihood.py
+++ b/tests/test_stats/test_log_marginal_likelihood.py
@@ -14,8 +14,8 @@ def fixture_solution(fact):
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
 
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_fixedpoint(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_fixedpoint(ssm=ssm)
+    solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
 
     init = solver.initial_condition()
@@ -96,8 +96,8 @@ def test_raises_error_for_filter(fact):
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
 
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_filter(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_filter(ssm=ssm)
+    solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
 
     grid = np.linspace(t0, t1, num=3)
     init = solver.initial_condition()

--- a/tests/test_stats/test_log_marginal_likelihood_terminal_values.py
+++ b/tests/test_stats/test_log_marginal_likelihood_terminal_values.py
@@ -29,8 +29,8 @@ def fixture_solution(strategy_func, fact):
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), (u0,), num=4)
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = strategy_func(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy, ssm=ssm)
+    strategy = strategy_func(ssm=ssm)
+    solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
 
     init = solver.initial_condition()

--- a/tests/test_stats/test_log_marginal_likelihood_terminal_values.py
+++ b/tests/test_stats/test_log_marginal_likelihood_terminal_values.py
@@ -30,7 +30,7 @@ def fixture_solution(strategy_func, fact):
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = strategy_func(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy)
+    solver = ivpsolvers.solver(strategy, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
 
     init = solver.initial_condition()

--- a/tests/test_stats/test_offgrid_marginals.py
+++ b/tests/test_stats/test_offgrid_marginals.py
@@ -13,8 +13,8 @@ def test_filter_marginals_close_only_to_left_boundary(fact):
     tcoeffs = (u0, vf(u0, t=t0))
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_filter(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_filter(ssm=ssm)
+    solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
 
     init = solver.initial_condition()
     grid = np.linspace(t0, t1, endpoint=True, num=5)
@@ -37,8 +37,8 @@ def test_smoother_marginals_close_to_both_boundaries(fact):
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), (u0,), num=4)
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_smoother(ssm=ssm)
+    solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
 
     init = solver.initial_condition()
     grid = np.linspace(t0, t1, endpoint=True, num=5)

--- a/tests/test_stats/test_offgrid_marginals.py
+++ b/tests/test_stats/test_offgrid_marginals.py
@@ -14,7 +14,7 @@ def test_filter_marginals_close_only_to_left_boundary(fact):
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_filter(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy)
+    solver = ivpsolvers.solver(strategy, ssm=ssm)
 
     init = solver.initial_condition()
     grid = np.linspace(t0, t1, endpoint=True, num=5)
@@ -38,7 +38,7 @@ def test_smoother_marginals_close_to_both_boundaries(fact):
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy)
+    solver = ivpsolvers.solver(strategy, ssm=ssm)
 
     init = solver.initial_condition()
     grid = np.linspace(t0, t1, endpoint=True, num=5)

--- a/tests/test_stats/test_sample.py
+++ b/tests/test_stats/test_sample.py
@@ -13,7 +13,7 @@ def fixture_approximation(fact):
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy)
+    solver = ivpsolvers.solver(strategy, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
 
     init = solver.initial_condition()

--- a/tests/test_stats/test_sample.py
+++ b/tests/test_stats/test_sample.py
@@ -12,8 +12,8 @@ def fixture_approximation(fact):
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), (u0,), num=2)
     ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-    strategy = ivpsolvers.strategy_smoother(ibm, ts0, ssm=ssm)
-    solver = ivpsolvers.solver(strategy, ssm=ssm)
+    strategy = ivpsolvers.strategy_smoother(ssm=ssm)
+    solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolve.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
 
     init = solver.initial_condition()


### PR DESCRIPTION
Instead of constructing a solver as solver(strategy(prior, correction)), we now construct a solver as solver(strategy, prior, correction).  This is better because it discouples strategies from priors and corrections and because it removes code complexity from the source.  

The diff should make it really obvious how to update the code. As usual, all examples are updated. 

This change is not backwards compatible.