### PR TITLE
Rename `prior_ibm` to `prior_wiener_integrated` and simplify the initial state

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-merge-conflict
   - repo: https://github.com/lyz-code/yamlfix/
-    rev: 1.17.0
+    rev: 1.18.0
     hooks:
       - id: yamlfix
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/docs/benchmarks/hires/run_hires.py
+++ b/docs/benchmarks/hires/run_hires.py
@@ -89,7 +89,7 @@ def solver_probdiffeq(*, num_derivatives: int) -> Callable:
         # Build a solver
         vf_auto = functools.partial(vf_probdiffeq, t=t0)
         tcoeffs = taylor.odejet_padded_scan(vf_auto, (u0,), num=num_derivatives)
-        ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact="dense")
+        init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact="dense")
         ts1 = ivpsolvers.correction_ts1(ssm=ssm)
         strategy = ivpsolvers.strategy_filter(ssm=ssm)
         solver = ivpsolvers.solver_dynamic(strategy, prior=ibm, correction=ts1, ssm=ssm)
@@ -97,9 +97,6 @@ def solver_probdiffeq(*, num_derivatives: int) -> Callable:
         adaptive_solver = ivpsolvers.adaptive(
             solver, atol=1e-2 * tol, rtol=tol, control=control, ssm=ssm, clip_dt=True
         )
-
-        # Initial state
-        init = solver.initial_condition()
 
         # Solve
         dt0 = ivpsolve.dt0(vf_auto, (u0,))

--- a/docs/benchmarks/lotkavolterra/run_lotkavolterra.py
+++ b/docs/benchmarks/lotkavolterra/run_lotkavolterra.py
@@ -80,7 +80,9 @@ def solver_probdiffeq(num_derivatives: int, implementation, correction) -> Calla
         vf_auto = functools.partial(vf_probdiffeq, t=t0)
         tcoeffs = taylor.odejet_padded_scan(vf_auto, (u0,), num=num_derivatives)
 
-        ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=implementation)
+        init, ibm, ssm = ivpsolvers.prior_wiener_integrated(
+            tcoeffs, ssm_fact=implementation
+        )
         strategy = ivpsolvers.strategy_filter(ssm=ssm)
         corr = correction(ssm=ssm)
         solver = ivpsolvers.solver_mle(strategy, prior=ibm, correction=corr, ssm=ssm)
@@ -88,9 +90,6 @@ def solver_probdiffeq(num_derivatives: int, implementation, correction) -> Calla
         adaptive_solver = ivpsolvers.adaptive(
             solver, atol=1e-2 * tol, rtol=tol, control=control, ssm=ssm
         )
-
-        # Initial state
-        init = solver.initial_condition()
 
         # Solve
         dt0 = ivpsolve.dt0(vf_auto, (u0,))

--- a/docs/benchmarks/pleiades/run_pleiades.py
+++ b/docs/benchmarks/pleiades/run_pleiades.py
@@ -99,7 +99,9 @@ def solver_probdiffeq(*, num_derivatives: int, correction_fun) -> Callable:
         vf_auto = functools.partial(vf_probdiffeq, t=t0)
         tcoeffs = taylor.odejet_padded_scan(vf_auto, (u0, du0), num=num_derivatives - 1)
 
-        ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact="isotropic")
+        init, ibm, ssm = ivpsolvers.prior_wiener_integrated(
+            tcoeffs, ssm_fact="isotropic"
+        )
         ts0_or_ts1 = correction_fun(ssm=ssm, ode_order=2)
         strategy = ivpsolvers.strategy_filter(ssm=ssm)
         solver = ivpsolvers.solver_dynamic(
@@ -109,9 +111,6 @@ def solver_probdiffeq(*, num_derivatives: int, correction_fun) -> Callable:
         adaptive_solver = ivpsolvers.adaptive(
             solver, atol=1e-3 * tol, rtol=tol, control=control, ssm=ssm
         )
-
-        # Initial state
-        init = solver.initial_condition()
 
         # Solve
         dt0 = ivpsolve.dt0(vf_auto, (u0, du0))

--- a/docs/benchmarks/vanderpol/run_vanderpol.py
+++ b/docs/benchmarks/vanderpol/run_vanderpol.py
@@ -81,7 +81,7 @@ def solver_probdiffeq(*, num_derivatives: int) -> Callable:
         vf_auto = functools.partial(vf_probdiffeq, t=t0)
         tcoeffs = taylor.odejet_padded_scan(vf_auto, (u0, du0), num=num_derivatives - 1)
 
-        ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact="dense")
+        init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact="dense")
         ts0_or_ts1 = ivpsolvers.correction_ts1(ode_order=2, ssm=ssm)
         strategy = ivpsolvers.strategy_filter(ssm=ssm)
 
@@ -92,9 +92,6 @@ def solver_probdiffeq(*, num_derivatives: int) -> Callable:
         adaptive_solver = ivpsolvers.adaptive(
             solver, atol=1e-3 * tol, rtol=tol, control=control, ssm=ssm, clip_dt=True
         )
-
-        # Initial state
-        init = solver.initial_condition()
 
         # Solve
         dt0 = ivpsolve.dt0(vf_auto, (u0, du0))

