### PR TITLE
Rename `Linearization` to `TaylorPoint` and change all DAE-API to a residual-stacking API

### DIFF
--- a/benchmarks/B0_work-precision-dae-robertson.py
+++ b/benchmarks/B0_work-precision-dae-robertson.py
@@ -226,9 +226,9 @@ def solver_residual(*, num_derivatives: int, time_span) -> Callable:
         )
 
         # We build a Jet constraint
-        linearization = probdiffeq.linearization_map(nlstsq)
+        taylor_point = probdiffeq.taylor_point_map(nlstsq)
         jet = probdiffeq.constraint_residual(
-            residual, ssm=ssm, linearization=linearization
+            residual, ssm=ssm, taylor_point=taylor_point
         )
         strategy = probdiffeq.strategy_filter(ssm=ssm)
 

--- a/benchmarks/B0_work-precision-dae-robertson.py
+++ b/benchmarks/B0_work-precision-dae-robertson.py
@@ -48,8 +48,8 @@ def main(start=3.0, stop=10.0, step=0.5, repeats=2, time_span=(1e-6, 1e5)) -> No
 
     # Assemble algorithms
     algorithms = {
-        "DAE | Jet(3)": solver_dae_iwp(num_derivatives=3, time_span=time_span),
-        "DAE | Jet(4)": solver_dae_iwp(num_derivatives=4, time_span=time_span),
+        "DAE | Jet(3)": solver_residual(num_derivatives=3, time_span=time_span),
+        "DAE | Jet(4)": solver_residual(num_derivatives=4, time_span=time_span),
         "ODE | TS1(3)": solver_ode(num_derivatives=3, time_span=time_span),
         "ODE | TS1(4)": solver_ode(num_derivatives=4, time_span=time_span),
         "ODE | TS1(7)": solver_ode(num_derivatives=7, time_span=time_span),
@@ -185,7 +185,7 @@ def solver_ode(*, num_derivatives: int, time_span) -> Callable:
     return param_to_solution
 
 
-def solver_dae_iwp(*, num_derivatives: int, time_span) -> Callable:
+def solver_residual(*, num_derivatives: int, time_span) -> Callable:
     """Construct a method that solves Robertson as a DAE."""
 
     @functools.partial(probdiffeq.jet_lift, lift_by=num_derivatives - 1)
@@ -206,7 +206,7 @@ def solver_dae_iwp(*, num_derivatives: int, time_span) -> Callable:
         del t
         return u[0] + u[1] + u[2] - 1
 
-    dae = probdiffeq.dae_system(differential, algebraic)
+    residual = probdiffeq.residual_from_stack(differential, algebraic)
 
     @jax.jit
     def param_to_solution(tol):
@@ -215,8 +215,8 @@ def solver_dae_iwp(*, num_derivatives: int, time_span) -> Callable:
         nlstsq = probdiffeq.wlstsq_nc_gauss_newton(
             maxiter=10, tol=jnp.finfo(y0[0].dtype).eps ** 0.5
         )
-        jetexpand = probdiffeq.jetexpand_dae_nlstsq(nlstsq=nlstsq, num=num_derivatives)
-        tcoeffs, _ = jetexpand(dae, y0, t=t0)
+        jetexpand = probdiffeq.jetexpand_residual(nlstsq=nlstsq, num=num_derivatives)
+        tcoeffs, _ = jetexpand(residual, y0, t=t0)
 
         ssm = probdiffeq.state_space_model()
 
@@ -227,7 +227,9 @@ def solver_dae_iwp(*, num_derivatives: int, time_span) -> Callable:
 
         # We build a Jet constraint
         linearization = probdiffeq.linearization_map(nlstsq)
-        jet = probdiffeq.constraint_dae(dae, ssm=ssm, linearization=linearization)
+        jet = probdiffeq.constraint_residual(
+            residual, ssm=ssm, linearization=linearization
+        )
         strategy = probdiffeq.strategy_filter(ssm=ssm)
 
         # For proper DAEs, non-iterated solver's simply don't cut it

--- a/benchmarks/B0_work-precision-dae-robertson.py
+++ b/benchmarks/B0_work-precision-dae-robertson.py
@@ -212,7 +212,7 @@ def solver_residual(*, num_derivatives: int, time_span) -> Callable:
     def param_to_solution(tol):
         t0, t1 = time_span
         y0 = [jnp.array([1.0, 0.0, 0.0])]
-        nlstsq = probdiffeq.wlstsq_nc_gauss_newton(
+        nlstsq = probdiffeq.lstsq_constrained_gauss_newton(
             maxiter=10, tol=jnp.finfo(y0[0].dtype).eps ** 0.5
         )
         jetexpand = probdiffeq.jetexpand_residual(nlstsq=nlstsq, num=num_derivatives)

--- a/benchmarks/B0_work-precision-dae-robertson.py
+++ b/benchmarks/B0_work-precision-dae-robertson.py
@@ -226,7 +226,7 @@ def solver_residual(*, num_derivatives: int, time_span) -> Callable:
         )
 
         # We build a Jet constraint
-        taylor_point = probdiffeq.taylor_point_map(nlstsq)
+        taylor_point = probdiffeq.taylor_point_maximum_a_posteriori(nlstsq)
         jet = probdiffeq.constraint_residual(
             residual, ssm=ssm, taylor_point=taylor_point
         )

--- a/examples/B3_DAEs.py
+++ b/examples/B3_DAEs.py
@@ -46,10 +46,9 @@ def main(t0=1e-6, t1=1e5) -> None:
 
     ssm = probdiffeq.state_space_model()
 
-    nlstsq = probdiffeq.wlstsq_nc_gauss_newton(maxiter=10, tol=1e-8)
-    jetexpand = probdiffeq.jetexpand_dae_nlstsq(num=4, nlstsq=nlstsq)
-    dae = probdiffeq.dae_system(differential, algebraic)
-    y0, _info = jetexpand(dae, [jnp.array([1.0, 0.0, 0.0])], t=t0)
+    jetexpand = probdiffeq.jetexpand_residual(num=4)
+    residual = probdiffeq.residual_from_stack(differential, algebraic)
+    y0, _info = jetexpand(residual, [jnp.array([1.0, 0.0, 0.0])], t=t0)
 
     # This base scale is critical to Robertson, because
     # the solutions live on vastly different scales
@@ -60,8 +59,8 @@ def main(t0=1e-6, t1=1e5) -> None:
     )
 
     # We build a Jet constraint. Iteration is key, because DAEs are proper stiff.
-    linearization = probdiffeq.linearization_map(nlstsq)
-    jet = probdiffeq.constraint_dae(dae, ssm=ssm, linearization=linearization)
+    linearization = probdiffeq.linearization_map()
+    jet = probdiffeq.constraint_residual(residual, ssm=ssm, linearization=linearization)
     strategy = probdiffeq.strategy_smoother_fixedpoint(ssm=ssm)
     solver = probdiffeq.solver_dynamic(
         strategy=strategy, prior=ioup, constraint=jet, ssm=ssm

--- a/examples/B3_DAEs.py
+++ b/examples/B3_DAEs.py
@@ -59,7 +59,7 @@ def main(t0=1e-6, t1=1e5) -> None:
     )
 
     # We build a Jet constraint. Iteration is key, because DAEs are proper stiff.
-    taylor_point = probdiffeq.taylor_point_map()
+    taylor_point = probdiffeq.taylor_point_maximum_a_posteriori()
     jet = probdiffeq.constraint_residual(residual, ssm=ssm, taylor_point=taylor_point)
     strategy = probdiffeq.strategy_smoother_fixedpoint(ssm=ssm)
     solver = probdiffeq.solver_dynamic(

--- a/examples/B3_DAEs.py
+++ b/examples/B3_DAEs.py
@@ -59,8 +59,8 @@ def main(t0=1e-6, t1=1e5) -> None:
     )
 
     # We build a Jet constraint. Iteration is key, because DAEs are proper stiff.
-    linearization = probdiffeq.linearization_map()
-    jet = probdiffeq.constraint_residual(residual, ssm=ssm, linearization=linearization)
+    taylor_point = probdiffeq.taylor_point_map()
+    jet = probdiffeq.constraint_residual(residual, ssm=ssm, taylor_point=taylor_point)
     strategy = probdiffeq.strategy_smoother_fixedpoint(ssm=ssm)
     solver = probdiffeq.solver_dynamic(
         strategy=strategy, prior=ioup, constraint=jet, ssm=ssm

--- a/examples/E3_learn_DAEs.py
+++ b/examples/E3_learn_DAEs.py
@@ -167,9 +167,9 @@ def solver(residual, tol, while_loop, trafo):
         )
 
         # We build a Jet constraint. Iteration is key, because DAEs are proper stiff.
