### PR TITLE
Fix bug in standard deviations of isotropic and blockdiags

### DIFF
--- a/probdiffeq/_ssm_impl/factorisation_via_blockdiag.py
+++ b/probdiffeq/_ssm_impl/factorisation_via_blockdiag.py
@@ -526,10 +526,8 @@ class BlockDiagNormal(interfaces.AbstractTreeNormal[BlockDiagTreeFlatten]):
         if self.mean_flat.ndim > 2:
             return func.vmap(BlockDiagNormal._std_batched)(self)
 
-        # TODO: use QR decomp instead of einsum to avoid sqrts
-        diag = np.einsum("ijk,ikj->ij", self.cholesky_flat, self.cholesky_flat)
-        std = np.sqrt(diag)
-        return self.tree_flatten.unflatten_array(std)
+        std_flat = func.vmap(func.vmap(linalg.vector_norm))(self.cholesky_flat)
+        return self.tree_flatten.unflatten_array(std_flat)
 
     def residual_white_rms_tree(self, u, /):
         # todo: add sth like an "axis" argument to make it more obvious

--- a/probdiffeq/_ssm_impl/factorisation_via_isotropic.py
+++ b/probdiffeq/_ssm_impl/factorisation_via_isotropic.py
@@ -126,9 +126,7 @@ class IsotropicNormal(interfaces.AbstractTreeNormal[IsotropicTreeFlatten]):
     def _std_batched(self):
         if self.mean_flat.ndim > 2:
             return func.vmap(IsotropicNormal._std_batched)(self)
-        # TODO: use QR decomp instead of einsum to avoid sqrts
-        diag = np.einsum("ij,ji->i", self.cholesky_flat, self.cholesky_flat)
-        std_flat = np.sqrt(diag)
+        std_flat = func.vmap(linalg.vector_norm)(self.cholesky_flat)
         return self.tree_flatten.unflatten_array_scalar(std_flat)
 
     def residual_white_rms_tree(self, u):


### PR DESCRIPTION
It produced covariances as cholesky @ cholesky instead of cholesky @ cholesky.T. This is fixed now.