--- a/docs/examples_advanced/equinox_while_loop.py
+++ b/docs/examples_advanced/equinox_while_loop.py
@@ -61,13 +61,12 @@ def solution_routine():
     u0 = jnp.asarray([0.1])
 
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), (u0,), num=1)
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact="isotropic")
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact="isotropic")
     ts0 = ivpsolvers.correction_ts0(ode_order=1, ssm=ssm)
 
     strategy = ivpsolvers.strategy_fixedpoint(ssm=ssm)
     solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolvers.adaptive(solver, ssm=ssm)
-    init = solver.initial_condition()
 
     def simulate(init_val):
         """Evaluate the parameter-to-solution function."""

--- a/docs/examples_advanced/neural_ode.py
+++ b/docs/examples_advanced/neural_ode.py
@@ -149,7 +149,7 @@ def loss_log_marginal_likelihood(vf, *, t0):
         """Loss function: log-marginal likelihood of the data."""
         # Build a solver
         tcoeffs = (*u0, vf(*u0, t=t0, p=p))
-        ibm, ssm = ivpsolvers.prior_ibm(
+        init, ibm, ssm = ivpsolvers.prior_wiener_integrated(
             tcoeffs, output_scale=output_scale, ssm_fact="isotropic"
         )
         ts0 = ivpsolvers.correction_ts0(ssm=ssm)
@@ -157,7 +157,6 @@ def loss_log_marginal_likelihood(vf, *, t0):
         solver_ts0 = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
 
         # Solve
-        init = solver_ts0.initial_condition()
         sol = ivpsolve.solve_fixed_grid(
             lambda *a, **kw: vf(*a, **kw, p=p),
             init,

--- a/docs/examples_advanced/parameter_estimation_blackjax.py
+++ b/docs/examples_advanced/parameter_estimation_blackjax.py
@@ -183,13 +183,12 @@ def solve_fixed(theta, *, ts):
     # Create a probabilistic solver
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), (theta,), num=2)
     output_scale = 10.0
-    ibm, ssm = ivpsolvers.prior_ibm(
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(
         tcoeffs, output_scale=output_scale, ssm_fact="isotropic"
     )
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_filter(ssm=ssm)
     solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
-    init = solver.initial_condition()
     return ivpsolve.solve_fixed_grid(vf, init, grid=ts, solver=solver, ssm=ssm)
 
 
@@ -199,15 +198,13 @@ def solve_adaptive(theta, *, save_at):
     # Create a probabilistic solver
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), (theta,), num=2)
     output_scale = 10.0
-    ibm, ssm = ivpsolvers.prior_ibm(
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(
         tcoeffs, output_scale=output_scale, ssm_fact="isotropic"
     )
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_filter(ssm=ssm)
     solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolvers.adaptive(solver, ssm=ssm)
-
-    init = solver.initial_condition()
     return ivpsolve.solve_adaptive_save_at(
         vf, init, save_at=save_at, adaptive_solver=adaptive_solver, dt0=0.1, ssm=ssm
     )

--- a/docs/examples_advanced/parameter_estimation_optax.py
+++ b/docs/examples_advanced/parameter_estimation_optax.py
@@ -59,14 +59,12 @@ def solve(p):
     """Evaluate the parameter-to-solution map."""
     tcoeffs = (u0, vf(u0, t0, p=p))
     output_scale = 10.0
-    ibm, ssm = ivpsolvers.prior_ibm(
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(
         tcoeffs, output_scale=output_scale, ssm_fact="isotropic"
     )
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_smoother(ssm=ssm)
     solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
-
-    init = solver.initial_condition()
     return ivpsolve.solve_fixed_grid(
         lambda y, t: vf(y, t, p=p), init, grid=ts, solver=solver, ssm=ssm
     )

--- a/docs/examples_basic/dynamic_output_scales.py
+++ b/docs/examples_basic/dynamic_output_scales.py
@@ -64,7 +64,9 @@ def vf(*ys, t):  # noqa: ARG001
 num_derivatives = 1
 
 tcoeffs = (u0, vf(u0, t=t0))
-ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, output_scale=1.0, ssm_fact="dense")
+init, ibm, ssm = ivpsolvers.prior_wiener_integrated(
+    tcoeffs, output_scale=1.0, ssm_fact="dense"
+)
 ts1 = ivpsolvers.correction_ts1(ssm=ssm)
 strategy = ivpsolvers.strategy_filter(ssm=ssm)
 dynamic = ivpsolvers.solver_dynamic(strategy, prior=ibm, correction=ts1, ssm=ssm)
@@ -77,12 +79,8 @@ num_pts = 200
 ts = jnp.linspace(t0, t1, num=num_pts, endpoint=True)
 
 
-init_mle = mle.initial_condition()
-init_dynamic = dynamic.initial_condition()
-solution_dynamic = ivpsolve.solve_fixed_grid(
-    vf, init_mle, grid=ts, solver=dynamic, ssm=ssm
-)
-solution_mle = ivpsolve.solve_fixed_grid(vf, init_dynamic, grid=ts, solver=mle, ssm=ssm)
+solution_dynamic = ivpsolve.solve_fixed_grid(vf, init, grid=ts, solver=dynamic, ssm=ssm)
+solution_mle = ivpsolve.solve_fixed_grid(vf, init, grid=ts, solver=mle, ssm=ssm)
 # -
 
 # Plot the solution.

--- a/docs/examples_basic/posterior_uncertainties.py
+++ b/docs/examples_basic/posterior_uncertainties.py
@@ -42,7 +42,7 @@ u0 = jnp.asarray([20.0, 20.0])
 # Set up a solver
 # To all users: Try replacing the fixedpoint-smoother with a filter!
 tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), (u0,), num=3)
-ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact="dense")
+init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact="dense")
 ts = ivpsolvers.correction_ts1(ssm=ssm)
 strategy = ivpsolvers.strategy_fixedpoint(ssm=ssm)
 solver = ivpsolvers.solver_mle(strategy, prior=ibm, correction=ts, ssm=ssm)
@@ -50,7 +50,6 @@ adaptive_solver = ivpsolvers.adaptive(solver, atol=1e-1, rtol=1e-1, ssm=ssm)
 
 # Solve the ODE
 ts = jnp.linspace(t0, t1, endpoint=True, num=50)
-init = solver.initial_condition()
 sol = ivpsolve.solve_adaptive_save_at(
     vf, init, save_at=ts, dt0=0.1, adaptive_solver=adaptive_solver, ssm=ssm
 )

--- a/docs/examples_basic/second_order_problems.py
+++ b/docs/examples_basic/second_order_problems.py
@@ -44,7 +44,9 @@ def vf_1(y, t):  # noqa: ARG001
 
 
 tcoeffs = taylor.odejet_padded_scan(lambda y: vf_1(y, t=t0), (u0,), num=4)
-ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, output_scale=1.0, ssm_fact="isotropic")
+init, ibm, ssm = ivpsolvers.prior_wiener_integrated(
+    tcoeffs, output_scale=1.0, ssm_fact="isotropic"
+)
 ts0 = ivpsolvers.correction_ts0(ssm=ssm)
 strategy = ivpsolvers.strategy_filter(ssm=ssm)
 solver_1st = ivpsolvers.solver_mle(strategy, prior=ibm, correction=ts0, ssm=ssm)
@@ -53,7 +55,6 @@ adaptive_solver_1st = ivpsolvers.adaptive(solver_1st, atol=1e-5, rtol=1e-5, ssm=
 
 # -
 
-init = solver_1st.initial_condition()
 solution = ivpsolve.solve_adaptive_save_every_step(
     vf_1, init, t0=t0, t1=t1, dt0=0.1, adaptive_solver=adaptive_solver_1st, ssm=ssm
 )
@@ -78,14 +79,14 @@ def vf_2(y, dy, t):  # noqa: ARG001
 
 # One derivative more than above because we don't transform to first order
 tcoeffs = taylor.odejet_padded_scan(lambda *ys: vf_2(*ys, t=t0), (u0, du0), num=3)
-ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, output_scale=1.0, ssm_fact="isotropic")
+init, ibm, ssm = ivpsolvers.prior_wiener_integrated(
+    tcoeffs, output_scale=1.0, ssm_fact="isotropic"
+)
 ts0 = ivpsolvers.correction_ts0(ode_order=2, ssm=ssm)
 strategy = ivpsolvers.strategy_filter(ssm=ssm)
 solver_2nd = ivpsolvers.solver_mle(strategy, prior=ibm, correction=ts0, ssm=ssm)
 adaptive_solver_2nd = ivpsolvers.adaptive(solver_2nd, atol=1e-5, rtol=1e-5, ssm=ssm)
 
-
-init = solver_2nd.initial_condition()
 # -
 
 solution = ivpsolve.solve_adaptive_save_every_step(

--- a/docs/examples_basic/taylor_coefficients.py
+++ b/docs/examples_basic/taylor_coefficients.py
@@ -57,12 +57,10 @@ def vf(*y, t):  # noqa: ARG001
 # +
 def solve(tc):
     """Solve the ODE."""
-    prior, ssm = ivpsolvers.prior_ibm(tc, ssm_fact="dense")
+    init, prior, ssm = ivpsolvers.prior_wiener_integrated(tc, ssm_fact="dense")
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_fixedpoint(ssm=ssm)
     solver = ivpsolvers.solver_mle(strategy, prior=prior, correction=ts0, ssm=ssm)
-    init = solver.initial_condition()
-
     ts = jnp.linspace(t0, t1, endpoint=True, num=10)
     adaptive_solver = ivpsolvers.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
     return ivpsolve.solve_adaptive_save_at(

--- a/docs/examples_quickstart/quickstart.py
+++ b/docs/examples_quickstart/quickstart.py
@@ -39,7 +39,7 @@ t0, t1 = 0.0, 5.0
 
 # Set up a state-space model
 tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), (u0,), num=1)
-ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact="dense")
+init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact="dense")
 
 
 # Build a solver
@@ -51,7 +51,6 @@ adaptive_solver = ivpsolvers.adaptive(solver, ssm=ssm)
 
 # Solve the ODE
 # To all users: Try different solution routines.
-init = solver.initial_condition()
 solution = ivpsolve.solve_adaptive_save_every_step(
     vf, init, t0=t0, t1=t1, dt0=0.1, adaptive_solver=adaptive_solver, ssm=ssm
 )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,7 +79,7 @@ nav:
   - Choosing a solver: choosing_a_solver.md
   - Troubleshooting: troubleshooting.md
   - EXAMPLES | BASIC:
-      - examples_basic/conditioning-on-zero-residual.ipynb
+      - examples_basic/conditioning_on_zero_residual.ipynb
       - examples_basic/posterior_uncertainties.ipynb
       - examples_basic/dynamic_output_scales.ipynb
       - examples_basic/second_order_problems.ipynb

