### PR TITLE
Fix a tracer conversion issue

### DIFF
--- a/probdiffeq/ivpsolvers.py
+++ b/probdiffeq/ivpsolvers.py
@@ -30,8 +30,9 @@ def prior_ibm(tcoeffs, *, ssm_fact: str, output_scale=None):
     """Construct an adaptive(/continuous-time), multiply-integrated Wiener process."""
     ssm = impl.choose(ssm_fact, tcoeffs_like=tcoeffs)
 
-    output_scale_user = output_scale or np.ones_like(ssm.prototypes.output_scale())
-    discretize = ssm.conditional.ibm_transitions(output_scale=output_scale_user)
+    if output_scale is None:
+        output_scale = np.ones_like(ssm.prototypes.output_scale())
+    discretize = ssm.conditional.ibm_transitions(output_scale=output_scale)
 
     output_scale_calib = np.ones_like(ssm.prototypes.output_scale())
     prior = _MarkovProcess(tcoeffs, output_scale_calib, discretize=discretize)


### PR DESCRIPTION
If output_scale is a traced array, `output_scale or ...` doesn't work. This PR fixes this.