-        linearization = probdiffeq.linearization_map(nlstsq)
+        taylor_point = probdiffeq.taylor_point_map(nlstsq)
         jet = probdiffeq.constraint_residual(
-            residual, ssm=ssm, linearization=linearization
+            residual, ssm=ssm, taylor_point=taylor_point
         )
         strategy = probdiffeq.strategy_smoother_fixedpoint(ssm=ssm)
         solver = probdiffeq.solver_dynamic(

--- a/examples/E3_learn_DAEs.py
+++ b/examples/E3_learn_DAEs.py
@@ -61,7 +61,7 @@ def main(
         del t
         return u[0] + u[1] + u[2] - 1
 
-    dae = probdiffeq.dae_system(differential, algebraic)
+    residual = probdiffeq.residual_from_stack(differential, algebraic)
 
     def while_loop(cond, body, init):
         """Evaluate a bounded while loop."""
@@ -75,7 +75,7 @@ def main(
 
     # Linear spacing on a log-scale
     save_at = 2.0 ** jnp.linspace(jnp.log2(t0), jnp.log2(t1), num=num_data)
-    solve = solver(dae, tol=tol, while_loop=while_loop, trafo=trafo)
+    solve = solver(residual, tol=tol, while_loop=while_loop, trafo=trafo)
 
     # True condition
     key = jax.random.PRNGKey(seed)
@@ -146,7 +146,7 @@ def loss_data_fit(solve, *, ssm, inputs, labels):
     return loss
 
 
-def solver(dae, tol, while_loop, trafo):
+def solver(residual, tol, while_loop, trafo):
     """Create a reverse-mode differentiable probabilistic solver."""
 
     @jax.jit
@@ -158,8 +158,8 @@ def solver(dae, tol, while_loop, trafo):
         nlstsq = probdiffeq.wlstsq_nc_gauss_newton(
             maxiter=10, tol=tol, while_loop=while_loop
         )
-        jetexpand = probdiffeq.jetexpand_dae_nlstsq(num=3, nlstsq=nlstsq)
-        y0, _info = jetexpand(dae, [y0], t=t0)
+        jetexpand = probdiffeq.jetexpand_residual(num=3, nlstsq=nlstsq)
+        y0, _info = jetexpand(residual, [y0], t=t0)
         ssm = probdiffeq.state_space_model()
 
         init, prior = probdiffeq.prior_wiener_integrated(
@@ -168,7 +168,9 @@ def solver(dae, tol, while_loop, trafo):
 
         # We build a Jet constraint. Iteration is key, because DAEs are proper stiff.
         linearization = probdiffeq.linearization_map(nlstsq)
-        jet = probdiffeq.constraint_dae(dae, ssm=ssm, linearization=linearization)
+        jet = probdiffeq.constraint_residual(
+            residual, ssm=ssm, linearization=linearization
+        )
         strategy = probdiffeq.strategy_smoother_fixedpoint(ssm=ssm)
         solver = probdiffeq.solver_dynamic(
             strategy=strategy, prior=prior, constraint=jet, ssm=ssm

--- a/examples/E3_learn_DAEs.py
+++ b/examples/E3_learn_DAEs.py
@@ -155,7 +155,7 @@ def solver(residual, tol, while_loop, trafo):
         y0 = trafo.latent_to_observed(p_sqrt)
         t0, _t1 = save_at[0], save_at[-1]
 
-        nlstsq = probdiffeq.wlstsq_nc_gauss_newton(
+        nlstsq = probdiffeq.lstsq_constrained_gauss_newton(
             maxiter=10, tol=tol, while_loop=while_loop
         )
         jetexpand = probdiffeq.jetexpand_residual(num=3, nlstsq=nlstsq)

--- a/examples/E3_learn_DAEs.py
+++ b/examples/E3_learn_DAEs.py
@@ -167,7 +167,7 @@ def solver(residual, tol, while_loop, trafo):
         )
 
         # We build a Jet constraint. Iteration is key, because DAEs are proper stiff.
-        taylor_point = probdiffeq.taylor_point_map(nlstsq)
+        taylor_point = probdiffeq.taylor_point_maximum_a_posteriori(nlstsq)
         jet = probdiffeq.constraint_residual(
             residual, ssm=ssm, taylor_point=taylor_point
         )

--- a/probdiffeq/_probdiffeq/constraints.py
+++ b/probdiffeq/_probdiffeq/constraints.py
@@ -50,14 +50,14 @@ from probdiffeq.backend.typing import Array, Callable, Protocol, Sequence, TypeV
 
 __all__ = [
     "Constraint",
-    "Linearization",
     "LstSqConstrained",
+    "TaylorPointFinder",
     "constraint_ode_ts0",
     "constraint_ode_ts1",
     "constraint_residual",
-    "linearization_map",
-    "linearization_prior_mean",
     "lstsq_constrained_gauss_newton",
+    "taylor_point_map",
+    "taylor_point_prior_mean",
 ]
 
 N = TypeVar("N", bound=ssm_impl.AbstractTreeNormal)
@@ -67,14 +67,14 @@ Used to type marginals, for example.
 """
 
 
-class Linearization:
-    """Find a linearization point.
+class TaylorPointFinder:
+    """Find a linearization point for the Taylor expansion.
 
-    Note how this object handles *where* to linearize, but not *how* to linearize.
+    Use this API to distinguish iterated filtering from extended filtering.
     """
 
     def __call__(self, constraint_flat: Callable, rv: N, **constraint_kwargs) -> Array:
-        """Find a linearization point.
+        """Find a linearization point for the Taylor expansion.
 
         Parameters
         ----------
@@ -167,8 +167,8 @@ class lstsq_constrained_gauss_newton(LstSqConstrained):
         return final.x, {"iters": final.i}
 
 
-class linearization_prior_mean(Linearization):
-    """Linearization point is the prior mean."""
+class taylor_point_prior_mean(TaylorPointFinder):
+    """TaylorPointFinder point is the prior mean."""
 
     def __call__(self, constraint_flat: Callable, rv, **constraint_kwargs) -> Array:
         del constraint_flat
@@ -176,8 +176,8 @@ class linearization_prior_mean(Linearization):
         return rv.mean_flat
 
 
-class linearization_map(Linearization):
-    """Linearization point is the maximum-a-posteriori estimate."""
+class taylor_point_map(TaylorPointFinder):
+    """TaylorPointFinder point is the maximum-a-posteriori estimate."""
 
     def __init__(self, wlstsq_nc: LstSqConstrained | None = None) -> None:
         if wlstsq_nc is None:
@@ -269,7 +269,7 @@ def constraint_residual(
     residual: problem_types.Residual,
     *,
     ssm: ssm_impl.FactSsmImpl,
-    linearization: Linearization | None = None,
+    taylor_point: TaylorPointFinder | None = None,
 ):
     r"""Construct a general constraint.
 
@@ -294,56 +294,15 @@ def constraint_residual(
         The residual to apply linearization to.
     ssm
         The state-space model to use for the constraint.
-    linearization
-        The strategy to use for finding the linearization point. If None, the prior mean is used as the linearization point.
+    taylor_point
+        The strategy to use for finding the linearization point for the Taylor expansion.
+        If None, the prior mean is used as the linearization point.
         Adjust this variable to use posterior linearization (also known as iterated filtering).
 
     """
     if not isinstance(residual, problem_types.Residual):
         raise TypeError(residual)
 
-    if linearization is None:
-        linearization = linearization_prior_mean()
-    return ssm.linearize.residual(residual=residual, linearization=linearization)
-
-
-# def constraint_dae(
-#     dae: problem_types.residual_from_stack,
-#     *,
-#     ssm: ssm_impl.FactSsmImpl,
-#     linearization: Linearization | None = None,
-# ):
-#     r"""Like `constraint`, but for DAEs.
-
-#     The advantage of a dedicated DAE constraint is that algebraic and differential
-#     roots can enjoy different jet-orders, which increases accuracy.
-
-#     This constraint handles problems of the form
-
-#     $$
-#     f\left(u(t), \frac{du}{dt}(t), ..., \frac{d^k u}{dt^k}(t), t\right) = 0,
-#     ~~~
-#     g\left(u(t), \frac{du}{dt}(t), ..., \frac{d^{k-1} u}{dt^{k-1}}(t), t\right) = 0
-#     $$
-
-#     where $f$ is the differential part and $g$ the algebraic part of the DAE. The order of the problem is read off the number of positional arguments in the algebraic root $g$ (argument `algebraic`), plus one. For instance, if the algebraic root has two positional arguments, then the problem is a second-order DAE. The differential root (argument `differential`) is expected to have one positional argument more than the algebraic root; in the previous example, the differential root would be expected to have three positional arguments.
-
-
-#     !!! warning "Warning: highly EXPERIMENTAL feature!"
-#         This function is highly experimental and not safe to use.
-#         There is no guarantee that it works correctly (or at all).
-#         It might be deleted tomorrow and without any deprecation policy.
-
-#     Parameters
-#     ----------
-#     dae
-#         The differential-algebraic equation system.
-#     ssm
-#         The state-space model to use for the constraint.
-#     linearization
-#         The strategy to use for finding the linearization point. If None, the prior mean is used as the linearization point.
-#     """
-#     if linearization is None:
-#         linearization = linearization_prior_mean()
-
-#     return ssm.linearize.dae(dae=dae, linearization=linearization)
+    if taylor_point is None:
+        taylor_point = taylor_point_prior_mean()
+    return ssm.linearize.residual(residual=residual, taylor_point=taylor_point)

--- a/probdiffeq/_probdiffeq/constraints.py
+++ b/probdiffeq/_probdiffeq/constraints.py
@@ -52,7 +52,6 @@ __all__ = [
     "Constraint",
     "Linearization",
     "WeightedLeastSquaresNonlinearlyConstrained",
-    "constraint_dae",
     "constraint_ode_ts0",
     "constraint_ode_ts1",
     "constraint_residual",
@@ -176,7 +175,11 @@ class linearization_prior_mean(Linearization):
 class linearization_map(Linearization):
     """Linearization point is the maximum-a-posteriori estimate."""
 
-    def __init__(self, wlstsq_nc: WeightedLeastSquaresNonlinearlyConstrained) -> None:
+    def __init__(
+        self, wlstsq_nc: WeightedLeastSquaresNonlinearlyConstrained | None = None
+    ) -> None:
+        if wlstsq_nc is None:
+            wlstsq_nc = wlstsq_nc_gauss_newton()
         self.wlstsq_nc = wlstsq_nc
 
     def __call__(self, constraint_flat: Callable, rv) -> Array:
@@ -302,43 +305,43 @@ def constraint_residual(
     return ssm.linearize.residual(residual=residual, linearization=linearization)
 
 
-def constraint_dae(
-    dae: problem_types.dae_system,
-    *,
-    ssm: ssm_impl.FactSsmImpl,
-    linearization: Linearization | None = None,
-):
-    r"""Like `constraint`, but for DAEs.
+# def constraint_dae(
+#     dae: problem_types.residual_from_stack,
+#     *,
+#     ssm: ssm_impl.FactSsmImpl,
+#     linearization: Linearization | None = None,
+# ):
+#     r"""Like `constraint`, but for DAEs.
 
-    The advantage of a dedicated DAE constraint is that algebraic and differential
-    roots can enjoy different jet-orders, which increases accuracy.
+#     The advantage of a dedicated DAE constraint is that algebraic and differential
+#     roots can enjoy different jet-orders, which increases accuracy.
 
-    This constraint handles problems of the form
+#     This constraint handles problems of the form
 
-    $$
-    f\left(u(t), \frac{du}{dt}(t), ..., \frac{d^k u}{dt^k}(t), t\right) = 0,
-    ~~~
-    g\left(u(t), \frac{du}{dt}(t), ..., \frac{d^{k-1} u}{dt^{k-1}}(t), t\right) = 0
-    $$
+#     $$
+#     f\left(u(t), \frac{du}{dt}(t), ..., \frac{d^k u}{dt^k}(t), t\right) = 0,
+#     ~~~
+#     g\left(u(t), \frac{du}{dt}(t), ..., \frac{d^{k-1} u}{dt^{k-1}}(t), t\right) = 0
+#     $$
 
-    where $f$ is the differential part and $g$ the algebraic part of the DAE. The order of the problem is read off the number of positional arguments in the algebraic root $g$ (argument `algebraic`), plus one. For instance, if the algebraic root has two positional arguments, then the problem is a second-order DAE. The differential root (argument `differential`) is expected to have one positional argument more than the algebraic root; in the previous example, the differential root would be expected to have three positional arguments.
+#     where $f$ is the differential part and $g$ the algebraic part of the DAE. The order of the problem is read off the number of positional arguments in the algebraic root $g$ (argument `algebraic`), plus one. For instance, if the algebraic root has two positional arguments, then the problem is a second-order DAE. The differential root (argument `differential`) is expected to have one positional argument more than the algebraic root; in the previous example, the differential root would be expected to have three positional arguments.
 
 
-    !!! warning "Warning: highly EXPERIMENTAL feature!"
-        This function is highly experimental and not safe to use.
-        There is no guarantee that it works correctly (or at all).
-        It might be deleted tomorrow and without any deprecation policy.
+#     !!! warning "Warning: highly EXPERIMENTAL feature!"
+#         This function is highly experimental and not safe to use.
+#         There is no guarantee that it works correctly (or at all).
+#         It might be deleted tomorrow and without any deprecation policy.
 
-    Parameters
-    ----------
-    dae
-        The differential-algebraic equation system.
-    ssm
-        The state-space model to use for the constraint.
-    linearization
-        The strategy to use for finding the linearization point. If None, the prior mean is used as the linearization point.
-    """
-    if linearization is None:
-        linearization = linearization_prior_mean()
+#     Parameters
+#     ----------
+#     dae
+#         The differential-algebraic equation system.
+#     ssm
+#         The state-space model to use for the constraint.
+#     linearization
+#         The strategy to use for finding the linearization point. If None, the prior mean is used as the linearization point.
+#     """
+#     if linearization is None:
+#         linearization = linearization_prior_mean()
 
-    return ssm.linearize.dae(dae=dae, linearization=linearization)
+#     return ssm.linearize.dae(dae=dae, linearization=linearization)

--- a/probdiffeq/_probdiffeq/constraints.py
+++ b/probdiffeq/_probdiffeq/constraints.py
@@ -73,7 +73,7 @@ class Linearization:
     Note how this object handles *where* to linearize, but not *how* to linearize.
     """
 
-    def __call__(self, constraint_flat: Callable, rv: N) -> Array:
+    def __call__(self, constraint_flat: Callable, rv: N, **constraint_kwargs) -> Array:
         """Find a linearization point.
 
         Parameters
@@ -82,6 +82,8 @@ class Linearization:
             The constraint to linearize, flattened to work with the raveled mean.
         rv
             The distribution to linearize around. The mean of this distribution is typically used as the linearization point.
+        **constraint_kwargs
+            Additional keyword-arguments to pass to the constraint function.
 
         Returns
         -------
@@ -123,7 +125,8 @@ class wlstsq_nc_gauss_newton(WeightedLeastSquaresNonlinearlyConstrained):
         self.lstsq = lstsq
         self.while_loop = while_loop
 
-    def __call__(self, constraint, x0, mean, cholesky):
+    def __call__(self, constraint, x0, mean, cholesky, **constraint_kwargs):
+
         @tree.register_dataclass
         @structs.dataclass
         class State:
@@ -148,7 +151,7 @@ class wlstsq_nc_gauss_newton(WeightedLeastSquaresNonlinearlyConstrained):
             return np.logical_and(np.logical_and(cond1, cond2), cond3)
 
         def body_fun(state: State) -> State:
-            Jx = func.jacfwd(constraint)(state.x)
+            Jx = func.jacfwd(lambda s: constraint(s, **constraint_kwargs))(state.x)
 
             H = Jx @ cholesky
             r = state.fx + Jx @ (mean - state.x)
@@ -156,10 +159,10 @@ class wlstsq_nc_gauss_newton(WeightedLeastSquaresNonlinearlyConstrained):
             dx = mean - state.x - cholesky @ dy
             xnew = state.x + dx
 
-            fxnew = constraint(xnew)
+            fxnew = constraint(xnew, **constraint_kwargs)
             return State(xnew, fxnew, dx=xnew - state.x, i=state.i + 1)
 
-        init = State(x0, constraint(x0), dx=np.ones_like(x0), i=0)
+        init = State(x0, constraint(x0, **constraint_kwargs), dx=np.ones_like(x0), i=0)
         final = self.while_loop(cond_fun, body_fun, init=init)
         return final.x, {"iters": final.i}
 
@@ -167,8 +170,9 @@ class wlstsq_nc_gauss_newton(WeightedLeastSquaresNonlinearlyConstrained):
 class linearization_prior_mean(Linearization):
     """Linearization point is the prior mean."""
 
-    def __call__(self, constraint_flat: Callable, rv) -> Array:
+    def __call__(self, constraint_flat: Callable, rv, **constraint_kwargs) -> Array:
         del constraint_flat
+        del constraint_kwargs
         return rv.mean_flat
 
 
@@ -182,10 +186,10 @@ class linearization_map(Linearization):
             wlstsq_nc = wlstsq_nc_gauss_newton()
         self.wlstsq_nc = wlstsq_nc
 
-    def __call__(self, constraint_flat: Callable, rv) -> Array:
+    def __call__(self, constraint_flat: Callable, rv, **constraint_kwargs) -> Array:
         mean = rv.mean_flat
         mean, _info = self.wlstsq_nc(
-            constraint_flat, mean, rv.mean_flat, rv.cholesky_flat
+            constraint_flat, mean, rv.mean_flat, rv.cholesky_flat, **constraint_kwargs
         )
         return mean
 

--- a/probdiffeq/_probdiffeq/constraints.py
+++ b/probdiffeq/_probdiffeq/constraints.py
@@ -51,7 +51,7 @@ from probdiffeq.backend.typing import Array, Callable, Protocol, Sequence, TypeV
 __all__ = [
     "Constraint",
     "LstSqConstrained",
-    "TaylorPointFinder",
+    "TaylorPoint",
     "constraint_ode_ts0",
     "constraint_ode_ts1",
     "constraint_residual",
@@ -67,7 +67,7 @@ Used to type marginals, for example.
 """
 
 
-class TaylorPointFinder:
+class TaylorPoint:
     """Find a linearization point for the Taylor expansion.
 
     Use this API to distinguish iterated filtering from extended filtering.
@@ -167,8 +167,8 @@ class lstsq_constrained_gauss_newton(LstSqConstrained):
         return final.x, {"iters": final.i}
 
 
-class taylor_point_prior(TaylorPointFinder):
-    """TaylorPointFinder point is the prior mean."""
+class taylor_point_prior(TaylorPoint):
+    """TaylorPoint point is the prior mean."""
 
     def __call__(self, constraint_flat: Callable, rv, **constraint_kwargs) -> Array:
         del constraint_flat
@@ -176,8 +176,8 @@ class taylor_point_prior(TaylorPointFinder):
         return rv.mean_flat
 
 
-class taylor_point_maximum_a_posteriori(TaylorPointFinder):
-    """TaylorPointFinder point is the maximum-a-posteriori estimate."""
+class taylor_point_maximum_a_posteriori(TaylorPoint):
+    """TaylorPoint point is the maximum-a-posteriori estimate."""
 
     def __init__(self, wlstsq_nc: LstSqConstrained | None = None) -> None:
         if wlstsq_nc is None:
@@ -269,7 +269,7 @@ def constraint_residual(
     residual: problem_types.Residual,
     *,
     ssm: ssm_impl.FactSsmImpl,
-    taylor_point: TaylorPointFinder | None = None,
+    taylor_point: TaylorPoint | None = None,
 ):
     r"""Construct a general constraint.
 

--- a/probdiffeq/_probdiffeq/constraints.py
+++ b/probdiffeq/_probdiffeq/constraints.py
@@ -56,8 +56,8 @@ __all__ = [
     "constraint_ode_ts1",
     "constraint_residual",
     "lstsq_constrained_gauss_newton",
-    "taylor_point_map",
-    "taylor_point_prior_mean",
+    "taylor_point_maximum_a_posteriori",
+    "taylor_point_prior",
 ]
 
 N = TypeVar("N", bound=ssm_impl.AbstractTreeNormal)
@@ -167,7 +167,7 @@ class lstsq_constrained_gauss_newton(LstSqConstrained):
         return final.x, {"iters": final.i}
 
 
-class taylor_point_prior_mean(TaylorPointFinder):
+class taylor_point_prior(TaylorPointFinder):
     """TaylorPointFinder point is the prior mean."""
 
     def __call__(self, constraint_flat: Callable, rv, **constraint_kwargs) -> Array:
@@ -176,7 +176,7 @@ class taylor_point_prior_mean(TaylorPointFinder):
         return rv.mean_flat
 
 
-class taylor_point_map(TaylorPointFinder):
+class taylor_point_maximum_a_posteriori(TaylorPointFinder):
     """TaylorPointFinder point is the maximum-a-posteriori estimate."""
 
     def __init__(self, wlstsq_nc: LstSqConstrained | None = None) -> None:
@@ -304,5 +304,5 @@ def constraint_residual(
         raise TypeError(residual)
 
     if taylor_point is None:
-        taylor_point = taylor_point_prior_mean()
+        taylor_point = taylor_point_prior()
     return ssm.linearize.residual(residual=residual, taylor_point=taylor_point)

--- a/probdiffeq/_probdiffeq/constraints.py
+++ b/probdiffeq/_probdiffeq/constraints.py
@@ -51,13 +51,13 @@ from probdiffeq.backend.typing import Array, Callable, Protocol, Sequence, TypeV
 __all__ = [
     "Constraint",
     "Linearization",
-    "WeightedLeastSquaresNonlinearlyConstrained",
+    "LstSqConstrained",
     "constraint_ode_ts0",
     "constraint_ode_ts1",
     "constraint_residual",
     "linearization_map",
     "linearization_prior_mean",
-    "wlstsq_nc_gauss_newton",
+    "lstsq_constrained_gauss_newton",
 ]
 
 N = TypeVar("N", bound=ssm_impl.AbstractTreeNormal)
@@ -93,8 +93,8 @@ class Linearization:
         raise NotImplementedError
 
 
-class WeightedLeastSquaresNonlinearlyConstrained:
-    r"""Solve nonlinearly constrained least-squares problems.
+class LstSqConstrained:
+    r"""Solve nonlinearly-constrained, weighted least-squares problems.
 
     Concretely, solve problems of the form
 
@@ -109,8 +109,8 @@ class WeightedLeastSquaresNonlinearlyConstrained:
         raise NotImplementedError
 
 
-class wlstsq_nc_gauss_newton(WeightedLeastSquaresNonlinearlyConstrained):
-    """Solve the weighted lstsq problem with nonlinear constraints using Gauss--Newton."""
+class lstsq_constrained_gauss_newton(LstSqConstrained):
+    """Solve the constrained LstSq problem using Gauss--Newton."""
 
     def __init__(
         self,
@@ -179,11 +179,9 @@ class linearization_prior_mean(Linearization):
 class linearization_map(Linearization):
     """Linearization point is the maximum-a-posteriori estimate."""
 
-    def __init__(
-        self, wlstsq_nc: WeightedLeastSquaresNonlinearlyConstrained | None = None
-    ) -> None:
+    def __init__(self, wlstsq_nc: LstSqConstrained | None = None) -> None:
         if wlstsq_nc is None:
-            wlstsq_nc = wlstsq_nc_gauss_newton()
+            wlstsq_nc = lstsq_constrained_gauss_newton()
         self.wlstsq_nc = wlstsq_nc
 
     def __call__(self, constraint_flat: Callable, rv, **constraint_kwargs) -> Array:

--- a/probdiffeq/_probdiffeq/jet_expansion_algorithms.py
+++ b/probdiffeq/_probdiffeq/jet_expansion_algorithms.py
@@ -368,12 +368,11 @@ def _allow_pytree_inits(expand):
 
 
 def jetexpand_residual(
-    num: int,
-    nlstsq: constraints.WeightedLeastSquaresNonlinearlyConstrained | None = None,
+    num: int, nlstsq: constraints.LstSqConstrained | None = None
 ) -> JetExpansionAlg[problem_types.Residual]:
     """Evaluate the Taylor series of a differential-algebraic equation system."""
     if nlstsq is None:
-        nlstsq = constraints.wlstsq_nc_gauss_newton()
+        nlstsq = constraints.lstsq_constrained_gauss_newton()
 
     # TODO: don't try too hard to refactor this one here, I dont think it'll be around for long
     # TODO: enable pytree inputs/outputs

--- a/probdiffeq/_probdiffeq/jet_expansion_algorithms.py
+++ b/probdiffeq/_probdiffeq/jet_expansion_algorithms.py
@@ -7,17 +7,17 @@ from probdiffeq.backend.typing import Array, Protocol, Sequence, TypeVar
 
 __all__ = [
     "JetExpansionAlg",
-    "jetexpand_dae_nlstsq",
     "jetexpand_ode_doubling_unroll",
     "jetexpand_ode_padded_scan",
     "jetexpand_ode_unroll",
     "jetexpand_ode_via_jvp",
+    "jetexpand_residual",
 ]
 
 
 T = TypeVar("T")
 F = TypeVar(
-    "F", bound=problem_types.ODEFunction | problem_types.dae_system, contravariant=True
+    "F", bound=problem_types.ODEFunction | problem_types.Residual, contravariant=True
 )
 
 
@@ -367,10 +367,10 @@ def _allow_pytree_inits(expand):
     return expand_wrapped
 
 
-def jetexpand_dae_nlstsq(
+def jetexpand_residual(
     num: int,
     nlstsq: constraints.WeightedLeastSquaresNonlinearlyConstrained | None = None,
-) -> JetExpansionAlg[problem_types.dae_system]:
+) -> JetExpansionAlg[problem_types.Residual]:
     """Evaluate the Taylor series of a differential-algebraic equation system."""
     if nlstsq is None:
         nlstsq = constraints.wlstsq_nc_gauss_newton()
@@ -379,7 +379,7 @@ def jetexpand_dae_nlstsq(
     # TODO: enable pytree inputs/outputs
     # TODO: raise error if DAE has the wrong type
     def expand(
-        dae: problem_types.dae_system, inits: Sequence[T], /, *, t: float
+        residual: problem_types.Residual, inits: Sequence[T], /, *, t: float
     ) -> tuple[list[T], dict]:
         """Evaluate the Taylor series of a differential-algebraic equation system.
 
@@ -411,19 +411,11 @@ def jetexpand_dae_nlstsq(
 
         def residual_jet(tcoeffs_flat):
             tcoeffs_all = unravel(tcoeffs_flat)
-
-            jet_order1 = dae.differential.num_derivatives_in_args
-            diff_eval1 = dae.differential.residual_function(
-                jet_coords=tcoeffs_all[:jet_order1], t=t
-            )
-
-            jet_order2 = dae.algebraic.num_derivatives_in_args
-            diff_eval2 = dae.algebraic.residual_function(
-                jet_coords=tcoeffs_all[:jet_order2], t=t
-            )
+            coords = tcoeffs_all[: residual.num_derivatives_in_args]
+            output = residual.residual_function(jet_coords=coords, t=t)
 
             # Flatten the output so that the Jacobians are matrices, not Pytrees.
-            return tree.ravel_pytree([diff_eval1, diff_eval2])[0]
+            return tree.ravel_pytree(output)[0]
 
         x1, info = nlstsq(residual_jet, x0, rv.mean_flat, rv.cholesky_flat)
         return list(unravel(x1)), info

--- a/probdiffeq/_probdiffeq/jet_expansion_algorithms.py
+++ b/probdiffeq/_probdiffeq/jet_expansion_algorithms.py
@@ -374,9 +374,7 @@ def jetexpand_residual(
     if nlstsq is None:
         nlstsq = constraints.lstsq_constrained_gauss_newton()
 
-    # TODO: don't try too hard to refactor this one here, I dont think it'll be around for long
     # TODO: enable pytree inputs/outputs
-    # TODO: raise error if DAE has the wrong type
     def expand(
         residual: problem_types.Residual, inits: Sequence[T], /, *, t: float
     ) -> tuple[list[T], dict]:

--- a/probdiffeq/_probdiffeq/priors.py
+++ b/probdiffeq/_probdiffeq/priors.py
@@ -12,6 +12,8 @@ __all__ = [
     "prior_wiener_integrated",
     "prior_wiener_integrated_diffuse",
 ]
+
+
 C = TypeVar("C", bound=Sequence)
 """A type-variable to describe sequences.
 

--- a/probdiffeq/_probdiffeq/problem_types.py
+++ b/probdiffeq/_probdiffeq/problem_types.py
@@ -68,13 +68,13 @@ __all__ = [
     "ProtocolResidualState",
     "ProtocolResidualVelocity",
     "Residual",
-    "dae_system",
     "jacobian_hutchinson_fwd",
     "jacobian_hutchinson_rev",
     "jacobian_materialize",
     "jet_lift",
     "ode",
     "ode_second_order",
+    "residual_from_stack",
     "residual_state",
     "residual_state_velocity",
     "residual_state_velocity_acceleration",
@@ -373,6 +373,21 @@ def residual_state(
     return Residual(jetfunc, jacobian=jacobian, num_derivatives_in_args=1)
 
 
+def residual_from_stack(*residual_stack: *tuple[Residual, ...]) -> Residual:
+    """Construct a description of a residual by stacking other residuals."""
+
+    def jetfunc(*, jet_coords: Sequence[T], t: float) -> list[T]:
+        return [
+            r.residual_function(jet_coords=jet_coords[: r.num_derivatives_in_args], t=t)
+            for r in residual_stack
+        ]
+
+    nums = [r.num_derivatives_in_args for r in residual_stack]
+    num_args = max(nums)
+    jacobian = residual_stack[0].jacobian
+    return Residual(jetfunc, jacobian=jacobian, num_derivatives_in_args=num_args)
+
+
 class ProtocolResidualVelocity(Protocol[T_contra]):
     def __call__(self, u: T_contra, du: T_contra, /, *, t: float) -> Any: ...
 
@@ -417,22 +432,6 @@ def residual_state_velocity_acceleration(
         jacobian = jacobian_hutchinson_fwd()
 
     return Residual(jetfunc, jacobian=jacobian, num_derivatives_in_args=3)
-
-
-class dae_system:
-    """Differential-algebraic equations."""
-
-    def __init__(self, differential: Residual, algebraic: Residual):
-        if not isinstance(differential, Residual):
-            raise TypeError(differential)
-        if not isinstance(algebraic, Residual):
-            raise TypeError(algebraic)
-
-        self.differential = differential
-        self.algebraic = algebraic
-
-    def __repr__(self):
-        return f"{self.__class__.__name__}(differential={self.differential}, algebraic={self.algebraic})"
 
 
 def jet_lift(residual: Residual, lift_by: int) -> Residual:

--- a/probdiffeq/_probdiffeq/problem_types.py
+++ b/probdiffeq/_probdiffeq/problem_types.py
@@ -92,7 +92,7 @@ class JacobianHandler:
         """
         raise NotImplementedError
 
-    def materialize_dense(self, fun, x, state, /):
+    def materialize_dense(self, fun, x, state, /, **fun_kwargs):
         """Materialize a dense Jacobian.
 
         This is typically used for first-order linearization in dense
@@ -100,7 +100,7 @@ class JacobianHandler:
         """
         raise NotImplementedError
 
-    def calculate_trace(self, fun, x, state, /):
+    def calculate_trace(self, fun, x, state, /, **fun_kwargs):
         """Calculate the trace of a Jacobian.
 
         This is typically used for first-order linearization in isotropic
@@ -108,7 +108,7 @@ class JacobianHandler:
         """
         raise NotImplementedError
 
-    def calculate_diagonal(self, fun, x, state, /):
+    def calculate_diagonal(self, fun, x, state, /, **fun_kwargs):
         """Calculate the diagonal of a Jacobian.
 
         This is typically used for first-order linearization in block-diagonal
@@ -132,23 +132,23 @@ class jacobian_materialize(JacobianHandler):
     def init_jacobian_handler(self):
         return ()
 
-    def materialize_dense(self, fun, x, state, /):
+    def materialize_dense(self, fun, x, state, /, **fun_kwargs):
         del state
-        fx = fun(x)
-        dfx = func.jacfwd(fun)(x)
+        fx = fun(x, **fun_kwargs)
+        dfx = func.jacfwd(lambda s: fun(s, **fun_kwargs))(x)
         return fx, dfx, ()
 
-    def calculate_trace(self, fun, x, state, /):
+    def calculate_trace(self, fun, x, state, /, **fun_kwargs):
         del state
-        fx = fun(x)
-        dfx = func.jacfwd(fun)(x)
+        fx = fun(x, **fun_kwargs)
+        dfx = func.jacfwd(lambda s: fun(s, **fun_kwargs))(x)
         dfx_trace = linalg.trace(dfx)
         return fx, dfx_trace, ()
 
-    def calculate_diagonal(self, fun, x, state, /):
+    def calculate_diagonal(self, fun, x, state, /, **fun_kwargs):
         del state
         fx = fun(x)
-        dfx = func.jacfwd(fun)(x)
+        dfx = func.jacfwd(lambda s: fun(s, **fun_kwargs))(x)
         dfx_diagonal = linalg.diagonal(dfx)
         return fx, dfx_diagonal, ()
 
@@ -179,29 +179,29 @@ class jacobian_hutchinson_fwd(JacobianHandler):
     def init_jacobian_handler(self):
         return random.prng_key(seed=self.seed)
 
-    def materialize_dense(self, fun, x, state, /):
+    def materialize_dense(self, fun, x, state, /, **fun_kwargs):
         # TODO: approximate Jacobian with outer products instead of forming?
         # What is the "correct" thing to do?
-        fx = fun(x)
-        dfx = func.jacfwd(fun)(x)
+        fx = fun(x, **fun_kwargs)
+        dfx = func.jacfwd(lambda s: fun(s, **fun_kwargs))(x)
         return fx, dfx, state
 
-    def calculate_trace(self, fun, x, key, /):
+    def calculate_trace(self, fun, x, key, /, **fun_kwargs):
         key, subkey = random.split(key, num=2)
         sample_shape = (self.num_probes, *x.shape)
         v = random.rademacher(subkey, shape=sample_shape, dtype=x.dtype)
 
-        fx, Jvp = func.linearize(fun, x)
+        fx, Jvp = func.linearize(lambda s: fun(s, **fun_kwargs), x)
         J_trace = func.vmap(lambda s: linalg.vector_dot(s, Jvp(s)))(v)
         J_trace = J_trace.mean(axis=0)
         return fx, J_trace, key
 
-    def calculate_diagonal(self, fun, x, key, /):
+    def calculate_diagonal(self, fun, x, key, /, **fun_kwargs):
         key, subkey = random.split(key, num=2)
         sample_shape = (self.num_probes, *x.shape)
         v = random.rademacher(subkey, shape=sample_shape, dtype=x.dtype)
 
-        fx, Jvp = func.linearize(fun, x)
+        fx, Jvp = func.linearize(lambda s: fun(s, **fun_kwargs), x)
         vJv = func.vmap(lambda s: s * Jvp(s))(v)
         J_diagonal = vJv.mean(axis=0)
         return fx, J_diagonal, key
@@ -233,29 +233,29 @@ class jacobian_hutchinson_rev(JacobianHandler):
     def init_jacobian_handler(self):
         return random.prng_key(seed=self.seed)
 
-    def materialize_dense(self, fun, x, state, /):
+    def materialize_dense(self, fun, x, state, /, **fun_kwargs):
         # TODO: approximate Jacobian with outer products instead of forming?
         # What is the "correct" thing to do?
-        fx = fun(x)
-        dfx = func.jacrev(fun)(x)
+        fx = fun(x, **fun_kwargs)
+        dfx = func.jacrev(lambda s: fun(s, **fun_kwargs))(x)
         return fx, dfx, state
 
-    def calculate_trace(self, fun, x, key, /):
+    def calculate_trace(self, fun, x, key, /, **fun_kwargs):
         key, subkey = random.split(key, num=2)
         sample_shape = (self.num_probes, *x.shape)
         v = random.rademacher(subkey, shape=sample_shape, dtype=x.dtype)
 
-        fx, vjp = func.vjp(fun, x)
+        fx, vjp = func.vjp(lambda s: fun(s, **fun_kwargs), x)
         J_trace = func.vmap(lambda s: linalg.vector_dot(s, vjp(s)[0]))(v)
         J_trace = J_trace.mean(axis=0)
         return fx, J_trace, key
 
-    def calculate_diagonal(self, fun, x, key, /):
+    def calculate_diagonal(self, fun, x, key, /, **fun_kwargs):
         key, subkey = random.split(key, num=2)
         sample_shape = (self.num_probes, *x.shape)
         v = random.rademacher(subkey, shape=sample_shape, dtype=x.dtype)
 
-        fx, vjp = func.vjp(fun, x)
+        fx, vjp = func.vjp(lambda s: fun(s, **fun_kwargs), x)
         vJv = func.vmap(lambda s: s * vjp(s)[0])(v)
         J_diagonal = vJv.mean(axis=0)
         return fx, J_diagonal, key

--- a/probdiffeq/_ssm_impl/factorisation_via_blockdiag.py
+++ b/probdiffeq/_ssm_impl/factorisation_via_blockdiag.py
@@ -1,6 +1,6 @@
 from probdiffeq._ssm_impl import interfaces, utilities
 from probdiffeq.backend import func, linalg, np, random, structs, tree
-from probdiffeq.backend.typing import Any, Array, Callable, Sequence, TypeVar
+from probdiffeq.backend.typing import Any, Array, Sequence, TypeVar
 from probdiffeq.util import cholesky_util
 
 __all__ = [
@@ -254,7 +254,7 @@ class BlockDiagPriorFactory(interfaces.AbstractPriorFactory):
 class BlockDiagLinearizationFactory(interfaces.AbstractLinearizationFactory):
     """Construct a block-diagonal linearization-factory."""
 
-    def residual(self, *, residual, linearization: Callable | None):
+    def residual(self, *, residual, taylor_point):
         raise NotImplementedError
 
     def ode_taylor_0th(self, *, ode):

--- a/probdiffeq/_ssm_impl/factorisation_via_blockdiag.py
+++ b/probdiffeq/_ssm_impl/factorisation_via_blockdiag.py
@@ -257,9 +257,6 @@ class BlockDiagLinearizationFactory(interfaces.AbstractLinearizationFactory):
     def residual(self, *, residual, linearization: Callable | None):
         raise NotImplementedError
 
-    def dae(self, *, dae, linearization):
-        raise NotImplementedError
-
     def ode_taylor_0th(self, *, ode):
         return BlockDiagOdeTs0(ode=ode)
 

--- a/probdiffeq/_ssm_impl/factorisation_via_dense.py
+++ b/probdiffeq/_ssm_impl/factorisation_via_dense.py
@@ -450,7 +450,7 @@ class DenseLinearizationFactory(interfaces.AbstractLinearizationFactory):
         return DenseRoot(residual, linearization=linearization)
 
     def dae(self, *, dae, linearization):
-        return DenseDAEPosteriorLinearization(dae=dae, linearization=linearization)
+        return DenseDAE(dae=dae, linearization=linearization)
 
     def ode_taylor_0th(self, *, ode):
         return DenseOdeTs0(ode=ode)
@@ -589,7 +589,7 @@ class DenseRoot(interfaces.AbstractRoot):
         return cond, state
 
 
-class DenseDAEPosteriorLinearization(interfaces.AbstractDAEPosteriorLinearization):
+class DenseDAE(interfaces.AbstractDAE):
     def init_linearization(self):
         # Skip the algebraic Jacobian because constraints get stacked
         # TODO: handle Jacobians separately and combine later

--- a/probdiffeq/_ssm_impl/factorisation_via_dense.py
+++ b/probdiffeq/_ssm_impl/factorisation_via_dense.py
@@ -454,7 +454,8 @@ class DenseLinearizationFactory(interfaces.AbstractLinearizationFactory):
 
     def ode_taylor_1st(self, *, ode):
         if ode.num_derivatives_in_args > 1:
-            msg = "Not implemented. Try the a residual-based TS1 constraint instead."
+            msg = "Not implemented."
+            msg += " Try zeroth-order methods or residual-based constraints instead."
             raise ValueError(msg)
 
         return DenseOdeTs1(ode=ode)
@@ -536,51 +537,40 @@ class DenseRoot(interfaces.AbstractRoot):
     def init_linearization(self):
         return self.residual.jacobian.init_jacobian_handler()
 
-    def constraint_flat(self, m: Array, *, t, tree_flatten) -> Array:
+    def constraint_flat(self, *, tree_flatten) -> Callable:
         """Evaluate a flattened version of the residual constraint."""
-        # Unravel the location and extract derivatives
-        m_tree = tree_flatten.unflatten_array(m)
-        relevant_tcoeffs = m_tree[: self.residual.num_derivatives_in_args]
 
-        # Evaluate the residual
-        residual_eval = self.residual.residual_function(
-            jet_coords=relevant_tcoeffs, t=t
-        )
+        def fun(m: Array, *, t):
+            # Unravel the location and extract derivatives
+            m_tree = tree_flatten.unflatten_array(m)
+            relevant_tcoeffs = m_tree[: self.residual.num_derivatives_in_args]
 
-        # Flatten the output so that the Jacobians are matrices, not Pytrees.
-        return tree.ravel_pytree(residual_eval)[0]
+            # Evaluate the residual
+            residual_eval = self.residual.residual_function(
+                jet_coords=relevant_tcoeffs, t=t
+            )
+
+            # Flatten the output so that the Jacobians are matrices, not Pytrees.
+            return tree.ravel_pytree(residual_eval)[0]
+
+        return fun
 
     def linearize(self, rv, state, *, damp: float, t):
 
         # Fix all arguments except the Array ones
-        constraint_flat = func.partial(
-            self.constraint_flat, t=t, tree_flatten=rv.tree_flatten
-        )
+        constraint_flat = self.constraint_flat(tree_flatten=rv.tree_flatten)
 
         # Get the linearization point (eg prior or posterior linearisation)
-        mean = self.linearization_point(constraint_flat, rv)
+        mean = self.linearization_point(constraint_flat, rv, t=t)
 
+        # Evaluate the linearization
         fx, linop, state = self.residual.jacobian.materialize_dense(
-            constraint_flat, mean, state
+            constraint_flat, mean, state, t=t
         )
         fx = fx - linop @ mean
 
-        # Find the tree structure of the output constraint
-        # (So that we can unravel the bias term and always work in the correct
-        # pytree structure.)
-        m_tree = rv.mean
-        relevant_tcoeffs = m_tree[: self.residual.num_derivatives_in_args]
-        residual_eval = func.eval_shape(
-            lambda s: [self.residual.residual_function(jet_coords=s, t=t)],
-            relevant_tcoeffs,
-        )
-
-        # Ensure that unravelling does not yield a ShapeDtypeStruct
-        residual_eval = tree.tree_map(np.zeros_like, residual_eval)
-        _, unravel = tree.ravel_pytree(residual_eval)
-
         # Turn the linearization into a conditional
-        noise = DenseNormal.from_dirac(unravel(fx), damp=damp)
+        noise = DenseNormal.from_dirac([fx], damp=damp)
 
         cond = interfaces.LatentCond.from_linop_and_noise(linop, noise)
         return cond, state

--- a/probdiffeq/_ssm_impl/factorisation_via_dense.py
+++ b/probdiffeq/_ssm_impl/factorisation_via_dense.py
@@ -446,8 +446,8 @@ DenseNormal.register_pytree_node()
 class DenseLinearizationFactory(interfaces.AbstractLinearizationFactory):
     """Construct a dense linearization factory."""
 
-    def residual(self, residual, *, linearization):
-        return DenseRoot(residual, linearization=linearization)
+    def residual(self, residual, *, taylor_point):
+        return DenseRoot(residual, taylor_point=taylor_point)
 
     def ode_taylor_0th(self, *, ode):
         return DenseOdeTs0(ode=ode)
@@ -530,9 +530,9 @@ class DenseOdeTs1(interfaces.AbstractOde):
 class DenseRoot(interfaces.AbstractRoot):
     """Construct a dense implementation of residual-TS1 linearization."""
 
-    def __init__(self, residual, *, linearization) -> None:
+    def __init__(self, residual, *, taylor_point) -> None:
         super().__init__(residual)
-        self.linearization_point = linearization
+        self.taylor_point = taylor_point
 
     def init_linearization(self):
         return self.residual.jacobian.init_jacobian_handler()
@@ -560,14 +560,13 @@ class DenseRoot(interfaces.AbstractRoot):
         # Fix all arguments except the Array ones
         constraint_flat = self.constraint_flat(tree_flatten=rv.tree_flatten)
 
-        # Get the linearization point (eg prior or posterior linearisation)
-        mean = self.linearization_point(constraint_flat, rv, t=t)
+        # Get the linearization point (i.e., prior or posterior linearisation)
+        xi = self.taylor_point(constraint_flat, rv, t=t)
 
         # Evaluate the linearization
-        fx, linop, state = self.residual.jacobian.materialize_dense(
-            constraint_flat, mean, state, t=t
-        )
-        fx = fx - linop @ mean
+        jacobian = self.residual.jacobian.materialize_dense
+        fx, linop, state = jacobian(constraint_flat, xi, state, t=t)
+        fx = fx - linop @ xi
 
         # Turn the linearization into a conditional
         noise = DenseNormal.from_dirac([fx], damp=damp)

--- a/probdiffeq/_ssm_impl/factorisation_via_dense.py
+++ b/probdiffeq/_ssm_impl/factorisation_via_dense.py
@@ -449,9 +449,6 @@ class DenseLinearizationFactory(interfaces.AbstractLinearizationFactory):
     def residual(self, residual, *, linearization):
         return DenseRoot(residual, linearization=linearization)
 
-    def dae(self, *, dae, linearization):
-        return DenseDAE(dae=dae, linearization=linearization)
-
     def ode_taylor_0th(self, *, ode):
         return DenseOdeTs0(ode=ode)
 
@@ -584,54 +581,6 @@ class DenseRoot(interfaces.AbstractRoot):
 
         # Turn the linearization into a conditional
         noise = DenseNormal.from_dirac(unravel(fx), damp=damp)
-
-        cond = interfaces.LatentCond.from_linop_and_noise(linop, noise)
-        return cond, state
-
-
-class DenseDAE(interfaces.AbstractDAE):
-    def init_linearization(self):
-        # Skip the algebraic Jacobian because constraints get stacked
-        # TODO: handle Jacobians separately and combine later
-        return self.dae.differential.jacobian.init_jacobian_handler()
-
-    def constraint_flat(self, m: Array, *, t, tree_flatten) -> Array:
-        """Evaluate a flattened version of the residual constraint."""
-        # Unravel the location and extract derivatives
-        m_tree = tree_flatten.unflatten_array(m)
-
-        # Evaluate the residual
-
-        jet_order1 = self.dae.differential.num_derivatives_in_args
-        diff_eval1 = self.dae.differential.residual_function(
-            jet_coords=m_tree[:jet_order1], t=t
-        )
-
-        jet_order2 = self.dae.algebraic.num_derivatives_in_args
-        diff_eval2 = self.dae.algebraic.residual_function(
-            jet_coords=m_tree[:jet_order2], t=t
-        )
-
-        # Flatten the output so that the Jacobians are matrices, not Pytrees.
-        return tree.ravel_pytree([diff_eval1, diff_eval2])[0]
-
-    def linearize(self, rv, state, *, damp: float, t):
-
-        # Fix all arguments except the Array ones
-        constraint_flat = func.partial(
-            self.constraint_flat, t=t, tree_flatten=rv.tree_flatten
-        )
-
-        # Get the linearization point (eg prior or posterior linearisation)
-        mean = self.linearization(constraint_flat, rv)
-
-        fx, linop, state = self.dae.differential.jacobian.materialize_dense(
-            constraint_flat, mean, state
-        )
-        fx = fx - linop @ mean
-
-        # Turn the linearization into a conditional
-        noise = DenseNormal.from_dirac([fx], damp=damp)
 
         cond = interfaces.LatentCond.from_linop_and_noise(linop, noise)
         return cond, state

--- a/probdiffeq/_ssm_impl/factorisation_via_isotropic.py
+++ b/probdiffeq/_ssm_impl/factorisation_via_isotropic.py
@@ -1,6 +1,6 @@
 from probdiffeq._ssm_impl import interfaces, utilities
 from probdiffeq.backend import func, linalg, np, random, structs, tree
-from probdiffeq.backend.typing import Any, Array, Callable, Sequence, TypeVar
+from probdiffeq.backend.typing import Any, Array, Sequence, TypeVar
 from probdiffeq.util import cholesky_util
 
 T = TypeVar("T", bound=Array)
@@ -416,7 +416,7 @@ class IsotropicPriorFactory(interfaces.AbstractPriorFactory):
 class IsotropicLinearizationFactory(interfaces.AbstractLinearizationFactory):
     """Construct an isotropic linearization-factory."""
 
-    def residual(self, *, residual, linearization: Callable | None):
+    def residual(self, *, residual, taylor_point):
         raise NotImplementedError
 
     def ode_taylor_1st(self, *, ode):

--- a/probdiffeq/_ssm_impl/factorisation_via_isotropic.py
+++ b/probdiffeq/_ssm_impl/factorisation_via_isotropic.py
@@ -419,9 +419,6 @@ class IsotropicLinearizationFactory(interfaces.AbstractLinearizationFactory):
     def residual(self, *, residual, linearization: Callable | None):
         raise NotImplementedError
 
-    def dae(self, *, dae, linearization):
-        raise NotImplementedError
-
     def ode_taylor_1st(self, *, ode):
         if ode.num_derivatives_in_args > 1:
             msg = "This linearization is not compatible with high-order ODEs as of yet."

--- a/probdiffeq/_ssm_impl/interfaces.py
+++ b/probdiffeq/_ssm_impl/interfaces.py
@@ -111,7 +111,7 @@ class AbstractRoot(AbstractLinearization):
         return f"{self.__class__.__name__}(residual={self.residual})"
 
 
-class AbstractDAEPosteriorLinearization(AbstractLinearization):
+class AbstractDAE(AbstractLinearization):
     """Interface for linearizations of general residuals."""
 
     def __init__(self, *, dae, linearization) -> None:
@@ -149,7 +149,7 @@ class AbstractLinearizationFactory(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def dae(self, *, dae, linearization) -> AbstractDAEPosteriorLinearization:
+    def dae(self, *, dae, linearization) -> AbstractDAE:
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/probdiffeq/_ssm_impl/interfaces.py
+++ b/probdiffeq/_ssm_impl/interfaces.py
@@ -111,17 +111,6 @@ class AbstractRoot(AbstractLinearization):
         return f"{self.__class__.__name__}(residual={self.residual})"
 
 
-class AbstractDAE(AbstractLinearization):
-    """Interface for linearizations of general residuals."""
-
-    def __init__(self, *, dae, linearization) -> None:
-        self.dae = dae
-        self.linearization = linearization
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(dae={self.dae}, linearization={self.linearization})"
-
-
 class AbstractOde(AbstractLinearization):
     """Interface for linearizations of ODEs."""
 
@@ -146,10 +135,6 @@ class AbstractLinearizationFactory(abc.ABC):
     @abc.abstractmethod
     def residual(self, residual, *, linearization: Callable | None) -> AbstractRoot:
         """Construct an implementation of 1st-order Taylor-linearization for residuals."""
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def dae(self, *, dae, linearization) -> AbstractDAE:
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/probdiffeq/_ssm_impl/interfaces.py
+++ b/probdiffeq/_ssm_impl/interfaces.py
@@ -1,5 +1,5 @@
 from probdiffeq.backend import abc, func, np, tree
-from probdiffeq.backend.typing import Array, Callable, Generic, Sequence, TypeVar
+from probdiffeq.backend.typing import Array, Generic, Sequence, TypeVar
 
 __all__ = [
     "AbstractConditional",
@@ -133,7 +133,7 @@ class AbstractLinearizationFactory(abc.ABC):
         return f"{self.__class__.__name__}()"
 
     @abc.abstractmethod
-    def residual(self, residual, *, linearization: Callable | None) -> AbstractRoot:
+    def residual(self, residual, *, taylor_point) -> AbstractRoot:
         """Construct an implementation of 1st-order Taylor-linearization for residuals."""
         raise NotImplementedError
 

--- a/tests/test_probdiffeq/test_constraint_dae.py
+++ b/tests/test_probdiffeq/test_constraint_dae.py
@@ -19,7 +19,7 @@ def solve_ode(inits, num):
     def vf_ode(y, /, *, t):
         del t
         beta, gamma = 2.0, 0.5  # infection and recovery rates
-        S, I, _R = y  # noqa: E741 ("I" is a good variable name in an SIR model)
+        S, I, _R = y  # noqa: E741 ("I" is in fact a good variable name in SIR models)
 
         f0 = -beta * S * I
         f1 = beta * S * I - gamma * I

--- a/tests/test_probdiffeq/test_constraint_dae.py
+++ b/tests/test_probdiffeq/test_constraint_dae.py
@@ -68,14 +68,14 @@ def solve_dae(inits, num):
 
         return np.stack([F1, F2])
 
-    dae = probdiffeq.dae_system(differential=differential, algebraic=algebraic)
+    residual = probdiffeq.residual_from_stack(differential, algebraic)
 
-    jetexpand = probdiffeq.jetexpand_dae_nlstsq(num=num)
-    tcoeffs, _ = jetexpand(dae, inits, t=0.0)
+    jetexpand = probdiffeq.jetexpand_residual(num=num)
+    tcoeffs, _ = jetexpand(residual, inits, t=0.0)
 
     ssm = probdiffeq.state_space_model(ssm_fact="dense")
     init, iwp = probdiffeq.prior_wiener_integrated(tcoeffs, ssm=ssm)
-    ts0 = probdiffeq.constraint_dae(dae, ssm=ssm)
+    ts0 = probdiffeq.constraint_residual(residual, ssm=ssm)
     strategy = probdiffeq.strategy_filter(ssm=ssm)
     solver = probdiffeq.solver(strategy=strategy, prior=iwp, constraint=ts0, ssm=ssm)
     error = probdiffeq.error_state_std(constraint=ts0, prior=iwp, ssm=ssm)

--- a/tests/test_probdiffeq/test_constraint_jet_lift.py
+++ b/tests/test_probdiffeq/test_constraint_jet_lift.py
@@ -95,7 +95,7 @@ def fixture_expected(residual, derivatives):
 
 
 def case_jet_lift_dae(residual):
-    linearization = probdiffeq.linearization_map()
+    taylor_point = probdiffeq.taylor_point_map()
 
     def constraint_residual(ssm, lift_by: int):
         differential = probdiffeq.residual_state_velocity(
@@ -108,20 +108,20 @@ def case_jet_lift_dae(residual):
         residual_stack = probdiffeq.residual_from_stack(differential, algebraic)
 
         return probdiffeq.constraint_residual(
-            residual_stack, ssm=ssm, linearization=linearization
+            residual_stack, ssm=ssm, taylor_point=taylor_point
         )
 
     return constraint_residual
 
 
 def case_jet_lift_residual(residual):
-    linearization = probdiffeq.linearization_map()
+    taylor_point = probdiffeq.taylor_point_map()
 
     def constraint_residual(ssm, lift_by: int):
         implicit = probdiffeq.residual_state_velocity(residual.residual)
         implicit = probdiffeq.jet_lift(implicit, lift_by=lift_by)
         return probdiffeq.constraint_residual(
-            implicit, ssm=ssm, linearization=linearization
+            implicit, ssm=ssm, taylor_point=taylor_point
         )
 
     return constraint_residual

--- a/tests/test_probdiffeq/test_constraint_jet_lift.py
+++ b/tests/test_probdiffeq/test_constraint_jet_lift.py
@@ -14,8 +14,8 @@ class Root:
     """
 
     residual: Callable
-    residual_dae_algebraic: Callable
-    residual_dae_differential: Callable
+    residual_algebraic: Callable
+    residual_differential: Callable
     ode_vf: Callable
     t0: float
     u0: Array
@@ -74,8 +74,8 @@ def fixture_residual_sir():
     t0 = 0.0
     return Root(
         residual=residual,
-        residual_dae_differential=dae_differential,
-        residual_dae_algebraic=dae_algebraic,
+        residual_differential=dae_differential,
+        residual_algebraic=dae_algebraic,
         ode_vf=vf,
         t0=t0,
         u0=u0,
@@ -95,27 +95,27 @@ def fixture_expected(residual, derivatives):
 
 
 def case_jet_lift_dae(residual):
-    nlstsq = probdiffeq.wlstsq_nc_gauss_newton(maxiter=50, tol=1e-10)
-    linearization = probdiffeq.linearization_map(nlstsq)
+    linearization = probdiffeq.linearization_map()
 
     def constraint_residual(ssm, lift_by: int):
         differential = probdiffeq.residual_state_velocity(
-            residual.residual_dae_differential
+            residual.residual_differential
         )
         differential = probdiffeq.jet_lift(differential, lift_by=lift_by)
 
-        algebraic = probdiffeq.residual_state(residual.residual_dae_algebraic)
+        algebraic = probdiffeq.residual_state(residual.residual_algebraic)
         algebraic = probdiffeq.jet_lift(algebraic, lift_by=lift_by + 1)
-        dae = probdiffeq.dae_system(differential, algebraic)
+        residual_stack = probdiffeq.residual_from_stack(differential, algebraic)
 
-        return probdiffeq.constraint_dae(dae, ssm=ssm, linearization=linearization)
+        return probdiffeq.constraint_residual(
+            residual_stack, ssm=ssm, linearization=linearization
+        )
 
     return constraint_residual
 
 
 def case_jet_lift_residual(residual):
-    nlstsq = probdiffeq.wlstsq_nc_gauss_newton(maxiter=50, tol=1e-10)
-    linearization = probdiffeq.linearization_map(nlstsq)
+    linearization = probdiffeq.linearization_map()
 
     def constraint_residual(ssm, lift_by: int):
         implicit = probdiffeq.residual_state_velocity(residual.residual)

--- a/tests/test_probdiffeq/test_constraint_jet_lift.py
+++ b/tests/test_probdiffeq/test_constraint_jet_lift.py
@@ -95,7 +95,7 @@ def fixture_expected(residual, derivatives):
 
 
 def case_jet_lift_dae(residual):
-    taylor_point = probdiffeq.taylor_point_map()
+    taylor_point = probdiffeq.taylor_point_maximum_a_posteriori()
 
     def constraint_residual(ssm, lift_by: int):
         differential = probdiffeq.residual_state_velocity(
@@ -115,7 +115,7 @@ def case_jet_lift_dae(residual):
 
 
 def case_jet_lift_residual(residual):
-    taylor_point = probdiffeq.taylor_point_map()
+    taylor_point = probdiffeq.taylor_point_maximum_a_posteriori()
 
     def constraint_residual(ssm, lift_by: int):
         implicit = probdiffeq.residual_state_velocity(residual.residual)

--- a/tests/test_probdiffeq/test_jetexpand/test_residual.py
+++ b/tests/test_probdiffeq/test_jetexpand/test_residual.py
@@ -5,22 +5,22 @@ from probdiffeq.backend import func, np, testing
 
 
 @testing.parametrize("num", [0, 1, 10])
-def test_daejet_matches_expectation_on_sir_model(num):
-
+def test_residual_init_matches_expectation_on_sir_model(num):
+    # todo: rename linearization to meanfinding or so
+    # Baseline
     y0 = [np.asarray([0.99, 0.01, 0.0])]
     jetexpand_ode = probdiffeq.jetexpand_ode_unroll(num=num)
     expected, _ = jetexpand_ode(vf_ode, y0, t=0.0)
 
+    # Residual via DAE
     differential_lifted = probdiffeq.jet_lift(differential, lift_by=len(expected) - 2)
     algebraic_lifted = probdiffeq.jet_lift(algebraic, lift_by=len(expected) - 1)
-    dae = probdiffeq.dae_system(
-        differential=differential_lifted, algebraic=algebraic_lifted
-    )
-    eps = np.finfo_eps(y0[0].dtype)
-    nlstsq = probdiffeq.wlstsq_nc_gauss_newton(maxiter=10, tol=eps)
-    jetexpand = probdiffeq.jetexpand_dae_nlstsq(num=num, nlstsq=nlstsq)
+    residual = probdiffeq.residual_from_stack(differential_lifted, algebraic_lifted)
+
+    # Jet expansion
+    jetexpand = probdiffeq.jetexpand_residual(num=num)
     jetexpand = func.jit(jetexpand, static_argnums=(0,))
-    received, _info = jetexpand(dae, y0, t=0.0)
+    received, _info = jetexpand(residual, y0, t=0.0)
     assert testing.allclose(received, expected)
 
 

--- a/tests/test_probdiffeq/test_solver_uses_constraint_init.py
+++ b/tests/test_probdiffeq/test_solver_uses_constraint_init.py
@@ -56,7 +56,7 @@ def test_output_matches_reference(ivp, solver_factory, derivatives, ssm_fact) ->
     )
 
     # Build a solver
-    nlstsq = probdiffeq.wlstsq_nc_gauss_newton(maxiter=50, tol=1e-10)
+    nlstsq = probdiffeq.lstsq_constrained_gauss_newton(maxiter=50, tol=1e-10)
     strategy = probdiffeq.strategy_filter(ssm=ssm)
     linearization = probdiffeq.linearization_map(nlstsq)
     constraint = probdiffeq.constraint_residual(

--- a/tests/test_probdiffeq/test_solver_uses_constraint_init.py
+++ b/tests/test_probdiffeq/test_solver_uses_constraint_init.py
@@ -58,9 +58,9 @@ def test_output_matches_reference(ivp, solver_factory, derivatives, ssm_fact) ->
     # Build a solver
     nlstsq = probdiffeq.lstsq_constrained_gauss_newton(maxiter=50, tol=1e-10)
     strategy = probdiffeq.strategy_filter(ssm=ssm)
-    linearization = probdiffeq.linearization_map(nlstsq)
+    taylor_point = probdiffeq.taylor_point_map(nlstsq)
     constraint = probdiffeq.constraint_residual(
-        residual, ssm=ssm, linearization=linearization
+        residual, ssm=ssm, taylor_point=taylor_point
     )
     solver = solver_factory(
         strategy=strategy,

--- a/tests/test_probdiffeq/test_solver_uses_constraint_init.py
+++ b/tests/test_probdiffeq/test_solver_uses_constraint_init.py
@@ -58,7 +58,7 @@ def test_output_matches_reference(ivp, solver_factory, derivatives, ssm_fact) ->
     # Build a solver
     nlstsq = probdiffeq.lstsq_constrained_gauss_newton(maxiter=50, tol=1e-10)
     strategy = probdiffeq.strategy_filter(ssm=ssm)
-    taylor_point = probdiffeq.taylor_point_map(nlstsq)
+    taylor_point = probdiffeq.taylor_point_maximum_a_posteriori(nlstsq)
     constraint = probdiffeq.constraint_residual(
         residual, ssm=ssm, taylor_point=taylor_point
     )


### PR DESCRIPTION
- Prior vs posterior linearisation is now TaylorPointFinder, taylor_point_mean, taylor_point_map, to clarify that it finds a linearization point (instead of determining how to linearise)
- All DAE code internally stacked differential and algebraic constraints, and now it is implemented as such. No dedicated DAE logic. 