--- a/probdiffeq/backend/linalg.py
+++ b/probdiffeq/backend/linalg.py
@@ -39,13 +39,6 @@ def qr_r_jvp(primals, tangents):
 # All Cholesky factors are lower-triangular by default
 
 
-def cholesky_factor(arr, /):
-    return jnp.linalg.cholesky(arr)
-
-
-# All Cholesky factors are lower-triangular by default
-
-
 def cholesky_solve(arr, rhs, /):
     return jax.scipy.linalg.cho_solve((arr, True), rhs)
 

--- a/probdiffeq/backend/numpy.py
+++ b/probdiffeq/backend/numpy.py
@@ -60,10 +60,6 @@ def squeeze(arr, /):
     return jnp.squeeze(arr)
 
 
-def squeeze_along_axis(arr, /, *, axis):
-    return jnp.squeeze(arr, axis=axis)
-
-
 def atleast_1d(arr, /):
     return jnp.atleast_1d(arr)
 

--- a/probdiffeq/backend/typing.py
+++ b/probdiffeq/backend/typing.py
@@ -1,7 +1,7 @@
 """Typing module."""
 
 from collections.abc import Callable, Sequence
-from typing import Any, Generic, Optional, TypeAlias, TypeVar
+from typing import Any, Generic, TypeAlias, TypeVar
 
 import jax
 from mypy_extensions import NamedArg

--- a/probdiffeq/impl/_prototypes.py
+++ b/probdiffeq/impl/_prototypes.py
@@ -26,18 +26,18 @@ class DensePrototype(PrototypeBackend):
         self.ode_shape = ode_shape
 
     def qoi(self):
-        return np.empty(self.ode_shape)
+        return np.ones(self.ode_shape)
 
     def observed(self):
-        mean = np.empty(self.ode_shape)
-        cholesky = np.empty(self.ode_shape + self.ode_shape)
+        mean = np.ones(self.ode_shape)
+        cholesky = np.ones(self.ode_shape + self.ode_shape)
         return _normal.Normal(mean, cholesky)
 
     def error_estimate(self):
-        return np.empty(self.ode_shape)
+        return np.ones(self.ode_shape)
 
     def output_scale(self):
-        return np.empty(())
+        return np.ones(())
 
 
 class IsotropicPrototype(PrototypeBackend):
@@ -45,18 +45,18 @@ class IsotropicPrototype(PrototypeBackend):
         self.ode_shape = ode_shape
 
     def qoi(self):
-        return np.empty(self.ode_shape)
+        return np.ones(self.ode_shape)
 
     def observed(self):
-        mean = np.empty((1, *self.ode_shape))
-        cholesky = np.empty(())
+        mean = np.ones((1, *self.ode_shape))
+        cholesky = np.ones(())
         return _normal.Normal(mean, cholesky)
 
     def error_estimate(self):
-        return np.empty(())
+        return np.ones(())
 
     def output_scale(self):
-        return np.empty(())
+        return np.ones(())
 
 
 class BlockDiagPrototype(PrototypeBackend):
@@ -64,15 +64,15 @@ class BlockDiagPrototype(PrototypeBackend):
         self.ode_shape = ode_shape
 
     def qoi(self):
-        return np.empty(self.ode_shape)
+        return np.ones(self.ode_shape)
 
     def observed(self):
-        mean = np.empty((*self.ode_shape, 1))
-        cholesky = np.empty((*self.ode_shape, 1, 1))
+        mean = np.ones((*self.ode_shape, 1))
+        cholesky = np.ones((*self.ode_shape, 1, 1))
         return _normal.Normal(mean, cholesky)
 
     def error_estimate(self):
-        return np.empty(self.ode_shape)
+        return np.ones(self.ode_shape)
 
     def output_scale(self):
-        return np.empty(self.ode_shape)
+        return np.ones(self.ode_shape)

--- a/probdiffeq/impl/impl.py
+++ b/probdiffeq/impl/impl.py
@@ -15,6 +15,7 @@ class FactImpl:
     stats: _stats.StatsBackend
     linearise: _linearise.LinearisationBackend
     conditional: _conditional.ConditionalBackend
+    num_derivatives: int
 
     # To assert a valid tree_equal of solutions, the factorisations
     # must be comparable.
@@ -67,6 +68,7 @@ def _select_dense(*, tcoeffs_like) -> FactImpl:
         normal=normal,
         prototypes=prototypes,
         stats=stats,
+        num_derivatives=len(tcoeffs_like) - 1,
     )
 
 
@@ -92,6 +94,7 @@ def _select_isotropic(*, tcoeffs_like) -> FactImpl:
         stats=stats,
         linearise=linearise,
         conditional=conditional,
+        num_derivatives=len(tcoeffs_like) - 1,
     )
 
 
@@ -117,4 +120,5 @@ def _select_blockdiag(*, tcoeffs_like) -> FactImpl:
         stats=stats,
         linearise=linearise,
         conditional=conditional,
+        num_derivatives=len(tcoeffs_like) - 1,
     )

