### PR TITLE
Bundle shape info in SSMs

### DIFF
--- a/probdiffeq/backend/structs.py
+++ b/probdiffeq/backend/structs.py
@@ -4,6 +4,7 @@ import dataclasses
 from enum import Enum  # noqa: F401
 from typing import NamedTuple  # noqa: F401
 
+from jax import ShapeDtypeStruct  # noqa: F401
 from typing_extensions import dataclass_transform  # new in Python 3.11
 
 

--- a/probdiffeq/probdiffeq.py
+++ b/probdiffeq/probdiffeq.py
@@ -202,6 +202,7 @@ def loss_lml_terminal_values(*, ssm: ssm_impl.FactSsmImpl, tcoeff_index=0):
     def loss(u, /, *, marginals, std):
         u = tree.tree_map(np.asarray, u)
 
+        # TODO: this is the wrong shape! We should expect std.shape == u.shape...
         std_expected = tree.tree_map(lambda _s: ssm.prototypes.std(), u)
         std = tree.tree_map(np.asarray, std)
         shapes = tree.tree_map(lambda a, b: a.shape == b.shape, std, std_expected)

--- a/probdiffeq/probdiffeq.py
+++ b/probdiffeq/probdiffeq.py
@@ -979,11 +979,6 @@ class ProbabilisticSolver:
         self.constraint_init = constraint_init
 
     @property
-    def error_contraction_rate(self):
-        """The error-contraction rate of the solver."""
-        return self.ssm.num_derivatives + 1
-
-    @property
     def is_suitable_for_offgrid_marginals(self):
         """Whether the solver admits offgrid-marginal calculation.
 
@@ -1444,7 +1439,7 @@ class strategy_smoother_fixedinterval(MarkovStrategy[MarkovSequence]):
         )
 
     def init_posterior(self, *, u: TaylorCoeffTarget):
-        cond = self.ssm.conditional.identity(self.ssm.num_derivatives + 1)
+        cond = self.ssm.conditional.identity()
         posterior = MarkovSequence(marginal=u.marginals, conditional=cond, reverse=True)
         return u, posterior
 
@@ -1682,7 +1677,7 @@ class strategy_smoother_fixedpoint(MarkovStrategy[MarkovSequence]):
         )
 
     def init_posterior(self, *, u):
-        cond = self.ssm.conditional.identity(self.ssm.num_derivatives + 1)
+        cond = self.ssm.conditional.identity()
         posterior = MarkovSequence(u.marginals, cond, reverse=True)
         return u, posterior
 
@@ -1729,7 +1724,7 @@ class strategy_smoother_fixedpoint(MarkovStrategy[MarkovSequence]):
         return estimate, posterior
 
     def interpolate_at_t1(self, *, posterior_t1: MarkovSequence):
-        cond_identity = self.ssm.conditional.identity(self.ssm.num_derivatives + 1)
+        cond_identity = self.ssm.conditional.identity()
         resume_from = MarkovSequence(
             posterior_t1.marginal,
             conditional=cond_identity,
@@ -1815,7 +1810,7 @@ class strategy_smoother_fixedpoint(MarkovStrategy[MarkovSequence]):
         _, extrapolated_t = self.predict(
             posterior=posterior_t0, transition=transition_t0_t
         )
-        conditional_id = self.ssm.conditional.identity(self.ssm.num_derivatives + 1)
+        conditional_id = self.ssm.conditional.identity()
         previous_new = MarkovSequence(
             extrapolated_t.marginal, conditional_id, reverse=extrapolated_t.reverse
         )
@@ -2455,7 +2450,9 @@ class error_residual_std(ErrorEstimator):
         error, _ = tree.ravel_pytree(error)
 
         # Compute a reference
-        u0 = tree.tree_leaves(previous.u.mean)[0]
+        previous_leaves = tree.tree_leaves(previous.u.mean)
+        error_contraction_rate = len(previous_leaves)
+        u0 = previous_leaves[0]
         u1 = tree.tree_leaves(proposed.u.mean)[0]
         reference = np.maximum(np.abs(u0), np.abs(u1))
         reference, _ = tree.ravel_pytree(reference)
@@ -2476,7 +2473,6 @@ class error_residual_std(ErrorEstimator):
         error_norm = self.error_norm(error_abs, reference, atol=atol, rtol=rtol)
 
         # Scale the error norm with the error contraction rate and return
-        error_contraction_rate = self.ssm.num_derivatives + 1
         error_power = error_norm ** (-1.0 / error_contraction_rate)
         return error_power, state
 
@@ -2537,6 +2533,8 @@ class error_state_std(ErrorEstimator):
         mean = previous.u.marginals.evaluate_mean()
         rv = self.ssm.conditional.apply(mean, transition)
 
+        mean_leaves = tree.tree_leaves(mean)
+        error_contraction_rate = len(mean_leaves)
         # Optionally: re-linearize
         if self.re_linearize_before_error:
             linearized, state = self.constraint.linearize(
@@ -2573,6 +2571,5 @@ class error_state_std(ErrorEstimator):
         error_norm = self.error_norm(error_abs, reference, atol=atol, rtol=rtol)
 
         # Scale the error norm with the error contraction rate and return
-        error_contraction_rate = self.ssm.num_derivatives + 1
         error_power = error_norm ** (-1.0 / error_contraction_rate)
         return error_power, state

--- a/probdiffeq/probdiffeq.py
+++ b/probdiffeq/probdiffeq.py
@@ -446,7 +446,11 @@ def constraint_jet(
         primals, series = func.jet(jet_call, ps, ss, is_tcoeff=False)
         return [primals, *series]
 
-    order = ssm.num_derivatives + 1 if jet_order == "max" else jet_order + root_order
+    order = (
+        ssm.shape_info.num_derivatives + 1
+        if jet_order == "max"
+        else jet_order + root_order
+    )
     return ssm.linearize.root(
         root_jet, root_order=order, jacobian=jacobian, nlstsq=nlstsq
     )
@@ -540,7 +544,7 @@ def constraint_jet_imex(
         return [primals1, *series1]
 
     if jet_order_explicit == "max" or jet_order_implicit == "max":
-        order = ssm.num_derivatives + 1
+        order = ssm.shape_info.num_derivatives + 1
     else:
         order_ex = root_order_ex + jet_order_explicit
         order_im = root_order_im + jet_order_implicit
@@ -630,7 +634,7 @@ def constraint_jet_dae(
         return [primals, *series]
 
     if jet_order_differential == "max" or jet_order_algebraic == "max":
-        order = ssm.num_derivatives + 1
+        order = ssm.shape_info.num_derivatives + 1
     else:
         order_diff = root_order_diff + jet_order_differential
         order_alg = root_order_alg + jet_order_algebraic
@@ -1345,17 +1349,17 @@ def prior_exponential(
     """
     # TODO: offer a "jacobian" option to enable isotropic and blockdiag implementations?
     prior_order = _verify_ioup_signature_and_parse_order(vf_linear)
-    if prior_order != ssm.num_derivatives + 1:
+    if prior_order != ssm.shape_info.num_derivatives + 1:
         msg = f"""The exponential prior does not match the Taylor coefficients in the SSM.
 
         Concretely:
 
         - For two Taylor coefficients, we expect `f(u, du, /)`.
-        - For three Taylor coefficients, we expect `f(u, du, ddu /)`.
-        - For two Taylor coefficients, we expect `f(u, du, ddu, dddu/)`.
+        - For three Taylor coefficients, we expect `f(u, du, ddu, /)`.
+        - For two Taylor coefficients, we expect `f(u, du, ddu, dddu, /)`.
 
         and so on. The passed dynamics correspond to **{prior_order}** Taylor
-        coefficients, whereas the state-space model includes **{ssm.num_derivatives + 1}**
+        coefficients, whereas the state-space model includes **{ssm.shape_info.num_derivatives + 1}**
         Taylor coeffients.
         """
         raise TypeError(msg)

