### PR TITLE
Add dedicated tests for DAEs and 2nd order ODEs, and check pytree structure in output base-scales

### DIFF
--- a/probdiffeq/_probdiffeq/constraints.py
+++ b/probdiffeq/_probdiffeq/constraints.py
@@ -112,7 +112,12 @@ class wlstsq_nc_gauss_newton(WeightedLeastSquaresNonlinearlyConstrained):
     """Solve the weighted lstsq problem with nonlinear constraints using Gauss--Newton."""
 
     def __init__(
-        self, *, maxiter, tol, lstsq=linalg.lstsq_svd, while_loop=flow.while_loop
+        self,
+        *,
+        maxiter=10,
+        tol=1e-6,
+        lstsq=linalg.lstsq_svd,
+        while_loop=flow.while_loop,
     ):
         self.maxiter = maxiter
         self.tol = tol

--- a/probdiffeq/_probdiffeq/jet_expansion_algorithms.py
+++ b/probdiffeq/_probdiffeq/jet_expansion_algorithms.py
@@ -1,9 +1,9 @@
 r"""Evaluate jet-recursions in differential equations."""
 
 from probdiffeq import probdiffeq
-from probdiffeq._probdiffeq import problem_types, utilities
+from probdiffeq._probdiffeq import constraints, problem_types, utilities
 from probdiffeq.backend import flow, func, np, tree
