### PR TITLE
Remove iterability from the Solution object because it is mathematically ill-defined

### DIFF
--- a/probdiffeq/ivpsolve.py
+++ b/probdiffeq/ivpsolve.py
@@ -2,6 +2,7 @@
 
 from probdiffeq import stats
 from probdiffeq.backend import (
+    containers,
     control_flow,
     functools,
     linalg,
@@ -10,62 +11,21 @@ from probdiffeq.backend import (
     warnings,
 )
 from probdiffeq.backend import numpy as np
+from probdiffeq.backend.typing import Any, Array
 
 
+@containers.dataclass
 class _Solution:
     """Estimated initial value problem solution."""
 
-    def __init__(self, t, u, u_std, output_scale, marginals, posterior, num_steps, ssm):
-        """Construct a solution object."""
-        self.t = t
-        self.u = u
-        self.u_std = u_std
-        self.output_scale = output_scale
-        self.marginals = marginals  # todo: marginals are replaced by "u" and "u_std"
-        self.posterior = posterior
-        self.num_steps = num_steps
-        self.ssm = ssm
-
-    def __repr__(self):
-        """Evaluate a string-representation of the solution object."""
-        return (
-            f"{self.__class__.__name__}("
-            f"t={self.t},"
-            f"u={self.u},"
-            f"output_scale={self.output_scale},"
-            f"marginals={self.marginals},"
-            f"posterior={self.posterior},"
-            f"num_steps={self.num_steps},"
-            ")"
-        )
-
-    def __len__(self):
-        """Evaluate the length of a solution."""
-        if np.ndim(self.t) < 1:
-            msg = "Solution object not batched :("
-            raise ValueError(msg)
-        return self.t.shape[0]
-
-    def __getitem__(self, item):
-        """Access a single item of the solution."""
-        if np.ndim(self.t) < 1:
-            msg = "Solution object not batched :("
-            raise ValueError(msg)
-
-        if np.ndim(self.t) == 1 and item != -1:
-            msg = "Access to non-terminal states is not available."
-            raise ValueError(msg)
-
-        return tree_util.tree_map(lambda s: s[item, ...], self)
-
-    def __iter__(self):
-        """Iterate through the solution."""
-        if np.ndim(self.t) <= 1:
-            msg = "Solution object not batched :("
-            raise ValueError(msg)
-
-        for i in range(self.t.shape[0]):
-            yield self[i]
+    t: Array
+    u: Array
+    u_std: Array
+    output_scale: Array
+    marginals: Any
+    posterior: Any
+    num_steps: Array
+    ssm: Any
 
     @staticmethod
     def register_pytree_node():

--- a/tests/test_ivpsolve/test_solution_object.py
+++ b/tests/test_ivpsolve/test_solution_object.py
@@ -1,8 +1,7 @@
 """Tests for interaction with the solution object."""
 
 from probdiffeq import ivpsolve, ivpsolvers, taylor
-from probdiffeq.backend import containers, functools, ode, testing
-from probdiffeq.backend import numpy as np
+from probdiffeq.backend import containers, ode, testing
 from probdiffeq.backend.typing import Array
 
 
@@ -37,91 +36,6 @@ def fixture_approximate_solution(fact):
 def test_u_inherits_data_structure(approximate_solution):
     assert isinstance(approximate_solution.u, Taylor)
 
-    solution_t1 = approximate_solution[-1]
-    assert isinstance(solution_t1.u, Taylor)
-
 
 def test_u_std_inherits_data_structure(approximate_solution):
     assert isinstance(approximate_solution.u_std, Taylor)
-
-    solution_t1 = approximate_solution[-1]
-    assert isinstance(solution_t1.u_std, Taylor)
-
-
-def test_getitem_possible_for_terminal_values(approximate_solution):
-    solution_t1 = approximate_solution[-1]
-    assert isinstance(solution_t1, type(approximate_solution))
-
-
-@testing.parametrize("item", [-2, 0, slice(1, -1, 1)])
-def test_getitem_impossible_for_nonterminal_values(approximate_solution, item):
-    with testing.raises(ValueError, match="non-terminal"):
-        _ = approximate_solution[item]
-
-
-@testing.parametrize("item", [-1, -2, 0, slice(1, -1, 1)])
-def test_getitem_impossible_at_single_time_for_any_item(approximate_solution, item):
-    # Allowed slicing:
-    # solution_t1 is not batched now, so further slicing should be impossible
-    solution_t1 = approximate_solution[-1]
-
-    with testing.raises(ValueError, match="not batched"):
-        _ = solution_t1[item]
-
-
-def test_iter_impossible(approximate_solution):
-    with testing.raises(ValueError, match="not batched"):
-        for _ in approximate_solution:
-            pass
-
-
-@testing.fixture(name="approximate_solution_batched")
-@testing.parametrize("fact", ["dense", "blockdiag", "isotropic"])
-def fixture_approximate_solution_batched(fact):
-    vf, (u0,), (t0, t1) = ode.ivp_lotka_volterra()
-
-    # Generate a solver
-    save_at = np.linspace(t0, t1, endpoint=True, num=4)
-
-    def solve(init):
-        tcoeffs = (init, vf(init, t=None))
-        ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
-
-        ts0 = ivpsolvers.correction_ts0(ssm=ssm)
-        strategy = ivpsolvers.strategy_filter(ssm=ssm)
-        solver = ivpsolvers.solver_mle(strategy, prior=ibm, correction=ts0, ssm=ssm)
-        adaptive_solver = ivpsolvers.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
-
-        initcond = solver.initial_condition()
-        return ivpsolve.solve_adaptive_save_at(
-            vf,
-            initcond,
-            save_at=save_at,
-            adaptive_solver=adaptive_solver,
-            dt0=0.1,
-            ssm=ssm,
-        )
-
-    u0_batched = u0[None, ...]
-    solve = functools.vmap(solve)
-    return solve(u0_batched)
-
-
-def test_batched_getitem_possible(approximate_solution_batched):
-    solution_type = type(approximate_solution_batched)
-    for idx in (0,):
-        approximate_solution = approximate_solution_batched[idx]
-        assert isinstance(approximate_solution, solution_type)
-        assert np.allclose(approximate_solution.t, approximate_solution_batched.t[idx])
-
-        for u1, u2 in zip(approximate_solution.u, approximate_solution_batched.u[idx]):
-            assert np.allclose(u1, u2)
-
-
-def test_batched_iter_possible(approximate_solution_batched):
-    solution_type = type(approximate_solution_batched)
-    for idx, approximate_solution in enumerate(approximate_solution_batched):
-        assert isinstance(approximate_solution, solution_type)
-        assert np.allclose(approximate_solution.t, approximate_solution_batched.t[idx])
-        for u1, u2 in zip(approximate_solution.u, approximate_solution_batched.u[idx]):
-            assert np.allclose(u1, u2)


### PR DESCRIPTION
This is breaking because `solution[-1]` is not possible anymore.

Why was iterability an issue? Because the posterior is a Markov sequence, and selecting the "i"th transition density does not yield a parametrisation of the ith sub-sequence. In other words, the behaviour was mathematically incorrect. Since I don't know how to correct it (without a million conditions in `__iter__`), I deleted it.