--- a/probdiffeq/ssm_impl.py
+++ b/probdiffeq/ssm_impl.py
@@ -227,7 +227,7 @@ class AbstractConditional(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def identity(self, ndim, /):
+    def identity(self, /):
         """Construct an identity conditional (unit linop, zero noise)."""
         raise NotImplementedError
 
@@ -258,9 +258,23 @@ class ShapeInfo:
         # TODO: assert that the tree is a tree of Taylor coefficients
         #       (which means each leaf has the same tree structure)
 
-        self.tree_flat, self.tree_unravel = tree.ravel_pytree(tcoeffs)
-        self.leaf_flat, self.leaf_unravel = tree.ravel_pytree(tcoeffs[0])
+        # A flattened representation of the Taylor coefficients
+        self.all_flat, self.all_unravel = tree.ravel_pytree(tcoeffs)
+
+        # A flattened representation of each Taylor coefficient
+        self.single_flat, self.single_unravel = tree.ravel_pytree(tcoeffs[0])
+
+        # The number of derivatives in the SSM
         self.num_derivatives = len(tcoeffs) - 1
+
+        # The leaves in the Taylor coefficients.
+        # Note how each Taylor coefficient can itself be a PyTree,
+        # but the leaves must always be arrays.
+        # This specific info is especially important for blockdiagonal models.
+        # TODO: this somewhat duplicates the above,
+        #       but not enough to prioritise refactoring...
+        self.leaves, self.treedef = tree.tree_flatten(tcoeffs)
+        _, self.leaf_unravel = tree.ravel_pytree(self.leaves[0])
 
 
 @structs.dataclass
@@ -279,8 +293,8 @@ class FactSsmImpl:
     conditional: AbstractConditional
     """An implementation of manipulating conditionals."""
 
-    num_derivatives: int
-    """The number of derivatives in the state-space model."""
+    shape_info: ShapeInfo
+    """Information about Taylor-coefficient shapes/counts/etc.."""
 
     @classmethod
     def from_tcoeffs_dense(cls, tcoeffs_like, /):
@@ -296,74 +310,53 @@ class FactSsmImpl:
             conditional=conditional,
             normal=normal,
             prototypes=prototypes,
-            num_derivatives=len(tcoeffs_like) - 1,
+            shape_info=shape_info,
         )
 
     @classmethod
     def from_tcoeffs_isotropic(cls, tcoeffs_like, /):
         """Construct a factorised state-space model implementation."""
-        ode_shape = tree.ravel_pytree(tcoeffs_like[0])[0].shape
-        num_derivatives = len(tcoeffs_like) - 1
+        shape_info = ShapeInfo(tcoeffs_like)
 
-        tcoeffs_tree_only = tree.tree_map(lambda *_a: 0.0, tcoeffs_like)
-        _, unravel_tree = tree.ravel_pytree(tcoeffs_tree_only)
+        # ode_shape = tree.ravel_pytree(tcoeffs_like[0])[0].shape
+        # num_derivatives = len(tcoeffs_like) - 1
 
-        leaves, tree_structure = tree.tree_flatten(tcoeffs_like)
-        _, unravel_leaf = tree.ravel_pytree(leaves[0])
+        # tcoeffs_tree_only = tree.tree_map(lambda *_a: 0.0, tcoeffs_like)
+        # _, unravel_tree = tree.ravel_pytree(tcoeffs_tree_only)
 
-        def unravel(z):
-            pytree = func.vmap(unravel_tree, in_axes=1, out_axes=0)(z)
-            return tree.tree_map(unravel_leaf, pytree)
+        # leaves, tree_structure = tree.tree_flatten(tcoeffs_like)
+        # _, unravel_leaf = tree.ravel_pytree(leaves[0])
 
-        prototypes = IsotropicPrototype(ode_shape=ode_shape)
+        # def unravel(z):
+        #     pytree = func.vmap(unravel_tree, in_axes=1, out_axes=0)(z)
+        #     return tree.tree_map(unravel_leaf, pytree)
+
+        prototypes = IsotropicPrototype()
         normal = IsotropicNormal
-        linearize = IsotropicLinearizationFactory(unravel=unravel)
-        conditional = IsotropicConditional(
-            ode_shape=ode_shape,
-            num_derivatives=num_derivatives,
-            unravel_tree=unravel_tree,
-            tree_structure=tree_structure,
-        )
+        linearize = IsotropicLinearizationFactory(shape_info=shape_info)
+        conditional = IsotropicConditional(shape_info=shape_info)
         return cls(
             prototypes=prototypes,
             normal=normal,
             linearize=linearize,
             conditional=conditional,
-            num_derivatives=len(tcoeffs_like) - 1,
+            shape_info=shape_info,
         )
 
     @classmethod
     def from_tcoeffs_blockdiag(cls, tcoeffs_like, /):
         """Construct a factorised state-space model implementation."""
-        ode_shape = tree.ravel_pytree(tcoeffs_like[0])[0].shape
-        num_derivatives = len(tcoeffs_like) - 1
-
-        tcoeffs_tree_only = tree.tree_map(lambda *_a: 0.0, tcoeffs_like)
-        _, unravel_tree = tree.ravel_pytree(tcoeffs_tree_only)
-
-        leaves, treedef = tree.tree_flatten(tcoeffs_like)
-        _, unravel_leaf = tree.ravel_pytree(leaves[0])
-
-        def unravel(z):
-            pytree = func.vmap(unravel_tree, in_axes=0, out_axes=0)(z)
-            return tree.tree_map(unravel_leaf, pytree)
-
-        prototypes = BlockDiagPrototype(ode_shape=ode_shape)
+        shape_info = ShapeInfo(tcoeffs_like)
+        prototypes = BlockDiagPrototype(shape_info=shape_info)
         normal = BlockDiagNormal
-        linearize = BlockDiagLinearizationFactory(unravel=unravel)
-        conditional = BlockDiagConditional(
-            ode_shape=ode_shape,
-            num_derivatives=num_derivatives,
-            unravel_tree=unravel_tree,
-            treedef=treedef,
-            unravel_leaf=unravel_leaf,
-        )
+        linearize = BlockDiagLinearizationFactory(shape_info=shape_info)
+        conditional = BlockDiagConditional(shape_info=shape_info)
         return cls(
             prototypes=prototypes,
             normal=normal,
             linearize=linearize,
             conditional=conditional,
-            num_derivatives=len(tcoeffs_like) - 1,
+            shape_info=shape_info,
         )
 
 
@@ -586,14 +579,15 @@ class DenseConditional(AbstractConditional):
         observed = DenseNormal(mean, cholesky, unravel=cond.noise.unravel)
         return observed, cond_new
 
-    def identity(self, ndim, /) -> LatentCond:
-        (d,) = self.shape_info.leaf_flat.shape
+    def identity(self, /) -> LatentCond:
+        ndim = self.shape_info.num_derivatives + 1
+        (d,) = self.shape_info.single_flat.shape
         n = ndim * d
 
         A = np.eye(n)
         m = np.zeros((n,))
         C = np.zeros((n, n))
-        noise = DenseNormal(m, C, unravel=self.shape_info.tree_unravel)
+        noise = DenseNormal(m, C, unravel=self.shape_info.all_unravel)
         ones = np.ones((n,))
         return LatentCond(A, noise, to_latent=ones, to_observed=ones)
 
@@ -602,13 +596,13 @@ class DenseConditional(AbstractConditional):
 
         # Construct the transitions
         a, q_sqrtm = system_matrices_1d_iwp(self.shape_info.num_derivatives)
-        (d,) = self.shape_info.leaf_flat.shape
+        (d,) = self.shape_info.single_flat.shape
 
         eye_d = np.eye(d)
         A = np.kron(a, eye_d)
         Q = np.kron(q_sqrtm, Lambda)
 
-        q0 = np.zeros(self.shape_info.tree_flat.shape)
+        q0 = np.zeros(self.shape_info.all_flat.shape)
         precon_fun = preconditioner_taylor(
             num_derivatives=self.shape_info.num_derivatives
         )