-from probdiffeq.backend.typing import Array, Callable, Protocol, Sequence, TypeVar
+from probdiffeq.backend.typing import Array, Protocol, Sequence, TypeVar
 
 __all__ = [
     "JetExpansionAlg",
@@ -368,9 +368,12 @@ def _allow_pytree_inits(expand):
 
 
 def jetexpand_dae_nlstsq(
-    num: int, nlstsq: Callable
+    num: int,
+    nlstsq: constraints.WeightedLeastSquaresNonlinearlyConstrained | None = None,
 ) -> JetExpansionAlg[problem_types.dae_system]:
     """Evaluate the Taylor series of a differential-algebraic equation system."""
+    if nlstsq is None:
+        nlstsq = constraints.wlstsq_nc_gauss_newton()
 
     # TODO: don't try too hard to refactor this one here, I dont think it'll be around for long
     # TODO: enable pytree inputs/outputs

--- a/probdiffeq/_ssm_impl/factorisation_via_blockdiag.py
+++ b/probdiffeq/_ssm_impl/factorisation_via_blockdiag.py
@@ -78,12 +78,20 @@ class BlockDiagPriorFactory(interfaces.AbstractPriorFactory):
         single_flat, single_unravel = tree.ravel_pytree(tcoeffs_mean[0])
         coeff_like = np.ones_like(single_flat)
         base_scale_expected = single_unravel(coeff_like)
+
         if base_scale is None:
             base_scale = base_scale_expected
         else:
-            if base_scale.shape != base_scale_expected.shape:
+            base_scale = tree.tree_map(np.asarray, base_scale)
+
+            def shape_equal(A, B):
+                return tree.tree_map(lambda a, b: np.shape(a) == np.shape(b), A, B)
+
+            if not tree.tree_all(
+                shape_equal(base_scale.shape, base_scale_expected.shape)
+            ):
                 msg = "The base-scale has the wrong shape."
-                msg += f" Expected: {base_scale_expected.shape}."
+                msg += f" Expected: {tree.tree_map(np.shape, base_scale_expected)}."
                 msg += f" Received: {base_scale.shape}."
                 raise ValueError(msg)
 

--- a/probdiffeq/_ssm_impl/factorisation_via_blockdiag.py
+++ b/probdiffeq/_ssm_impl/factorisation_via_blockdiag.py
@@ -82,14 +82,20 @@ class BlockDiagPriorFactory(interfaces.AbstractPriorFactory):
         if base_scale is None:
             base_scale = base_scale_expected
         else:
+            if tree.tree_structure(base_scale) != tree.tree_structure(
+                base_scale_expected
+            ):
+                msg = "The 'base_scale' argument has an unexpected PyTree structure."
+                msg += f" Expected: {tree.tree_structure(base_scale_expected)}."
+                msg += f" Received: {tree.tree_structure(base_scale)}."
+                raise TypeError(msg)
+
             base_scale = tree.tree_map(np.asarray, base_scale)
 
             def shape_equal(A, B):
                 return tree.tree_map(lambda a, b: np.shape(a) == np.shape(b), A, B)
 
-            if not tree.tree_all(
-                shape_equal(base_scale.shape, base_scale_expected.shape)
-            ):
+            if not tree.tree_all(shape_equal(base_scale, base_scale_expected)):
                 msg = "The base-scale has the wrong shape."
                 msg += f" Expected: {tree.tree_map(np.shape, base_scale_expected)}."
                 msg += f" Received: {base_scale.shape}."

--- a/probdiffeq/_ssm_impl/factorisation_via_dense.py
+++ b/probdiffeq/_ssm_impl/factorisation_via_dense.py
@@ -276,6 +276,12 @@ class DensePriorFactory(interfaces.AbstractPriorFactory):
         def shape_equal(A, B):
             return tree.tree_map(lambda a, b: np.shape(a) == np.shape(b), A, B)
 
+        if tree.tree_structure(base_scale) != tree.tree_structure(base_scale_expected):
+            msg = "The 'base_scale' argument has an unexpected PyTree structure."
+            msg += f" Expected: {tree.tree_structure(base_scale_expected)}."
+            msg += f" Received: {tree.tree_structure(base_scale)}."
+            raise TypeError(msg)
+
         if not tree.tree_all(shape_equal(base_scale, base_scale_expected)):
             msg = "The base-scale has the wrong shape."
             msg += f" Expected: {tree.tree_map(np.shape, base_scale_expected)}."

--- a/probdiffeq/_ssm_impl/factorisation_via_dense.py
+++ b/probdiffeq/_ssm_impl/factorisation_via_dense.py
@@ -271,10 +271,14 @@ class DensePriorFactory(interfaces.AbstractPriorFactory):
             return linalg.diagonal_matrix(base_scale)
 
         # Otherwise, check the shape and turn the scale into a matrix
-        base_scale = np.asarray(base_scale)
-        if base_scale.shape != base_scale_expected.shape:
+        base_scale = tree.tree_map(np.asarray, base_scale)
+
+        def shape_equal(A, B):
+            return tree.tree_map(lambda a, b: np.shape(a) == np.shape(b), A, B)
+
+        if not tree.tree_all(shape_equal(base_scale, base_scale_expected)):
             msg = "The base-scale has the wrong shape."
-            msg += f" Expected: {base_scale_expected.shape}."
+            msg += f" Expected: {tree.tree_map(np.shape, base_scale_expected)}."
             msg += f" Received: {base_scale.shape}."
             raise ValueError(msg)
 

--- a/probdiffeq/_ssm_impl/factorisation_via_isotropic.py
+++ b/probdiffeq/_ssm_impl/factorisation_via_isotropic.py
@@ -264,6 +264,12 @@ class IsotropicPriorFactory(interfaces.AbstractPriorFactory):
         if base_scale is None:
             base_scale = np.ones(())
         else:
+            if tree.tree_structure(base_scale) != tree.tree_structure(1.0):
+                msg = "The 'base_scale' argument has an unexpected PyTree structure."
+                msg += f" Expected: {tree.tree_structure(1.0)}."
+                msg += f" Received: {tree.tree_structure(base_scale)}."
+                raise TypeError(msg)
+
             base_scale = np.asarray(base_scale)
             if base_scale.shape != ():
                 msg = "The base-scale has the wrong shape."

--- a/probdiffeq/backend/np.py
+++ b/probdiffeq/backend/np.py
@@ -246,3 +246,7 @@ def dtype(arr_or_dtype, /):
 
 def hypot(x1, x2, /):
     return jnp.hypot(x1, x2)
+
+
+def cos(x, /):
+    return jnp.cos(x)

--- a/probdiffeq/backend/ode.py
+++ b/probdiffeq/backend/ode.py
@@ -51,7 +51,8 @@ def ivp_three_body_1st():
     f, u0, (t0, t1), f_args = ivps.three_body_restricted_first_order()
 
     # Dictionary to ensure pytree compatibility
-    def vf(u, /, *, t):  # noqa: ARG001
+    def vf(u, /, *, t):
+        del t
         return {"u": f(u["u"], *f_args)}
 
     return vf, ({"u": u0},), (t0, t1)

--- a/tests/test_probdiffeq/test_constraint_dae.py
+++ b/tests/test_probdiffeq/test_constraint_dae.py
@@ -1,0 +1,87 @@
+"""Tests for sampling behaviour."""
+
+from probdiffeq import ivpsolve, probdiffeq
+from probdiffeq.backend import func, np, testing
+
+
+def test_solution_matches_odesolve():
+    y0 = [np.asarray([0.99, 0.01, 0.0])]
+    solution_ode = solve_ode(y0, num=3)
+    solution_dae = solve_dae(y0, num=3)
+    assert testing.allclose(solution_ode.u.mean[0], solution_dae.u.mean[0])
+
+
+@func.partial(func.jit, static_argnames=("num",))
+def solve_ode(inits, num):
+    jetexpand = probdiffeq.jetexpand_ode_padded_scan(num=num)
+    tcoeffs, _ = jetexpand(vf_ode, inits, t=0.0)
+
+    ssm = probdiffeq.state_space_model(ssm_fact="dense")
+    init, iwp = probdiffeq.prior_wiener_integrated(tcoeffs, ssm=ssm)
+    ts0 = probdiffeq.constraint_ode_ts0(vf_ode, ssm=ssm)
+    strategy = probdiffeq.strategy_filter(ssm=ssm)
+    solver = probdiffeq.solver(strategy=strategy, prior=iwp, constraint=ts0, ssm=ssm)
+    error = probdiffeq.error_state_std(constraint=ts0, prior=iwp, ssm=ssm)
+    solve = ivpsolve.solve_adaptive_save_at(solver=solver, error=error)
+
+    save_at = np.linspace(0.0, 5.0, endpoint=True, num=10)
+    return func.jit(solve)(init, save_at=save_at, atol=1e-6, rtol=1e-6)
+
+
+@func.partial(func.jit, static_argnames=("num",))
+def solve_dae(inits, num):
+    differential_lifted = probdiffeq.jet_lift(differential, lift_by=num - 1)
+    algebraic_lifted = probdiffeq.jet_lift(algebraic, lift_by=num)
+    dae = probdiffeq.dae_system(
+        differential=differential_lifted, algebraic=algebraic_lifted
+    )
+
+    nlstsq = probdiffeq.wlstsq_nc_gauss_newton(maxiter=10, tol=1e-5)
+    jetexpand = probdiffeq.jetexpand_dae_nlstsq(num=num, nlstsq=nlstsq)
+    tcoeffs, _ = jetexpand(dae, inits, t=0.0)
+
+    ssm = probdiffeq.state_space_model(ssm_fact="dense")
+    init, iwp = probdiffeq.prior_wiener_integrated(tcoeffs, ssm=ssm)
+    ts0 = probdiffeq.constraint_dae(dae, ssm=ssm)
+    strategy = probdiffeq.strategy_filter(ssm=ssm)
+    solver = probdiffeq.solver(strategy=strategy, prior=iwp, constraint=ts0, ssm=ssm)
+    error = probdiffeq.error_state_std(constraint=ts0, prior=iwp, ssm=ssm)
+    solve = ivpsolve.solve_adaptive_save_at(solver=solver, error=error)
+
+    save_at = np.linspace(0.0, 5.0, endpoint=True, num=10)
+    return func.jit(solve)(init, save_at=save_at, atol=1e-6, rtol=1e-6)
+
+
+@probdiffeq.ode
+def vf_ode(y, /, *, t):
+    del t
+    beta, gamma = 2.0, 0.5  # infection and recovery rates
+    S, I, _R = y  # noqa: E741 ("I" is a good variable name in an SIR model)
+
+    f0 = -beta * S * I
+    f1 = beta * S * I - gamma * I
+    f2 = gamma * I
+
+    return np.stack([f0, f1, f2])
+
+
+@probdiffeq.residual_state
+def algebraic(u, /, *, t):
+    del t
+    N = 1.0  # total population
+    return u[0] + u[1] + u[2] - N
+
+
+@probdiffeq.residual_state_velocity
+def differential(u, du, /, *, t):
+    del t
+    beta, gamma = 2.0, 0.5
+    S, I, _R = u  # noqa: E741 ("I" is a good variable name in an SIR model)
+
+    f0 = -beta * S * I
+    f1 = beta * S * I - gamma * I
+
+    F1 = du[0] - f0
+    F2 = du[1] - f1
+
+    return np.stack([F1, F2])

--- a/tests/test_probdiffeq/test_constraint_dae.py
+++ b/tests/test_probdiffeq/test_constraint_dae.py
@@ -13,6 +13,20 @@ def test_solution_matches_odesolve():
 
 @func.partial(func.jit, static_argnames=("num",))
 def solve_ode(inits, num):
+    """Solve the SIR model as an ODE to serve as a reference solution."""
+
+    @probdiffeq.ode
+    def vf_ode(y, /, *, t):
+        del t
+        beta, gamma = 2.0, 0.5  # infection and recovery rates
+        S, I, _R = y  # noqa: E741 ("I" is a good variable name in an SIR model)
+
+        f0 = -beta * S * I
+        f1 = beta * S * I - gamma * I
+        f2 = gamma * I
+
+        return np.stack([f0, f1, f2])
+
     jetexpand = probdiffeq.jetexpand_ode_padded_scan(num=num)
     tcoeffs, _ = jetexpand(vf_ode, inits, t=0.0)
 
@@ -30,14 +44,33 @@ def solve_ode(inits, num):
 
 @func.partial(func.jit, static_argnames=("num",))
 def solve_dae(inits, num):
-    differential_lifted = probdiffeq.jet_lift(differential, lift_by=num - 1)
-    algebraic_lifted = probdiffeq.jet_lift(algebraic, lift_by=num)
-    dae = probdiffeq.dae_system(
-        differential=differential_lifted, algebraic=algebraic_lifted
-    )
+    """Solve the SIR model as a DAE."""
 
-    nlstsq = probdiffeq.wlstsq_nc_gauss_newton(maxiter=10, tol=1e-5)
-    jetexpand = probdiffeq.jetexpand_dae_nlstsq(num=num, nlstsq=nlstsq)
+    @func.partial(probdiffeq.jet_lift, lift_by=num)
+    @probdiffeq.residual_state
+    def algebraic(u, /, *, t):
+        del t
+        N = 1.0  # total population
+        return u[0] + u[1] + u[2] - N
+
+    @func.partial(probdiffeq.jet_lift, lift_by=num - 1)
+    @probdiffeq.residual_state_velocity
+    def differential(u, du, /, *, t):
+        del t
+        beta, gamma = 2.0, 0.5
+        S, I, _R = u  # noqa: E741 ("I" is a good variable name in an SIR model)
+
+        f0 = -beta * S * I
+        f1 = beta * S * I - gamma * I
+
+        F1 = du[0] - f0
+        F2 = du[1] - f1
+
+        return np.stack([F1, F2])
+
+    dae = probdiffeq.dae_system(differential=differential, algebraic=algebraic)
+
+    jetexpand = probdiffeq.jetexpand_dae_nlstsq(num=num)
     tcoeffs, _ = jetexpand(dae, inits, t=0.0)
 
     ssm = probdiffeq.state_space_model(ssm_fact="dense")
@@ -50,38 +83,3 @@ def solve_dae(inits, num):
 
     save_at = np.linspace(0.0, 5.0, endpoint=True, num=10)
     return func.jit(solve)(init, save_at=save_at, atol=1e-6, rtol=1e-6)
-
-
-@probdiffeq.ode
-def vf_ode(y, /, *, t):
-    del t
-    beta, gamma = 2.0, 0.5  # infection and recovery rates
-    S, I, _R = y  # noqa: E741 ("I" is a good variable name in an SIR model)
-
-    f0 = -beta * S * I
-    f1 = beta * S * I - gamma * I
-    f2 = gamma * I
-
-    return np.stack([f0, f1, f2])
-
-
-@probdiffeq.residual_state
-def algebraic(u, /, *, t):
-    del t
-    N = 1.0  # total population
-    return u[0] + u[1] + u[2] - N
-
-
-@probdiffeq.residual_state_velocity
-def differential(u, du, /, *, t):
-    del t
-    beta, gamma = 2.0, 0.5
-    S, I, _R = u  # noqa: E741 ("I" is a good variable name in an SIR model)
-
-    f0 = -beta * S * I
-    f1 = beta * S * I - gamma * I
-
-    F1 = du[0] - f0
-    F2 = du[1] - f1
-
-    return np.stack([F1, F2])

--- a/tests/test_probdiffeq/test_constraint_jet_lift.py
+++ b/tests/test_probdiffeq/test_constraint_jet_lift.py
@@ -94,7 +94,7 @@ def fixture_expected(residual, derivatives):
     return coeffs
 
 
-def case_jet_dae_iterated(residual):
+def case_jet_lift_dae(residual):
     nlstsq = probdiffeq.wlstsq_nc_gauss_newton(maxiter=50, tol=1e-10)
     linearization = probdiffeq.linearization_map(nlstsq)
 
@@ -113,7 +113,7 @@ def case_jet_dae_iterated(residual):
     return constraint_residual
 
 
-def case_jet_constraint_iterated(residual):
+def case_jet_lift_residual(residual):
     nlstsq = probdiffeq.wlstsq_nc_gauss_newton(maxiter=50, tol=1e-10)
     linearization = probdiffeq.linearization_map(nlstsq)
 

--- a/tests/test_probdiffeq/test_constraint_ode_second_order.py
+++ b/tests/test_probdiffeq/test_constraint_ode_second_order.py
@@ -5,7 +5,7 @@ from probdiffeq.backend import func, np, testing
 
 
 @testing.parametrize("fact", ["dense", "isotropic", "blockdiag"])
-def test_solution_matches_first_order(fact):
+def test_solution_is_accurate(fact):
 
     @probdiffeq.ode_second_order
     def vf(u, du, /, *, t):

--- a/tests/test_probdiffeq/test_constraint_ode_second_order.py
+++ b/tests/test_probdiffeq/test_constraint_ode_second_order.py
@@ -1,0 +1,30 @@
+"""Tests for sampling behaviour."""
+
+from probdiffeq import ivpsolve, probdiffeq
+from probdiffeq.backend import func, np, testing
+
+
+@testing.parametrize("fact", ["dense", "isotropic", "blockdiag"])
+def test_solution_matches_first_order(fact):
+
+    @probdiffeq.ode_second_order
+    def vf(u, du, /, *, t):
+        del t
+        del du
+        return -u
+
+    jetexpand = probdiffeq.jetexpand_ode_padded_scan(num=2)
+    tcoeffs, _ = jetexpand(vf, (1.0, 0.0), t=0.0)
+
+    ssm = probdiffeq.state_space_model(ssm_fact=fact)
+    init, iwp = probdiffeq.prior_wiener_integrated(tcoeffs, ssm=ssm)
+    ts0 = probdiffeq.constraint_ode_ts0(vf, ssm=ssm)
+    strategy = probdiffeq.strategy_filter(ssm=ssm)
+    solver = probdiffeq.solver(strategy=strategy, prior=iwp, constraint=ts0, ssm=ssm)
+    error = probdiffeq.error_state_std(constraint=ts0, prior=iwp, ssm=ssm)
+    solve = ivpsolve.solve_adaptive_save_at(solver=solver, error=error)
+
+    save_at = np.linspace(0.0, 5.0, endpoint=True, num=10)
+    solution_2nd = func.jit(solve)(init, save_at=save_at, atol=1e-6, rtol=1e-6)
+
+    assert testing.allclose(solution_2nd.u.mean[0], np.cos(solution_2nd.t))

--- a/tests/test_probdiffeq/test_prior_output_scales.py
+++ b/tests/test_probdiffeq/test_prior_output_scales.py
@@ -1,7 +1,7 @@
 """Tests for output scales."""
 
 from probdiffeq import probdiffeq
-from probdiffeq.backend import func, np, structs, testing
+from probdiffeq.backend import func, np, structs, testing, tree
 from probdiffeq.backend.typing import Callable, Literal
 
 
@@ -31,7 +31,9 @@ def case_scale_rules_iwp_dense() -> ScaleShapeRules:
 
 
 def case_scale_rules_ioup_dense() -> ScaleShapeRules:
-    linop = np.zeros_like
+    def linop(s):
+        return tree.tree_map(np.zeros_like, s)
+
     prior = func.partial(probdiffeq.prior_ornstein_uhlenbeck_integrated, linop)
     return ScaleShapeRules(
         ssm_fact="dense",
@@ -126,3 +128,25 @@ def test_output_scales_wrong_shape_raises_error_at_calling(rules: ScaleShapeRule
     for shapes in rules.calibrated_baddies:
         with testing.raises(ValueError, match="wrong shape"):
             _ = iwp(1.0, np.ones(shapes))
+
+
+@testing.parametrize_with_cases("rules", cases=".", prefix="case_scale_rules_")
+def test_output_scales_wrong_type_raises_error(rules: ScaleShapeRules):
+    ssm = probdiffeq.state_space_model(ssm_fact=rules.ssm_fact)
+
+    # Sanity check: assert that the same error does not happen with the correct shape
+    tcoeffs = [{"u": np.ones(rules.ode)}, {"u": np.ones(rules.ode)}]
+
+    # output scale should inherit pytree structure
+    if rules.ssm_fact == "isotropic":
+        scale_good = np.ones(rules.base)  # bad: not a dict
+        scale_bad = {"u": scale_good}  # good: dict
+    else:
+        scale_bad = np.ones(rules.base)  # bad: not a dict
+        scale_good = {"u": scale_bad}  # good: dict
+
+    _ = rules.prior(tcoeffs, output_scale=scale_good, ssm=ssm)
+
+    # Test that for the wrong shape or type, an error is raised during construction
+    with testing.raises(TypeError, match="unexpected PyTree structure"):
+        _ = rules.prior(tcoeffs, output_scale=scale_bad, ssm=ssm)


### PR DESCRIPTION
- Add two simple tests for DAEs and 2nd order ODEs to catch problems before running the examples
- Add a check to output-scale initialisation in the priors that verifies that output scales have the correct pytree structure