--- a/probdiffeq/ivpsolve.py
+++ b/probdiffeq/ivpsolve.py
@@ -148,11 +148,9 @@ def solve_adaptive_save_at(
 
     # I think the user expects the initial condition to be part of the state
     # (as well as marginals), so we compute those things here
-    posterior_t0 = initial_condition.posterior
+    init_t0 = initial_condition
     posterior_save_at, output_scale = solution_save_at
-    _tmp = _userfriendly_output(
-        posterior=posterior_save_at, posterior_t0=posterior_t0, ssm=ssm
-    )
+    _tmp = _userfriendly_output(posterior=posterior_save_at, init_t0=init_t0, ssm=ssm)
     marginals, posterior = _tmp
     u = ssm.stats.qoi_from_sample(marginals.mean)
     std = ssm.stats.standard_deviation(marginals)
@@ -238,9 +236,9 @@ def solve_adaptive_save_every_step(
     t = np.concatenate((np.atleast_1d(t0), t))
 
     # I think the user expects marginals, so we compute them here
-    posterior_t0 = initial_condition.posterior
+    init_t0 = initial_condition
     posterior, output_scale = solution_every_step
-    _tmp = _userfriendly_output(posterior=posterior, posterior_t0=posterior_t0, ssm=ssm)
+    _tmp = _userfriendly_output(posterior=posterior, init_t0=init_t0, ssm=ssm)
     marginals, posterior = _tmp
 
     u = ssm.stats.qoi_from_sample(marginals.mean)
@@ -296,8 +294,8 @@ def solve_fixed_grid(
     _t, (posterior, output_scale) = solver.extract(result_state)
 
     # I think the user expects marginals, so we compute them here
-    posterior_t0 = initial_condition.posterior
-    _tmp = _userfriendly_output(posterior=posterior, posterior_t0=posterior_t0, ssm=ssm)
+    init_t0 = initial_condition
+    _tmp = _userfriendly_output(posterior=posterior, init_t0=init_t0, ssm=ssm)
     marginals, posterior = _tmp
 
     u = ssm.stats.qoi_from_sample(marginals.mean)
@@ -315,7 +313,7 @@ def solve_fixed_grid(
     )
 
 
-def _userfriendly_output(*, posterior, posterior_t0, ssm):
+def _userfriendly_output(*, posterior, init_t0, ssm):
     if isinstance(posterior, stats.MarkovSeq):
         # Compute marginals
         posterior_no_filter_marginals = stats.markov_select_terminal(posterior)
@@ -328,11 +326,10 @@ def _userfriendly_output(*, posterior, posterior_t0, ssm):
         marginals = tree_array_util.tree_append(marginals, marginal_t1)
 
         # Prepend the marginal at t1 to the inits
-        init_t0 = posterior_t0.init
         init = tree_array_util.tree_prepend(init_t0, posterior.init)
         posterior = stats.MarkovSeq(init=init, conditional=posterior.conditional)
     else:
-        posterior = tree_array_util.tree_prepend(posterior_t0, posterior)
+        posterior = tree_array_util.tree_prepend(init_t0, posterior)
         marginals = posterior
     return marginals, posterior
 

--- a/tests/test_ivpsolve/test_fixed_grid_vs_save_every_step.py
+++ b/tests/test_ivpsolve/test_fixed_grid_vs_save_every_step.py
@@ -17,14 +17,13 @@ def test_fixed_grid_result_matches_adaptive_grid_result(fact):
 
     tcoeffs = Taylor(*taylor.odejet_padded_scan(lambda y: vf(y, t=t0), u0, num=2))
 
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_filter(ssm=ssm)
     solver = ivpsolvers.solver_mle(strategy, prior=ibm, correction=ts0, ssm=ssm)
 
     asolver = ivpsolvers.adaptive(solver, ssm=ssm, atol=1e-2, rtol=1e-2, clip_dt=True)
 
-    init = solver.initial_condition()
     args = (vf, init)
 
     adaptive_kwargs = {

--- a/tests/test_ivpsolve/test_save_at_vs_save_every_step.py
+++ b/tests/test_ivpsolve/test_save_at_vs_save_every_step.py
@@ -12,13 +12,12 @@ def test_save_at_result_matches_interpolated_adaptive_result(fact):
 
     # Generate a solver
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), u0, num=2)
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_filter(ssm=ssm)
     solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolvers.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
 
-    init = solver.initial_condition()
     problem_args = (vf, init)
     adaptive_kwargs = {"adaptive_solver": adaptive_solver, "dt0": 0.1, "ssm": ssm}
 

--- a/tests/test_ivpsolve/test_save_every_step.py
+++ b/tests/test_ivpsolve/test_save_every_step.py
@@ -27,11 +27,11 @@ def python_loop_solution(ivp, *, fact, strategy_fun):
     vf, u0, (t0, t1) = ivp
 
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), u0, num=4)
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+    init, transition, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
 
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = strategy_fun(ssm=ssm)
-    solver = ivpsolvers.solver_mle(strategy, prior=ibm, correction=ts0, ssm=ssm)
+    solver = ivpsolvers.solver_mle(strategy, prior=transition, correction=ts0, ssm=ssm)
 
     # clip=False because we need to test adaptive-step-interpolation
     #  for smoothers
@@ -42,9 +42,6 @@ def python_loop_solution(ivp, *, fact, strategy_fun):
     dt0 = ivpsolve.dt0_adaptive(
         vf, u0, t0=t0, atol=1e-2, rtol=1e-2, error_contraction_rate=5
     )