@@ -620,7 +614,7 @@ class DenseConditional(AbstractConditional):
             p = np.repeat(p, d)
             p_inv = np.repeat(p_inv, d)
 
-            unravel = self.shape_info.tree_unravel
+            unravel = self.shape_info.all_unravel
             noise = DenseNormal(q0, output_scale * Q, unravel=unravel)
             return LatentCond(A, noise, to_latent=p_inv, to_observed=p)
 
@@ -628,8 +622,8 @@ class DenseConditional(AbstractConditional):
 
     def _process_base_scale(self, base_scale):
         # Process the expected shape of the base-scale
-        ones_like = np.ones_like(self.shape_info.leaf_flat)
-        base_scale_expected = self.shape_info.leaf_unravel(ones_like)
+        ones_like = np.ones_like(self.shape_info.single_flat)
+        base_scale_expected = self.shape_info.single_unravel(ones_like)
 
         if base_scale is None:
             base_scale = base_scale_expected
@@ -658,11 +652,11 @@ class DenseConditional(AbstractConditional):
         Lambda = self._process_base_scale(base_scale)
 
         # Turn the linear vector field into the bottom block of the IOUP
-        leaf_like = np.ones_like(self.shape_info.leaf_flat)
+        leaf_like = np.ones_like(self.shape_info.single_flat)
         leaves = [leaf_like for _ in range(self.shape_info.num_derivatives + 1)]
 
         def vf_flat(tcoeffs):
-            tcoeffs_tree = tree.tree_map(self.shape_info.leaf_unravel, tcoeffs)
+            tcoeffs_tree = tree.tree_map(self.shape_info.single_unravel, tcoeffs)
             fx = vf_linear(*tcoeffs_tree)
             return tree.ravel_pytree(fx)[0]
 
@@ -670,7 +664,7 @@ class DenseConditional(AbstractConditional):
         bottom_block = np.concatenate(rate, axis=-1)
 
         # Construct the SDE matrices
-        (d,) = self.shape_info.leaf_flat.shape
+        (d,) = self.shape_info.single_flat.shape
         num_derivatives = self.shape_info.num_derivatives
         eye_d = np.eye(d)
         a = linalg.diagonal_matrix(np.ones((num_derivatives,)), k=1)
@@ -693,7 +687,7 @@ class DenseConditional(AbstractConditional):
         exp_gram = gram_util.exp_gram_cholesky(
             pade_legendre=pade_legendre, solve=linalg.solve_lu
         )
-        q0 = np.zeros(self.shape_info.tree_flat.shape)
+        q0 = np.zeros(self.shape_info.all_flat.shape)
 
         def discretise(dt, output_scale=1.0):
             output_scale = self._process_calibrated_scale(output_scale)
@@ -707,7 +701,7 @@ class DenseConditional(AbstractConditional):
             B_p = np.sqrt(dt) * p_inv[:, None] * B
 
             eA, L = exp_gram(A_p, B_p)
-            unravel = self.shape_info.tree_unravel
+            unravel = self.shape_info.all_unravel
             noise = DenseNormal(q0, output_scale * L, unravel=unravel)
             return LatentCond(eA, noise, to_latent=p_inv, to_observed=p)
 
@@ -748,10 +742,10 @@ class DenseLinearizationOdeTs0(AbstractLinearizationOde):
 
         def a1(m):
             """Select the 'n'-th derivative."""
-            m0 = self.shape_info.tree_unravel(m)[self.ode_order]
+            m0 = self.shape_info.all_unravel(m)[self.ode_order]
             return tree.ravel_pytree(m0)[0]
 
-        Ms = self.shape_info.tree_unravel(rv.mean)
+        Ms = self.shape_info.all_unravel(rv.mean)
         fm = fun(*Ms[: self.ode_order])
         fx, unravel = tree.ravel_pytree(fm)
         linop = func.jacrev(a1)(rv.mean)
@@ -782,7 +776,7 @@ class DenseLinearizationOdeTs1(AbstractLinearizationOde):
 
     def linearize(self, rv, state: None, *, damp: float, t):
         fun = func.partial(self.vector_field, t=t)
-        m_tree = self.shape_info.tree_unravel(rv.mean)
+        m_tree = self.shape_info.all_unravel(rv.mean)
         m0, unravel = tree.ravel_pytree(m_tree[0])
 
         def vf_flat(s):
@@ -792,7 +786,7 @@ class DenseLinearizationOdeTs1(AbstractLinearizationOde):
 
         def select_i(i):
             def select(s):
-                s_tree = self.shape_info.tree_unravel(s)
+                s_tree = self.shape_info.all_unravel(s)
                 s_flat, _ = tree.ravel_pytree(s_tree[i])
                 return s_flat
 
@@ -825,7 +819,7 @@ class DenseLinearizationRoot(AbstractLinearizationRoot):
     def constraint_flat(self, m: Array, *, t) -> Array:
         """Evaluate a flattened version of the root constraint."""
         # Unravel the location and extract derivatives
-        m_tree = self.shape_info.tree_unravel(m)
+        m_tree = self.shape_info.all_unravel(m)
         relevant_tcoeffs = m_tree[: self.root_order]
 
         # Evaluate the root
@@ -845,7 +839,7 @@ class DenseLinearizationRoot(AbstractLinearizationRoot):
         fx = fx - linop @ mean
 
         # Understand how to unravel
-        m_tree = func.eval_shape(self.shape_info.tree_unravel, rv.mean)
+        m_tree = func.eval_shape(self.shape_info.all_unravel, rv.mean)
         relevant_tcoeffs = m_tree[: self.root_order]
         root_eval = func.eval_shape(lambda s: self.root(*s, t=t), relevant_tcoeffs)
         root_eval = tree.tree_map(np.zeros_like, root_eval)
@@ -860,9 +854,9 @@ class DenseLinearizationRoot(AbstractLinearizationRoot):
 class IsotropicLinearizationOdeTs0(AbstractLinearizationOde):
     """Construct an isotropic implementation of ODE-TS0 linearization."""
 
-    def __init__(self, vf, *, ode_order, unravel) -> None:
+    def __init__(self, vf, *, ode_order, shape_info) -> None:
         super().__init__(vf, ode_order=ode_order)
-        self.unravel = unravel
+        self.shape_info = shape_info
 
     @property
     def root_order(self):
@@ -876,8 +870,11 @@ class IsotropicLinearizationOdeTs0(AbstractLinearizationOde):
         fun = func.partial(self.vector_field, t=t)
         mean = rv.mean
 
-        mean_tree = self.unravel(mean)
-        m1 = mean_tree[: self.ode_order]
+        m1 = [*(mean[: self.ode_order])]
+        m1 = tree.tree_map(self.shape_info.single_unravel, m1)
+
+        # mean_tree = self.unravel(mean)
+        # m1 = mean_tree[: self.ode_order]
         fx_tree = fun(*m1)
         fx, unravel_obs = tree.ravel_pytree(fx_tree)
 
@@ -893,13 +890,13 @@ class IsotropicLinearizationOdeTs0(AbstractLinearizationOde):
 class IsotropicLinearizationOdeTs1(AbstractLinearizationOde):
     """Construct an isotropic implementation of ODE-TS1 linearization."""
 
-    def __init__(self, vf, *, ode_order: int, unravel: Callable, jacobian: Any) -> None:
+    def __init__(self, vf, *, ode_order: int, shape_info, jacobian: Any) -> None:
         if ode_order > 1:
             msg = "This linearization is not compatible with high-order ODEs as of yet."
             raise ValueError(msg)
         super().__init__(vf, ode_order=1)
 
-        self.unravel = unravel
+        self.shape_info = shape_info
         self.jacobian = jacobian
 
     def init_linearization(self):
@@ -908,10 +905,12 @@ class IsotropicLinearizationOdeTs1(AbstractLinearizationOde):
     def linearize(self, rv, state, *, damp: float, t):
         fun = func.partial(self.vector_field, t=t)
         # Evaluate the linearisation
-        m0, unravel = tree.ravel_pytree(self.unravel(rv.mean)[0])
+        m0 = rv.mean[0]
 
         def vf_ravel(s):
-            return tree.ravel_pytree(fun(unravel(s)))[0]
+            s_tree = self.shape_info.single_unravel(s)
+            fs = fun(s_tree)
+            return tree.ravel_pytree(fs)[0]
 
         # Estimate the trace using Hutchinson's estimator
         fx, J_trace, state = self.jacobian.calculate_trace(vf_ravel, m0, state)
@@ -924,7 +923,7 @@ class IsotropicLinearizationOdeTs1(AbstractLinearizationOde):
         fx = fx - linop @ rv.mean
 
         # Turn fx and J_trace into an observation model
-        vf_dummy = func.eval_shape(lambda s: fun(unravel(s)), m0)
+        vf_dummy = func.eval_shape(lambda s: fun(self.shape_info.single_unravel(s)), m0)
         _, structure = tree.tree_flatten(vf_dummy)
         fx = tree.tree_unflatten(structure, [*fx])
         noise = IsotropicNormal.from_dirac(fx, damp=damp)
@@ -935,9 +934,8 @@ class IsotropicLinearizationOdeTs1(AbstractLinearizationOde):
 class BlockDiagLinearizationOdeTs0(AbstractLinearizationOde):
     """Construct a block-diagonal implementation of ODE-TS0 linearization."""
 
-    def __init__(self, vf, *, ode_order: int, unravel: Callable) -> None:
+    def __init__(self, vf, *, ode_order: int) -> None:
         super().__init__(vf, ode_order=ode_order)
-        self.unravel = unravel
 
     def init_linearization(self) -> None:
         return None
@@ -962,12 +960,12 @@ class BlockDiagLinearizationOdeTs0(AbstractLinearizationOde):
 class BlockDiagLinearizationOdeTs1(AbstractLinearizationOde):
     """Construct a block-diagonal implementation of ODE-TS1 linearization."""
 
-    def __init__(self, vf, *, ode_order: int, unravel: Callable, jacobian: Any) -> None:
+    def __init__(self, vf, *, ode_order: int, shape_info, jacobian: Any) -> None:
         if ode_order > 1:
             msg = "This linearization is not compatible with high-order ODEs as of yet."
             raise ValueError(msg)
         super().__init__(vf, ode_order=1)
-        self.unravel = unravel
+        self.shape_info = shape_info
         self.jacobian = jacobian
 
     def init_linearization(self):
@@ -983,13 +981,15 @@ class BlockDiagLinearizationOdeTs1(AbstractLinearizationOde):
         linop = func.vmap(func.jacrev(a1))(mean)
 
         def vf_flat(u):
-            return tree.ravel_pytree(fun(unravel(u)))[0]
+            u_tree = self.shape_info.single_unravel(u)
+            fu_tree = fun(u_tree)
+            return tree.ravel_pytree(fu_tree)[0]
 
         def select_0(s):
-            return tree.ravel_pytree(self.unravel(s)[0])
+            return s[:, 0]
 
         # Evaluate the linearisation
-        m0, unravel = select_0(rv.mean)
+        m0 = select_0(rv.mean)
         fx, J_diag, state = self.jacobian.calculate_diagonal(vf_flat, m0, state)
 
         E1 = func.jacrev(lambda s: s[0])(rv.mean[0])
@@ -1008,53 +1008,46 @@ class BlockDiagLinearizationOdeTs1(AbstractLinearizationOde):
 class IsotropicLinearizationFactory(AbstractLinearizationFactory):
     """Construct an isotropic linearization-factory."""
 
-    def __init__(self, unravel) -> None:
-        self.unravel = unravel
+    def __init__(self, shape_info) -> None:
+        self.shape_info = shape_info
 
     def root(self, root, *, jacobian, root_order: int, nlstsq: Callable | None):
         raise NotImplementedError
 
     def ode_taylor_1st(self, vf, *, ode_order, jacobian):
         return IsotropicLinearizationOdeTs1(
-            vf, jacobian=jacobian, ode_order=ode_order, unravel=self.unravel
+            vf, jacobian=jacobian, ode_order=ode_order, shape_info=self.shape_info
         )
 
     def ode_taylor_0th(self, vf, *, ode_order):
         return IsotropicLinearizationOdeTs0(
-            vf, ode_order=ode_order, unravel=self.unravel
+            vf, ode_order=ode_order, shape_info=self.shape_info
         )
 
 
 class BlockDiagLinearizationFactory(AbstractLinearizationFactory):
     """Construct a block-diagonal linearization-factory."""
 
-    def __init__(self, unravel) -> None:
-        self.unravel = unravel
+    def __init__(self, shape_info) -> None:
+        self.shape_info = shape_info
 
     def root(self, root, *, jacobian, root_order: int, nlstsq: Callable | None):
         raise NotImplementedError
 
     def ode_taylor_0th(self, vf, *, ode_order):
-        return BlockDiagLinearizationOdeTs0(
-            vf, ode_order=ode_order, unravel=self.unravel
-        )
+        return BlockDiagLinearizationOdeTs0(vf, ode_order=ode_order)
 
     def ode_taylor_1st(self, vf, *, ode_order, jacobian):
         return BlockDiagLinearizationOdeTs1(
-            vf, ode_order=ode_order, unravel=self.unravel, jacobian=jacobian
+            vf, ode_order=ode_order, shape_info=self.shape_info, jacobian=jacobian
         )
 
 
 class IsotropicConditional(AbstractConditional):
     """Construct an isotropic implementation of manipulating conditionals."""
 
-    def __init__(
-        self, *, ode_shape, num_derivatives, unravel_tree, tree_structure
-    ) -> None:
-        self.ode_shape = ode_shape
-        self.num_derivatives = num_derivatives
-        self.unravel_tree = unravel_tree
-        self.tree_structure = tree_structure
+    def __init__(self, *, shape_info) -> None:
+        self.shape_info = shape_info
 
     def apply(self, x, cond, /):
         leaves = tree.tree_leaves(x)
@@ -1127,10 +1120,12 @@ class IsotropicConditional(AbstractConditional):
         observed = IsotropicNormal(mean, cholesky, treedef=cond.noise.treedef)
         return observed, cond_new
 
-    def identity(self, num, /) -> LatentCond:
-        m0 = np.zeros((num, *self.ode_shape))
+    def identity(self, /) -> LatentCond:
+        num = self.shape_info.num_derivatives + 1
+        (d,) = self.shape_info.single_flat.shape
+        m0 = np.zeros((num, d))
         c0 = np.zeros((num, num))
-        noise = IsotropicNormal(m0, c0, treedef=self.tree_structure)
+        noise = IsotropicNormal(m0, c0, treedef=self.shape_info.treedef)
         matrix = np.eye(num)
         ones = np.ones((num,))
         return LatentCond(matrix, noise, to_latent=ones, to_observed=ones)
@@ -1147,9 +1142,11 @@ class IsotropicConditional(AbstractConditional):
                 msg += f" Received: {base_scale.shape}."
                 raise ValueError(msg)
 
-        A, q_sqrtm = system_matrices_1d_iwp(self.num_derivatives)
-        q0 = np.zeros((self.num_derivatives + 1, *self.ode_shape))
-        precon_fun = preconditioner_taylor(num_derivatives=self.num_derivatives)
+        num_derivatives = self.shape_info.num_derivatives
+        (d,) = self.shape_info.single_flat.shape
+        A, q_sqrtm = system_matrices_1d_iwp(num_derivatives)
+        q0 = np.zeros((num_derivatives + 1, d))
+        precon_fun = preconditioner_taylor(num_derivatives=num_derivatives)
 
         def discretise(dt, output_scale: Array = 1.0):
             output_scale = np.asarray(output_scale)