-
-    init = solver.initial_condition()
-
     args = (vf, init)
     kwargs = {
         "t0": t0,

--- a/tests/test_ivpsolve/test_solution_api.py
+++ b/tests/test_ivpsolve/test_solution_api.py
@@ -20,14 +20,12 @@ def fixture_pn_solution(fact):
 
     # Generate a solver
     tcoeffs = Taylor(*taylor.odejet_padded_scan(lambda y: vf(y, t=t0), u0, num=2))
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
 
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_filter(ssm=ssm)
     solver = ivpsolvers.solver_mle(strategy, prior=ibm, correction=ts0, ssm=ssm)
     asolver = ivpsolvers.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
-
-    init = solver.initial_condition()
     return ivpsolve.solve_adaptive_save_every_step(
         vf, init, t0=t0, t1=t1, dt0=0.1, adaptive_solver=asolver, ssm=ssm
     )

--- a/tests/test_ivpsolve/test_terminal_values_vs_save_every_step.py
+++ b/tests/test_ivpsolve/test_terminal_values_vs_save_every_step.py
@@ -12,14 +12,12 @@ def test_terminal_values_identical(fact):
 
     # Generate a solver
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), u0, num=2)
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
 
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_filter(ssm=ssm)
     solver = ivpsolvers.solver_mle(strategy, prior=ibm, correction=ts0, ssm=ssm)
     asolver = ivpsolvers.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
-
-    init = solver.initial_condition()
 
     args = (vf, init)
     kwargs = {"t0": t0, "t1": t1, "adaptive_solver": asolver, "dt0": 0.1, "ssm": ssm}

--- a/tests/test_ivpsolvers/test_calibration_dynamic_vs_mle.py
+++ b/tests/test_ivpsolvers/test_calibration_dynamic_vs_mle.py
@@ -14,12 +14,11 @@ from probdiffeq.backend import numpy as np
 def test_exponential_approximated_well(fact):
     vf, u0, (t0, t1) = ode.ivp_lotka_volterra()
 
-    ibm, ssm = ivpsolvers.prior_ibm((*u0, vf(*u0, t=t0)), ssm_fact=fact)
+    tcoeffs = (*u0, vf(*u0, t=t0))
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_filter(ssm=ssm)
     solver = ivpsolvers.solver_dynamic(strategy, prior=ibm, correction=ts0, ssm=ssm)
-
-    init = solver.initial_condition()
 
     problem_args = (vf, init)
     grid = np.linspace(t0, t1, num=20)

--- a/tests/test_ivpsolvers/test_calibration_mle_vs_none.py
+++ b/tests/test_ivpsolvers/test_calibration_mle_vs_none.py
@@ -16,14 +16,13 @@ def case_solve_fixed_grid(fact):
     vf, u0, (t0, t1) = ode.ivp_lotka_volterra()
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), u0, num=4)
 
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     kwargs = {"grid": np.linspace(t0, t1, endpoint=True, num=5), "ssm": ssm}
 
     def solver_to_solution(solver_fun, strategy_fun):
         strategy = strategy_fun(ssm=ssm)
         solver = solver_fun(strategy, prior=ibm, correction=ts0, ssm=ssm)
-        init = solver.initial_condition()
         return ivpsolve.solve_fixed_grid(vf, init, solver=solver, **kwargs)
 
     return solver_to_solution, ssm
@@ -37,7 +36,7 @@ def case_solve_adaptive_save_at(fact):
     dt0 = ivpsolve.dt0(lambda y: vf(y, t=t0), u0)
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), u0, num=4)
 
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
 
     save_at = np.linspace(t0, t1, endpoint=True, num=5)
@@ -46,8 +45,6 @@ def case_solve_adaptive_save_at(fact):
     def solver_to_solution(solver_fun, strategy_fun):
         strategy = strategy_fun(ssm=ssm)
         solver = solver_fun(strategy, prior=ibm, correction=ts0, ssm=ssm)
-
-        init = solver.initial_condition()
         adaptive_solver = ivpsolvers.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
         return ivpsolve.solve_adaptive_save_at(
             vf, init, adaptive_solver=adaptive_solver, **kwargs
@@ -64,15 +61,13 @@ def case_solve_adaptive_save_every_step(fact):
     dt0 = ivpsolve.dt0(lambda y: vf(y, t=t0), u0)
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), u0, num=4)
 
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     kwargs = {"t0": t0, "t1": t1, "dt0": dt0, "ssm": ssm}
 
     def solver_to_solution(solver_fun, strategy_fun):
         strategy = strategy_fun(ssm=ssm)
         solver = solver_fun(strategy, prior=ibm, correction=ts0, ssm=ssm)
-
-        init = solver.initial_condition()
         adaptive_solver = ivpsolvers.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
         return ivpsolve.solve_adaptive_save_every_step(
             vf, init, adaptive_solver=adaptive_solver, **kwargs
@@ -88,7 +83,7 @@ def case_simulate_terminal_values(fact):
     dt0 = ivpsolve.dt0(lambda y: vf(y, t=t0), u0)
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), u0, num=4)
 
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
 
     kwargs = {"t0": t0, "t1": t1, "dt0": dt0, "ssm": ssm}