@@ -1162,7 +1159,9 @@ class IsotropicConditional(AbstractConditional):
             scale = base_scale * output_scale
 
             p, p_inv = precon_fun(dt)
-            noise = IsotropicNormal(q0, scale * q_sqrtm, treedef=self.tree_structure)
+            noise = IsotropicNormal(
+                q0, scale * q_sqrtm, treedef=self.shape_info.treedef
+            )
             return LatentCond(A, noise, to_latent=p_inv, to_observed=p)
 
         return discretise
@@ -1199,14 +1198,8 @@ class IsotropicConditional(AbstractConditional):
 class BlockDiagConditional(AbstractConditional):
     """Construct a block-diagonal implementation of manipulating conditionals."""
 
-    def __init__(
-        self, *, ode_shape, num_derivatives, unravel_tree, treedef, unravel_leaf
-    ) -> None:
-        self.ode_shape = ode_shape
-        self.num_derivatives = num_derivatives
-        self.unravel_tree = unravel_tree
-        self.treedef = treedef
-        self.unravel_leaf = unravel_leaf
+    def __init__(self, *, shape_info) -> None:
+        self.shape_info = shape_info
 
     def apply(self, x, cond, /):
         leaves = tree.tree_leaves(x)
@@ -1322,18 +1315,24 @@ class BlockDiagConditional(AbstractConditional):
         )
         return observed, bwd
 
-    def identity(self, ndim, /) -> LatentCond:
-        m0 = np.zeros((*self.ode_shape, ndim))
-        c0 = np.zeros((*self.ode_shape, ndim, ndim))
+    def identity(self, /) -> LatentCond:
+        ndim = self.shape_info.num_derivatives + 1
+        (d,) = self.shape_info.single_flat.shape
+        m0 = np.zeros((d, ndim))
+        c0 = np.zeros((d, ndim, ndim))
         noise = BlockDiagNormal(
-            m0, c0, treedef=self.treedef, unravel_leaf=self.unravel_leaf
+            m0,
+            c0,
+            treedef=self.shape_info.treedef,
+            unravel_leaf=self.shape_info.leaf_unravel,
         )
-        matrix = np.ones((*self.ode_shape, 1, 1)) * np.eye(ndim, ndim)[None, ...]
+        matrix = np.ones((d, 1, 1)) * np.eye(ndim, ndim)[None, ...]
         return LatentCond.from_linop_and_noise(matrix, noise)
 
     def transition_wiener_integrated(self, base_scale: Array | None):
 
-        base_scale_expected = self.unravel_leaf(np.ones(self.ode_shape))
+        coeff_like = np.ones_like(self.shape_info.single_flat)
+        base_scale_expected = self.shape_info.single_unravel(coeff_like)
         if base_scale is None:
             base_scale = base_scale_expected
         else:
@@ -1345,9 +1344,10 @@ class BlockDiagConditional(AbstractConditional):
 
         base_scale, _ = tree.ravel_pytree(base_scale)
 
-        a, q_sqrtm = system_matrices_1d_iwp(self.num_derivatives)
-        q0 = np.zeros((self.num_derivatives + 1,))
-        precon_fun = preconditioner_taylor(num_derivatives=self.num_derivatives)
+        num_derivatives = self.shape_info.num_derivatives
+        a, q_sqrtm = system_matrices_1d_iwp(num_derivatives)
+        q0 = np.zeros((num_derivatives + 1,))
+        precon_fun = preconditioner_taylor(num_derivatives=num_derivatives)
 
         def discretise(dt, output_scale: Array | None = None):
             p, p_inv = precon_fun(dt)
@@ -1370,8 +1370,10 @@ class BlockDiagConditional(AbstractConditional):
             A_batch = np.ones((d, 1, 1)) * a[None, :, :]
             mean = np.ones((d, 1)) * q0[None, :]
             cholesky = scale[:, None, None] * q_sqrtm[None, :, :]
+            treedef = self.shape_info.treedef
+            unravel_leaf = self.shape_info.leaf_unravel
             noise = BlockDiagNormal(
-                mean, cholesky, treedef=self.treedef, unravel_leaf=self.unravel_leaf
+                mean, cholesky, treedef=treedef, unravel_leaf=unravel_leaf
             )
             p = np.ones((d, 1)) * p[None, :]
             p_inv = np.ones((d, 1)) * p_inv[None, :]
@@ -1602,7 +1604,13 @@ class BlockDiagNormal(AbstractTreeNormal):
     def __init__(self, mean, cholesky, treedef, unravel_leaf) -> None:
         super().__init__(mean=mean)
         self.cholesky = cholesky
+
+        # The treedef of the target
         self.treedef = treedef
+
+        # A map that unravels each leaf. Note that this is not the same
+        # as unravelling each Taylor coefficient, because the Taylor coefficients
+        # themselves can be pytrees, whereas the leaves are always arrays.
         self.unravel_leaf = unravel_leaf
 
     def __repr__(self) -> str:
@@ -1654,7 +1662,9 @@ class BlockDiagNormal(AbstractTreeNormal):
     def evaluate_mean(self):
         if self.mean.ndim > 2:
             return func.vmap(BlockDiagNormal.evaluate_mean)(self)
-        mean_tree = tree.tree_unflatten(self.treedef, [*(self.mean.T)])
+
+        mean_leaves = [*(self.mean.T)]
+        mean_tree = tree.tree_unflatten(self.treedef, mean_leaves)
         return tree.tree_map(self.unravel_leaf, mean_tree)
 
     def evaluate_std(self):
@@ -1757,9 +1767,6 @@ BlockDiagNormal.register_pytree_node()
 class IsotropicPrototype(AbstractPrototype):
     """Construct an isotropic implementation of prototypes."""
 
-    def __init__(self, ode_shape) -> None:
-        self.ode_shape = ode_shape
-
     def std(self):
         return np.ones(())
 
@@ -1770,11 +1777,15 @@ class IsotropicPrototype(AbstractPrototype):
 class BlockDiagPrototype(AbstractPrototype):
     """Construct a block-diagonal implementation of prototypes."""
 
-    def __init__(self, ode_shape) -> None:
-        self.ode_shape = ode_shape
+    def __init__(self, shape_info) -> None:
+        self.shape_info = shape_info
 
     def std(self):
-        return np.ones(self.ode_shape)
+        # TODO: technically, these should be pytrees according
+        # to the leaf structure, right?
+        return np.ones(self.shape_info.single_flat.shape)
 
     def output_scale_calibrated(self):
-        return np.ones(self.ode_shape)
+        # TODO: technically, these should be pytrees according
+        # to the leaf structure, right?
+        return np.ones(self.shape_info.single_flat.shape)

--- a/probdiffeq/ssm_impl.py
+++ b/probdiffeq/ssm_impl.py
@@ -367,7 +367,7 @@ class DensePrototype(AbstractPrototype):
         self.shape_info = shape_info
 
     def std(self):
-        return np.ones(self.shape_info.shape_leaf_flat)
+        return np.ones(self.shape_info.single_flat.shape)
 
     def output_scale_calibrated(self):
         return np.ones(())
@@ -711,17 +711,17 @@ class DenseConditional(AbstractConditional):
         A = cond.to_observed[:, None] * cond.A * cond.to_latent[None, :]
         mean = cond.to_observed * cond.noise.mean
         cholesky = cond.to_observed[:, None] * cond.noise.cholesky
-        noise = DenseNormal(mean, cholesky, unravel=self.unravel)
+        noise = DenseNormal(mean, cholesky, unravel=self.shape_info.all_unravel)
         return LatentCond.from_linop_and_noise(A, noise)
 
     def to_derivative(self, i, std):
         def select(a):
-            return tree.ravel_pytree(self.unravel(a)[i])[0]
+            return tree.ravel_pytree(self.shape_info.all_unravel(a)[i])[0]
 
-        x = np.zeros(self.flat_shape)
+        x = np.zeros(self.shape_info.all_flat.shape)
         linop = func.jacfwd(select)(x)
 