@@ -96,8 +91,6 @@ def case_simulate_terminal_values(fact):
     def solver_to_solution(solver_fun, strategy_fun):
         strategy = strategy_fun(ssm=ssm)
         solver = solver_fun(strategy, prior=ibm, correction=ts0, ssm=ssm)
-
-        init = solver.initial_condition()
         adaptive_solver = ivpsolvers.adaptive(solver, ssm=ssm, atol=1e-2, rtol=1e-2)
         return ivpsolve.solve_adaptive_terminal_values(
             vf, init, adaptive_solver=adaptive_solver, **kwargs

--- a/tests/test_ivpsolvers/test_corrections.py
+++ b/tests/test_ivpsolvers/test_corrections.py
@@ -40,7 +40,7 @@ def fixture_solution(correction_impl, fact):
 
     try:
         tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), u0, num=2)
-        ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+        init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
         corr = correction_impl(ssm=ssm, damp=1e-9)
 
     except NotImplementedError:
@@ -52,7 +52,6 @@ def fixture_solution(correction_impl, fact):
 
     adaptive_kwargs = {"adaptive_solver": adaptive_solver, "dt0": 0.1, "ssm": ssm}
 
-    init = solver.initial_condition()
     return ivpsolve.solve_adaptive_terminal_values(
         vf, init, t0=t0, t1=t1, **adaptive_kwargs
     )

--- a/tests/test_ivpsolvers/test_strategy_smoother_vs_filter.py
+++ b/tests/test_ivpsolvers/test_strategy_smoother_vs_filter.py
@@ -18,12 +18,12 @@ def fixture_solver_setup(fact):
 @testing.fixture(name="filter_solution")
 def fixture_filter_solution(solver_setup):
     tcoeffs = solver_setup["tcoeffs"]
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=solver_setup["fact"])
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(
+        tcoeffs, ssm_fact=solver_setup["fact"]
+    )
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_filter(ssm=ssm)
     solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
-
-    init = solver.initial_condition()
     return ivpsolve.solve_fixed_grid(
         solver_setup["vf"], init, grid=solver_setup["grid"], solver=solver, ssm=ssm
     )
@@ -32,12 +32,12 @@ def fixture_filter_solution(solver_setup):
 @testing.fixture(name="smoother_solution")
 def fixture_smoother_solution(solver_setup):
     tcoeffs = solver_setup["tcoeffs"]
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=solver_setup["fact"])
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(
+        tcoeffs, ssm_fact=solver_setup["fact"]
+    )
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_smoother(ssm=ssm)
     solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
-
-    init = solver.initial_condition()
     return ivpsolve.solve_fixed_grid(
         solver_setup["vf"], init, grid=solver_setup["grid"], solver=solver, ssm=ssm
     )

--- a/tests/test_ivpsolvers/test_strategy_smoother_vs_fixedpoint.py
+++ b/tests/test_ivpsolvers/test_strategy_smoother_vs_fixedpoint.py
@@ -20,13 +20,11 @@ def fixture_solver_setup(fact):
 @testing.fixture(name="solution_smoother")
 def fixture_solution_smoother(solver_setup):
     tcoeffs, fact = solver_setup["tcoeffs"], solver_setup["fact"]
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_smoother(ssm=ssm)
     solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolvers.adaptive(solver, atol=1e-3, rtol=1e-3, ssm=ssm)
-
-    init = solver.initial_condition()
     return ivpsolve.solve_adaptive_save_every_step(
         solver_setup["vf"],
         init,
@@ -41,15 +39,13 @@ def fixture_solution_smoother(solver_setup):
 def test_fixedpoint_smoother_equivalent_same_grid(solver_setup, solution_smoother):
     """Test that with save_at=smoother_solution.t, the results should be identical."""
     tcoeffs, fact = solver_setup["tcoeffs"], solver_setup["fact"]
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_fixedpoint(ssm=ssm)
     solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolvers.adaptive(solver, atol=1e-3, rtol=1e-3, ssm=ssm)
 
     save_at = solution_smoother.t
-
-    init = solver.initial_condition()
     solution_fixedpoint = ivpsolve.solve_adaptive_save_at(
         solver_setup["vf"],
         init,
@@ -67,7 +63,7 @@ def test_fixedpoint_smoother_equivalent_different_grid(solver_setup, solution_sm
 
     # Re-generate the smoothing solver
     tcoeffs, fact = solver_setup["tcoeffs"], solver_setup["fact"]
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+    _init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_smoother(ssm=ssm)
     solver_smoother = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
@@ -80,13 +76,11 @@ def test_fixedpoint_smoother_equivalent_different_grid(solver_setup, solution_sm
 
     # Generate a fixedpoint solver and solve (saving at the interpolation points)
     tcoeffs, fact = solver_setup["tcoeffs"], solver_setup["fact"]
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_fixedpoint(ssm=ssm)
     solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolvers.adaptive(solver, atol=1e-3, rtol=1e-3, ssm=ssm)
-    init = solver.initial_condition()
-
     solution_fixedpoint = ivpsolve.solve_adaptive_save_at(
         solver_setup["vf"],
         init,

--- a/tests/test_ivpsolvers/test_strategy_warnings_for_wrong_strategies.py
+++ b/tests/test_ivpsolvers/test_strategy_warnings_for_wrong_strategies.py
@@ -10,14 +10,12 @@ def test_warning_for_fixedpoint_in_save_every_step_mode(fact):
     vf, (u0,), (t0, t1) = ode.ivp_lotka_volterra()
 
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), (u0,), num=2)
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
 
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_fixedpoint(ssm=ssm)
     solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolvers.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
-
-    init = solver.initial_condition()
 
     with testing.warns():
         _ = ivpsolve.solve_adaptive_save_every_step(
@@ -30,14 +28,11 @@ def test_warning_for_smoother_in_save_at_mode(fact):
     vf, (u0,), (t0, t1) = ode.ivp_lotka_volterra()
 
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), (u0,), num=2)
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_smoother(ssm=ssm)
     solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolvers.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
-
-    init = solver.initial_condition()
-
     with testing.warns():
         _ = ivpsolve.solve_adaptive_save_at(
             vf,

--- a/tests/test_stats/test_log_marginal_likelihood.py
+++ b/tests/test_stats/test_log_marginal_likelihood.py
@@ -11,15 +11,12 @@ def fixture_solution(fact):
     vf, (u0,), (t0, t1) = ode.ivp_lotka_volterra()
 
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), (u0,), num=2)
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
 
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_fixedpoint(ssm=ssm)
     solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolvers.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
-
-    init = solver.initial_condition()
-
     save_at = np.linspace(t0, t1, endpoint=True, num=4)
     sol = ivpsolve.solve_adaptive_save_at(
         vf, init, save_at=save_at, adaptive_solver=adaptive_solver, dt0=0.1, ssm=ssm
@@ -93,14 +90,13 @@ def test_raises_error_for_filter(fact):
     vf, (u0,), (t0, t1) = ode.ivp_lotka_volterra()
 
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), (u0,), num=2)
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
 
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_filter(ssm=ssm)
     solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
 
     grid = np.linspace(t0, t1, num=3)