-        data_like = self.unravel(x)[0]
+        data_like = self.shape_info.all_unravel(x)[0]
         noise = DenseNormal.from_mean_and_std(data_like, std)
         return LatentCond.from_linop_and_noise(linop, noise)
 
@@ -1177,17 +1177,15 @@ class IsotropicConditional(AbstractConditional):
         A = cond.to_observed[:, None] * cond.A * cond.to_latent[None, :]
         mean = cond.to_observed[:, None] * cond.noise.mean
         cholesky = cond.to_observed[:, None] * cond.noise.cholesky
-        noise = IsotropicNormal(mean, cholesky, treedef=self.tree_structure)
+        noise = IsotropicNormal(mean, cholesky, treedef=self.shape_info.treedef)
         return LatentCond.from_linop_and_noise(A, noise)
 
     def to_derivative(self, i, std):
 
-        def select(a):
-            return tree.ravel_pytree(self.unravel_tree(a)[i])[0]
+        m = np.zeros((self.shape_info.num_derivatives + 1,))
+        linop = func.jacfwd(lambda s: np.asarray([s[i]]))(m)
 
-        m = np.zeros((self.num_derivatives + 1,))
-        linop = func.jacfwd(select)(m)
-        u_like = self.unravel_tree(m)[0]
+        u_like = tree.tree_unflatten(self.shape_info.treedef, m)[0]
 
         # Wrap u_like and std into a list because the random variable
         # expects TaylorCoefficients.
@@ -1393,7 +1391,10 @@ class BlockDiagConditional(AbstractConditional):
         mean = cond.to_observed * cond.noise.mean
         cholesky = cond.to_observed[:, :, None] * cond.noise.cholesky
         noise = BlockDiagNormal(
-            mean, cholesky, treedef=self.treedef, unravel_leaf=self.unravel_leaf
+            mean,
+            cholesky,
+            treedef=self.shape_info.treedef,
+            unravel_leaf=self.shape_info.leaf_unravel,
         )
         to_observed = np.ones_like(cond.to_observed)
         to_latent = np.ones_like(cond.to_latent)
@@ -1402,13 +1403,15 @@ class BlockDiagConditional(AbstractConditional):
     def to_derivative(self, i, std):
 
         def select(a):
-            return tree.ravel_pytree(self.unravel_tree(a)[i])[0]
+            return np.asarray([a[i]])
 
-        x = np.zeros((*self.ode_shape, self.num_derivatives + 1))
+        (d,) = self.shape_info.single_flat.shape
+        n = self.shape_info.num_derivatives + 1
+        x = np.zeros((d, n))
         linop = func.vmap(func.jacrev(select))(x)
 
-        u_like = tree.tree_unflatten(self.treedef, x.T)
-        u_like = tree.tree_map(self.unravel_leaf, u_like)
+        u_like = tree.tree_unflatten(self.shape_info.treedef, x.T)
+        u_like = tree.tree_map(self.shape_info.leaf_unravel, u_like)
         u_like = tree.tree_map(np.zeros_like, u_like[0])
         noise = BlockDiagNormal.from_mean_and_std(u_like, std)
         return LatentCond.from_linop_and_noise(linop, noise)

--- a/probdiffeq/ssm_impl.py
+++ b/probdiffeq/ssm_impl.py
@@ -258,14 +258,13 @@ class ShapeInfo:
         # TODO: assert that the tree is a tree of Taylor coefficients
         #       (which means each leaf has the same tree structure)
 
+        # TODO: don't store the arrays but only the shape and dtype
+
         # A flattened representation of the Taylor coefficients
         self.all_flat, self.all_unravel = tree.ravel_pytree(tcoeffs)
 
         # A flattened representation of each Taylor coefficient
         self.single_flat, self.single_unravel = tree.ravel_pytree(tcoeffs[0])
-
-        # The number of derivatives in the SSM
-        self.num_derivatives = len(tcoeffs) - 1
 
         # The leaves in the Taylor coefficients.
         # Note how each Taylor coefficient can itself be a PyTree,
@@ -275,6 +274,11 @@ class ShapeInfo:
         #       but not enough to prioritise refactoring...
         self.leaves, self.treedef = tree.tree_flatten(tcoeffs)
         _, self.leaf_unravel = tree.ravel_pytree(self.leaves[0])
+
+    @property
+    def num_derivatives(self):
+        """The number of derivatives in the SSM."""
+        return len(self.leaves) - 1
 
 
 @structs.dataclass

--- a/probdiffeq/ssm_impl.py
+++ b/probdiffeq/ssm_impl.py
@@ -251,6 +251,18 @@ class AbstractConditional(abc.ABC):
         raise NotImplementedError
 
 
+class ShapeInfo:
+    """Information about shapes of Taylor coefficients (lengths, sizes, etc.)."""
+
+    def __init__(self, tcoeffs: Sequence, /):
+        # TODO: assert that the tree is a tree of Taylor coefficients
+        #       (which means each leaf has the same tree structure)
+
+        self.tree_flat, self.tree_unravel = tree.ravel_pytree(tcoeffs)
+        self.leaf_flat, self.leaf_unravel = tree.ravel_pytree(tcoeffs[0])
+        self.num_derivatives = len(tcoeffs) - 1
+
+
 @structs.dataclass
 class FactSsmImpl:
     """Implementation of factorized Markovian state-space models."""
@@ -273,20 +285,12 @@ class FactSsmImpl:
     @classmethod
     def from_tcoeffs_dense(cls, tcoeffs_like, /):
         """Construct a factorised state-space model implementation."""
-        ode_shape = tree.ravel_pytree(tcoeffs_like[0])[0].shape
-        flat, unravel = tree.ravel_pytree(tcoeffs_like)
+        shape_info = ShapeInfo(tcoeffs_like)
 
-        num_derivatives = len(tcoeffs_like) - 1
-
-        prototypes = DensePrototype(ode_shape=ode_shape)
+        prototypes = DensePrototype(shape_info=shape_info)
         normal = DenseNormal
-        linearize = DenseLinearizationFactory(ode_shape=ode_shape, unravel=unravel)
-        conditional = DenseConditional(
-            ode_shape=ode_shape,
-            num_derivatives=num_derivatives,
-            unravel=unravel,
-            flat_shape=flat.shape,
-        )
+        linearize = DenseLinearizationFactory(shape_info=shape_info)
+        conditional = DenseConditional(shape_info=shape_info)
         return cls(
             linearize=linearize,
             conditional=conditional,
@@ -366,11 +370,11 @@ class FactSsmImpl:
 class DensePrototype(AbstractPrototype):
     """Construct a dense implementation of prototypes."""
 
-    def __init__(self, ode_shape) -> None:
-        self.ode_shape = ode_shape
+    def __init__(self, shape_info) -> None:
+        self.shape_info = shape_info
 
     def std(self):
-        return np.ones(self.ode_shape)
+        return np.ones(self.shape_info.shape_leaf_flat)
 
     def output_scale_calibrated(self):
         return np.ones(())
@@ -478,14 +482,13 @@ class DenseNormal(AbstractTreeNormal):
 class DenseLinearizationFactory(AbstractLinearizationFactory):
     """Construct a dense linearization factory."""
 
-    def __init__(self, ode_shape, unravel) -> None:
-        self.ode_shape = ode_shape
-        self.unravel = unravel
+    def __init__(self, shape_info) -> None:
+        self.shape_info = shape_info
 
     def root(self, root, *, jacobian, root_order: int, nlstsq: bool):
         return DenseLinearizationRoot(
             root,
-            unravel=self.unravel,
+            shape_info=self.shape_info,
             jacobian=jacobian,
             root_order=root_order,
             nlstsq=nlstsq,
@@ -493,7 +496,7 @@ class DenseLinearizationFactory(AbstractLinearizationFactory):
 
     def ode_taylor_0th(self, vf, *, ode_order):
         return DenseLinearizationOdeTs0(
-            vf, ode_order=ode_order, ode_shape=self.ode_shape, unravel=self.unravel
+            vf, ode_order=ode_order, shape_info=self.shape_info
         )
 
     def ode_taylor_1st(self, vf, *, ode_order, jacobian):
@@ -501,22 +504,15 @@ class DenseLinearizationFactory(AbstractLinearizationFactory):
             raise ValueError
 
         return DenseLinearizationOdeTs1(
-            vf,
-            ode_order=ode_order,
-            ode_shape=self.ode_shape,
-            unravel=self.unravel,
-            jacobian=jacobian,
+            vf, ode_order=ode_order, shape_info=self.shape_info, jacobian=jacobian
         )
 
 
 class DenseConditional(AbstractConditional):
     """Construct a dense implementation of manipulating conditionals."""
 
-    def __init__(self, ode_shape, num_derivatives, unravel, flat_shape) -> None:
-        self.ode_shape = ode_shape
-        self.num_derivatives = num_derivatives
-        self.unravel = unravel
-        self.flat_shape = flat_shape
+    def __init__(self, shape_info) -> None:
+        self.shape_info = shape_info
 
     def apply(self, x, cond, /):
 
@@ -591,13 +587,13 @@ class DenseConditional(AbstractConditional):
         return observed, cond_new
 
     def identity(self, ndim, /) -> LatentCond:
-        (d,) = self.ode_shape
+        (d,) = self.shape_info.leaf_flat.shape
         n = ndim * d
 
         A = np.eye(n)
         m = np.zeros((n,))
         C = np.zeros((n, n))
-        noise = DenseNormal(m, C, unravel=self.unravel)
+        noise = DenseNormal(m, C, unravel=self.shape_info.tree_unravel)
         ones = np.ones((n,))
         return LatentCond(A, noise, to_latent=ones, to_observed=ones)
 
@@ -605,15 +601,17 @@ class DenseConditional(AbstractConditional):
         Lambda = self._process_base_scale(base_scale)
 
         # Construct the transitions
-        a, q_sqrtm = system_matrices_1d_iwp(self.num_derivatives)
-        (d,) = self.ode_shape
+        a, q_sqrtm = system_matrices_1d_iwp(self.shape_info.num_derivatives)
+        (d,) = self.shape_info.leaf_flat.shape
 
         eye_d = np.eye(d)
         A = np.kron(a, eye_d)
         Q = np.kron(q_sqrtm, Lambda)
 
-        q0 = np.zeros(self.flat_shape)
-        precon_fun = preconditioner_taylor(num_derivatives=self.num_derivatives)
+        q0 = np.zeros(self.shape_info.tree_flat.shape)
+        precon_fun = preconditioner_taylor(
+            num_derivatives=self.shape_info.num_derivatives
+        )
 
         def discretise(dt, output_scale=1.0):
             output_scale = self._process_calibrated_scale(output_scale)
@@ -622,14 +620,17 @@ class DenseConditional(AbstractConditional):
             p = np.repeat(p, d)
             p_inv = np.repeat(p_inv, d)
 
-            noise = DenseNormal(q0, output_scale * Q, unravel=self.unravel)
+            unravel = self.shape_info.tree_unravel
+            noise = DenseNormal(q0, output_scale * Q, unravel=unravel)
             return LatentCond(A, noise, to_latent=p_inv, to_observed=p)
 
         return discretise
 
     def _process_base_scale(self, base_scale):
         # Process the expected shape of the base-scale
-        base_scale_expected = self.unravel(np.ones(self.flat_shape))[0]
+        ones_like = np.ones_like(self.shape_info.leaf_flat)
+        base_scale_expected = self.shape_info.leaf_unravel(ones_like)
+
         if base_scale is None:
             base_scale = base_scale_expected
         else:
@@ -657,14 +658,11 @@ class DenseConditional(AbstractConditional):
         Lambda = self._process_base_scale(base_scale)
 
         # Turn the linear vector field into the bottom block of the IOUP
-
-        leaf_like, unravel = tree.ravel_pytree(
-            self.unravel(np.ones(self.flat_shape))[0]
-        )
-        leaves = [leaf_like for _ in range(self.num_derivatives + 1)]
+        leaf_like = np.ones_like(self.shape_info.leaf_flat)
+        leaves = [leaf_like for _ in range(self.shape_info.num_derivatives + 1)]
 
         def vf_flat(tcoeffs):
-            tcoeffs_tree = tree.tree_map(unravel, tcoeffs)
+            tcoeffs_tree = tree.tree_map(self.shape_info.leaf_unravel, tcoeffs)
             fx = vf_linear(*tcoeffs_tree)
             return tree.ravel_pytree(fx)[0]
 
@@ -672,16 +670,17 @@ class DenseConditional(AbstractConditional):
         bottom_block = np.concatenate(rate, axis=-1)
 
         # Construct the SDE matrices
-        (d,) = self.ode_shape
+        (d,) = self.shape_info.leaf_flat.shape
+        num_derivatives = self.shape_info.num_derivatives
         eye_d = np.eye(d)
-        a = linalg.diagonal_matrix(np.ones((self.num_derivatives,)), k=1)
+        a = linalg.diagonal_matrix(np.ones((num_derivatives,)), k=1)
         A = np.kron(a, eye_d)
         A = A.at[-d:, :].set(bottom_block)
 
-        b = np.eye(self.num_derivatives + 1)[-1][:, None]
+        b = np.eye(num_derivatives + 1)[-1][:, None]
         B = np.kron(b, Lambda)
 
-        precon_fun = preconditioner_taylor(num_derivatives=self.num_derivatives)
+        precon_fun = preconditioner_taylor(num_derivatives=num_derivatives)
 
         # TODO: find a good default. Always using high orders seems wasteful.
         pade_legendre = (
@@ -694,7 +693,7 @@ class DenseConditional(AbstractConditional):
         exp_gram = gram_util.exp_gram_cholesky(
             pade_legendre=pade_legendre, solve=linalg.solve_lu
         )
-        q0 = np.zeros(self.flat_shape)
+        q0 = np.zeros(self.shape_info.tree_flat.shape)
 
         def discretise(dt, output_scale=1.0):
             output_scale = self._process_calibrated_scale(output_scale)
@@ -708,7 +707,8 @@ class DenseConditional(AbstractConditional):
             B_p = np.sqrt(dt) * p_inv[:, None] * B
 
             eA, L = exp_gram(A_p, B_p)
-            noise = DenseNormal(q0, output_scale * L, unravel=self.unravel)
+            unravel = self.shape_info.tree_unravel
+            noise = DenseNormal(q0, output_scale * L, unravel=unravel)
             return LatentCond(eA, noise, to_latent=p_inv, to_observed=p)
 
         return discretise
@@ -735,12 +735,9 @@ class DenseConditional(AbstractConditional):
 class DenseLinearizationOdeTs0(AbstractLinearizationOde):
     """Construct a dense implementation of ODE-TS0 linearization."""
 
-    def __init__(
-        self, vf, *, ode_order: int, ode_shape: tuple, unravel: Callable
-    ) -> None:
+    def __init__(self, vf, *, ode_order: int, shape_info: ShapeInfo) -> None:
         super().__init__(vf, ode_order=ode_order)
-        self.ode_shape = ode_shape
-        self.unravel = unravel
+        self.shape_info = shape_info
 
     def init_linearization(self) -> None:
         return None
@@ -751,9 +748,12 @@ class DenseLinearizationOdeTs0(AbstractLinearizationOde):
 
         def a1(m):
             """Select the 'n'-th derivative."""
-            return tree.ravel_pytree(self.unravel(m)[self.ode_order])[0]
+            m0 = self.shape_info.tree_unravel(m)[self.ode_order]
+            return tree.ravel_pytree(m0)[0]
 
-        fx, unravel = tree.ravel_pytree(fun(*self.unravel(rv.mean)[: self.ode_order]))
+        Ms = self.shape_info.tree_unravel(rv.mean)
+        fm = fun(*Ms[: self.ode_order])
+        fx, unravel = tree.ravel_pytree(fm)
         linop = func.jacrev(a1)(rv.mean)
         noise = DenseNormal.from_dirac(unravel(-fx), damp=damp)
         cond = LatentCond.from_linop_and_noise(linop, noise)
@@ -764,19 +764,13 @@ class DenseLinearizationOdeTs1(AbstractLinearizationOde):
     """Construct a dense implementation of ODE-TS1 linearization."""
 
     def __init__(
-        self,
-        vf: Callable,
-        ode_order: int,
-        ode_shape: tuple,
-        unravel: Callable,
-        jacobian: Any,
+        self, vf: Callable, ode_order: int, shape_info: ShapeInfo, jacobian: Any
     ) -> None:
         if ode_order > 1:
             msg = "Not implemented. Try the a root-based TS1 constraint instead."
             raise ValueError(msg)
         super().__init__(vf, ode_order=ode_order)
-        self.ode_shape = ode_shape
-        self.unravel = unravel
+        self.shape_info = shape_info
         self.jacobian = jacobian
 
     @property
@@ -788,15 +782,24 @@ class DenseLinearizationOdeTs1(AbstractLinearizationOde):
 
     def linearize(self, rv, state: None, *, damp: float, t):
         fun = func.partial(self.vector_field, t=t)
-        m0, unravel = tree.ravel_pytree(self.unravel(rv.mean)[0])
+        m_tree = self.shape_info.tree_unravel(rv.mean)
+        m0, unravel = tree.ravel_pytree(m_tree[0])
 
         def vf_flat(s):
             s0 = unravel(s)
             fs0 = fun(s0)
             return tree.ravel_pytree(fs0)[0]
 
-        E0 = func.jacfwd(lambda s: tree.ravel_pytree(self.unravel(s)[0])[0])(rv.mean)
-        E1 = func.jacfwd(lambda s: tree.ravel_pytree(self.unravel(s)[1])[0])(rv.mean)
+        def select_i(i):
+            def select(s):
+                s_tree = self.shape_info.tree_unravel(s)
+                s_flat, _ = tree.ravel_pytree(s_tree[i])
+                return s_flat
+
+            return select
+
+        E0 = func.jacfwd(select_i(i=0))(rv.mean)
+        E1 = func.jacfwd(select_i(i=1))(rv.mean)
 
         fx, J, state = self.jacobian.materialize_dense(vf_flat, m0, state)
         linop = E1 - J @ E0
@@ -810,9 +813,9 @@ class DenseLinearizationOdeTs1(AbstractLinearizationOde):
 class DenseLinearizationRoot(AbstractLinearizationRoot):
     """Construct a dense implementation of root-TS1 linearization."""
 
-    def __init__(self, root, *, root_order, unravel, jacobian, nlstsq) -> None:
+    def __init__(self, root, *, root_order, shape_info, jacobian, nlstsq) -> None:
         super().__init__(root, root_order=root_order)
-        self.unravel = unravel
+        self.shape_info = shape_info
         self.jacobian = jacobian
         self.nlstsq = nlstsq
 
@@ -822,7 +825,7 @@ class DenseLinearizationRoot(AbstractLinearizationRoot):
     def constraint_flat(self, m: Array, *, t) -> Array:
         """Evaluate a flattened version of the root constraint."""
         # Unravel the location and extract derivatives
-        m_tree = self.unravel(m)
+        m_tree = self.shape_info.tree_unravel(m)
         relevant_tcoeffs = m_tree[: self.root_order]
 
         # Evaluate the root
@@ -842,7 +845,7 @@ class DenseLinearizationRoot(AbstractLinearizationRoot):
         fx = fx - linop @ mean
 
         # Understand how to unravel
-        m_tree = func.eval_shape(self.unravel, rv.mean)
+        m_tree = func.eval_shape(self.shape_info.tree_unravel, rv.mean)
         relevant_tcoeffs = m_tree[: self.root_order]
         root_eval = func.eval_shape(lambda s: self.root(*s, t=t), relevant_tcoeffs)
         root_eval = tree.tree_map(np.zeros_like, root_eval)

--- a/probdiffeq/ssm_impl.py
+++ b/probdiffeq/ssm_impl.py
@@ -255,16 +255,19 @@ class ShapeInfo:
     """Information about shapes of Taylor coefficients (lengths, sizes, etc.)."""
 
     def __init__(self, tcoeffs: Sequence, /):
+        # Ensure everything has shapes and dtypes
+        tcoeffs = tree.tree_map(np.asarray, tcoeffs)
+
         # TODO: assert that the tree is a tree of Taylor coefficients
         #       (which means each leaf has the same tree structure)
 
-        # TODO: don't store the arrays but only the shape and dtype
-
         # A flattened representation of the Taylor coefficients
-        self.all_flat, self.all_unravel = tree.ravel_pytree(tcoeffs)
+        flat, self.all_unravel = tree.ravel_pytree(tcoeffs)
+        self.all_flat = structs.ShapeDtypeStruct(flat.shape, flat.dtype)
 
         # A flattened representation of each Taylor coefficient
-        self.single_flat, self.single_unravel = tree.ravel_pytree(tcoeffs[0])
+        flat, self.single_unravel = tree.ravel_pytree(tcoeffs[0])
+        self.single_flat = structs.ShapeDtypeStruct(flat.shape, flat.dtype)
 
         # The leaves in the Taylor coefficients.
         # Note how each Taylor coefficient can itself be a PyTree,
@@ -272,8 +275,9 @@ class ShapeInfo:
         # This specific info is especially important for blockdiagonal models.
         # TODO: this somewhat duplicates the above,
         #       but not enough to prioritise refactoring...
-        self.leaves, self.treedef = tree.tree_flatten(tcoeffs)
-        _, self.leaf_unravel = tree.ravel_pytree(self.leaves[0])
+        leaves, self.treedef = tree.tree_flatten(tcoeffs)
+        _, self.leaf_unravel = tree.ravel_pytree(leaves[0])
+        self.leaves = [structs.ShapeDtypeStruct(s.shape, s.dtype) for s in leaves]
 
     @property
     def num_derivatives(self):
@@ -321,19 +325,6 @@ class FactSsmImpl:
     def from_tcoeffs_isotropic(cls, tcoeffs_like, /):
         """Construct a factorised state-space model implementation."""
         shape_info = ShapeInfo(tcoeffs_like)
-
-        # ode_shape = tree.ravel_pytree(tcoeffs_like[0])[0].shape
-        # num_derivatives = len(tcoeffs_like) - 1
-
-        # tcoeffs_tree_only = tree.tree_map(lambda *_a: 0.0, tcoeffs_like)
-        # _, unravel_tree = tree.ravel_pytree(tcoeffs_tree_only)
-
-        # leaves, tree_structure = tree.tree_flatten(tcoeffs_like)
-        # _, unravel_leaf = tree.ravel_pytree(leaves[0])
-
-        # def unravel(z):
-        #     pytree = func.vmap(unravel_tree, in_axes=1, out_axes=0)(z)
-        #     return tree.tree_map(unravel_leaf, pytree)
 
         prototypes = IsotropicPrototype()
         normal = IsotropicNormal
@@ -876,9 +867,6 @@ class IsotropicLinearizationOdeTs0(AbstractLinearizationOde):
 
         m1 = [*(mean[: self.ode_order])]
         m1 = tree.tree_map(self.shape_info.single_unravel, m1)
-
-        # mean_tree = self.unravel(mean)
-        # m1 = mean_tree[: self.ode_order]
         fx_tree = fun(*m1)
         fx, unravel_obs = tree.ravel_pytree(fx_tree)
 


### PR DESCRIPTION
Before: each SSM factorisation had its own version of "ravel", "shape", etc..
Now: We construct one central "ShapeInfo" object that collects ravelling, treedefs, etc., and pass them into each factorisation. This removed some duplication and is overall easier to read. This PR also improves the memory efficiency slightly because we only ever store shapes and dtypes of template arrays instead of the arrays.