-    init = solver.initial_condition()
     sol = ivpsolve.solve_fixed_grid(vf, init, grid=grid, solver=solver, ssm=ssm)
 
     data = sol.u[0] + 0.1

--- a/tests/test_stats/test_log_marginal_likelihood_terminal_values.py
+++ b/tests/test_stats/test_log_marginal_likelihood_terminal_values.py
@@ -27,13 +27,11 @@ def fixture_solution(strategy_func, fact):
     vf, (u0,), (t0, t1) = ode.ivp_lotka_volterra()
 
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), (u0,), num=4)
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = strategy_func(ssm=ssm)
     solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolvers.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
-
-    init = solver.initial_condition()
     sol = ivpsolve.solve_adaptive_terminal_values(
         vf, init, t0=t0, t1=t1, adaptive_solver=adaptive_solver, dt0=0.1, ssm=ssm
     )

--- a/tests/test_stats/test_offgrid_marginals.py
+++ b/tests/test_stats/test_offgrid_marginals.py
@@ -11,12 +11,10 @@ def test_filter_marginals_close_only_to_left_boundary(fact):
     vf, (u0,), (t0, t1) = ode.ivp_lotka_volterra()
 
     tcoeffs = (u0, vf(u0, t=t0))
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_filter(ssm=ssm)
     solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
-
-    init = solver.initial_condition()
     grid = np.linspace(t0, t1, endpoint=True, num=5)
     sol = ivpsolve.solve_fixed_grid(vf, init, grid=grid, solver=solver, ssm=ssm)
 
@@ -35,12 +33,11 @@ def test_smoother_marginals_close_to_both_boundaries(fact):
     vf, (u0,), (t0, t1) = ode.ivp_lotka_volterra()
 
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), (u0,), num=4)
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_smoother(ssm=ssm)
     solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
 
-    init = solver.initial_condition()
     grid = np.linspace(t0, t1, endpoint=True, num=5)
     sol = ivpsolve.solve_fixed_grid(vf, init, grid=grid, solver=solver, ssm=ssm)
     # Extrapolate from the left: close-to-left boundary must be similar,

--- a/tests/test_stats/test_sample.py
+++ b/tests/test_stats/test_sample.py
@@ -10,13 +10,11 @@ def fixture_approximation(fact):
     vf, (u0,), (t0, t1) = ode.ivp_lotka_volterra()
 
     tcoeffs = taylor.odejet_padded_scan(lambda y: vf(y, t=t0), (u0,), num=2)
-    ibm, ssm = ivpsolvers.prior_ibm(tcoeffs, ssm_fact=fact)
+    init, ibm, ssm = ivpsolvers.prior_wiener_integrated(tcoeffs, ssm_fact=fact)
     ts0 = ivpsolvers.correction_ts0(ssm=ssm)
     strategy = ivpsolvers.strategy_smoother(ssm=ssm)
     solver = ivpsolvers.solver(strategy, prior=ibm, correction=ts0, ssm=ssm)
     adaptive_solver = ivpsolvers.adaptive(solver, atol=1e-2, rtol=1e-2, ssm=ssm)
-
-    init = solver.initial_condition()
     return ivpsolve.solve_adaptive_save_every_step(
         vf, init, t0=t0, t1=t1, adaptive_solver=adaptive_solver, dt0=0.1, ssm=ssm
     )


### PR DESCRIPTION
- Function renaming (as the title explains)
- Prior returns a triple (initial condition, discretisation, state-space model) instead of a tuple. The initial condition replaces a call to `solver.initial_condition()`.

Not backwards compatible. Consult the Quickstart for the new API (changes are minimal)