### PR TITLE
Implement a high-dimensional, stiff benchmark

### DIFF
--- a/benchmarks/A5_work-precision-burgers-pde.py
+++ b/benchmarks/A5_work-precision-burgers-pde.py
@@ -1,0 +1,287 @@
+"""Walltime | Burgers PDE."""
+
+from collections.abc import Callable
+
+import jax
+import jax.numpy as jnp
+import matplotlib.pyplot as plt
+import numpy as np
+import scipy.integrate
+import tqdm
+
+from probdiffeq import ivpsolve, probdiffeq
+from probdiffeq.util import benchmark_util
+
+# Fail this notebook on NaN detection (to catch those in the CI)
+jax.config.update("jax_debug_nans", True)
+
+N = 50
+"""Number of spatial grid points.
+
+Small enough to include dense methods,
+but large enough to penalise their O(d^3) complexity.
+"""
+
+NU = 0.01
+"""Diffusion coefficient.
+
+The larger, the stiffer the problem.
+"""
+
+
+def main(start=3.0, stop=8.0, step=1.0, repeats=1) -> None:
+    """Run the script."""
+    jax.config.update("jax_enable_x64", True)
+
+    # Visualise the dynamics
+    ts, ys = solve_ivp_once()
+
+    x = np.linspace(0.0, 1.0, N + 1, endpoint=True)[1:-1]
+    _fig, ax = plt.subplots(figsize=(5, 3))
+    pcm = ax.pcolormesh(x, ts, ys, cmap="coolwarm", vmin=-0.5, vmax=0.5)
+    _fig.colorbar(pcm, ax=ax)
+    ax.set_title("Burgers PDE")
+    ax.set_xlabel("Space")
+    ax.set_ylabel("Time")
+    plt.tight_layout()
+    plt.show()
+
+    # Read configuration from command line
+    tolerances = benchmark_util.setup_tolerances(start=start, stop=stop, step=step)
+    timeit_fun = benchmark_util.setup_timeit(repeats=repeats)
+
+    # Assemble algorithms
+    algorithms = {
+        r"TS1($3$, dense)": solver_dense(num_derivatives=3),
+        r"TS1($3$, blockdiag)": solver_blockdiag(num_derivatives=3),
+        r"TS1($3$, matfree)": solver_matfree(num_derivatives=3),
+    }
+
+    # Compute a reference solution
+    reference = solver_scipy(method="LSODA")(1e-13)
+    precision_fun = benchmark_util.rmse_absolute(reference)
+
+    # Compute all work-precision diagrams
+    results = {}
+    pbar = tqdm.tqdm(algorithms.items())
+    for label, algo in pbar:
+        pbar.set_description(label)
+        param_to_wp = benchmark_util.workprec(
+            algo, precision_fun=precision_fun, timeit_fun=timeit_fun
+        )
+        results[label] = param_to_wp(tolerances)
+
+    _fig, ax = plt.subplots(figsize=(5, 3))
+    for i, (label, wp) in enumerate(results.items()):
+        ax.loglog(wp["precision"], wp["work_mean"], ".-", label=label, color=f"C{i}")
+
+    ax.set_title("Work-precision diagram")
+    ax.set_xlabel("Precision (absolute RMSE)")
+    ax.set_ylabel("Work (avg. wall time)")
+    ax.grid(linestyle="dotted", which="both")
+    ax.legend(fontsize="small")
+
+    plt.tight_layout()
+    plt.show()
+
+
+def solve_ivp_once():
+    """Compute plotting values for the Burgers PDE."""
+
+    def vf_scipy(_t, u):
+        """Viscous Burgers equation, zero Dirichlet BC, conservative advection."""
+        dx = 1.0 / N
+        u_bc = np.pad(u, 1)  # zero Dirichlet ghosts
+        u_left = u_bc[:-2]
+        u_right = u_bc[2:]
+        flux = u_bc**2 / 2.0
+
+        fluxterm = (flux[2:] - flux[:-2]) / (2.0 * dx)
+        laplacian = (u_right - 2.0 * u + u_left) / dx**2
+        return -fluxterm + NU * laplacian
+
+    x = np.linspace(0.0, 1.0, N + 1, endpoint=True)[1:-1]
+    u0 = jnp.sin(3 * jnp.pi * x) ** 3 * (1 - x) ** 1.5
+    time_span = np.asarray([0.0, 1.0])
+    t_eval = np.linspace(0.0, 1.0, 200)
+
+    tol = 1e-9
+    solution = scipy.integrate.solve_ivp(
+        vf_scipy,
+        y0=u0,
+        t_span=time_span,
+        t_eval=t_eval,
+        atol=1e-3 * tol,
+        rtol=tol,
+        method="LSODA",
+    )
+    return solution.t, solution.y.T
+
+
+def solver_blockdiag(*, num_derivatives: int) -> Callable:
+    """Construct a solver that wraps ProbDiffEq's block-diagonal routines."""
+
+    @probdiffeq.ode
+    def vf(u, /, *, t):  # noqa: ARG001
+        """Viscous Burgers equation."""
+        dx = 1.0 / N
+        u_bc = jnp.pad(u, 1)  # zero Dirichlet ghosts
+        u_left = u_bc[:-2]
+        u_right = u_bc[2:]
+        flux = u_bc**2 / 2.0
+
+        fluxterm = (flux[2:] - flux[:-2]) / (2.0 * dx)
+        laplacian = (u_right - 2.0 * u + u_left) / dx**2
+        return -fluxterm + NU * laplacian
+
+    x = jnp.linspace(0.0, 1.0, N + 1, endpoint=True)[1:-1]
+    u0 = jnp.sin(3 * jnp.pi * x) ** 3 * (1 - x) ** 1.5
+    t0, t1 = 0.0, 1.0
+
+    ssm = probdiffeq.state_space_model_blockdiag()
+
+    @jax.jit
+    def param_to_solution(tol):
+        jetexpand = probdiffeq.jetexpand_ode_unroll(num=num_derivatives)
+        tcoeffs, _ = jetexpand(vf, (u0,), t=t0)
+
+        iwp = ssm.prior_wiener_integrated(tcoeffs)
+        ts1 = ssm.constraint_ode_ts1(vf)
+        strategy = probdiffeq.strategy_filter()
+        solver = probdiffeq.solver(strategy=strategy, constraint=ts1)
+        error = probdiffeq.error_state_std(constraint=ts1)
+        control = ivpsolve.control_proportional_integral()
+        solve_fn = ivpsolve.solve_adaptive_terminal_values(
+            solver=solver, error=error, control=control, clip_dt=True
+        )
+
+        solution = solve_fn(iwp, t0=t0, t1=t1, atol=1e-3 * tol, rtol=tol)
+        return jax.block_until_ready(solution.u.mean[0])
+
+    return param_to_solution
+
+
+def solver_matfree(*, num_derivatives: int) -> Callable:
+    """Construct a solver that wraps ProbDiffEq's matrix-free routines."""
+
+    @probdiffeq.ode
+    def vf(u, /, *, t):  # noqa: ARG001
+        """Viscous Burgers equation."""
+        dx = 1.0 / N
+        u_bc = jnp.pad(u, 1)  # zero Dirichlet ghosts
+        u_left = u_bc[:-2]
+        u_right = u_bc[2:]
+        flux = u_bc**2 / 2.0
+
+        fluxterm = (flux[2:] - flux[:-2]) / (2.0 * dx)
+        laplacian = (u_right - 2.0 * u + u_left) / dx**2
+        return -fluxterm + NU * laplacian
+
+    x = jnp.linspace(0.0, 1.0, N + 1, endpoint=True)[1:-1]
+    u0 = jnp.sin(3 * jnp.pi * x) ** 3 * (1 - x) ** 1.5
+    t0, t1 = 0.0, 1.0
+
+    key = jax.random.PRNGKey(1)
+    num_ensembles = (num_derivatives + 1) * 2
+    ssm = probdiffeq.state_space_model_matfree(key=key, num_ensembles=num_ensembles)
+
+    @jax.jit
+    def param_to_solution(tol):
+        jetexpand = probdiffeq.jetexpand_ode_unroll(num=num_derivatives)
+        tcoeffs, _ = jetexpand(vf, (u0,), t=t0)
+
+        iwp = ssm.prior_wiener_integrated(tcoeffs)
+        ts1 = ssm.constraint_ode_ts1(vf)
+        strategy = probdiffeq.strategy_filter()
+        solver = probdiffeq.solver(strategy=strategy, constraint=ts1)
+        error = probdiffeq.error_state_std(constraint=ts1)
+        control = ivpsolve.control_proportional_integral()
+        solve_fn = ivpsolve.solve_adaptive_terminal_values(
+            solver=solver, error=error, control=control, clip_dt=True
+        )
+
+        solution = solve_fn(iwp, t0=t0, t1=t1, atol=1e-3 * tol, rtol=tol)
+        return jax.block_until_ready(solution.u.mean[0])
+
+    return param_to_solution
+
+
+def solver_dense(*, num_derivatives: int) -> Callable:
+    """Construct a solver that wraps ProbDiffEq's matrix-free routines."""
+
+    @probdiffeq.ode
+    def vf(u, /, *, t):  # noqa: ARG001
+        """Viscous Burgers equation."""
+        dx = 1.0 / N
+        u_bc = jnp.pad(u, 1)  # zero Dirichlet ghosts
+        u_left = u_bc[:-2]
+        u_right = u_bc[2:]
+        flux = u_bc**2 / 2.0
+
+        fluxterm = (flux[2:] - flux[:-2]) / (2.0 * dx)
+        laplacian = (u_right - 2.0 * u + u_left) / dx**2
+        return -fluxterm + NU * laplacian
+
+    x = jnp.linspace(0.0, 1.0, N + 1, endpoint=True)[1:-1]
+    u0 = jnp.sin(3 * jnp.pi * x) ** 3 * (1 - x) ** 1.5
+    t0, t1 = 0.0, 1.0
+
+    ssm = probdiffeq.state_space_model_dense()
+
+    @jax.jit
+    def param_to_solution(tol):
+        jetexpand = probdiffeq.jetexpand_ode_unroll(num=num_derivatives)
+        tcoeffs, _ = jetexpand(vf, (u0,), t=t0)
+
+        iwp = ssm.prior_wiener_integrated(tcoeffs)
+        ts1 = ssm.constraint_ode_ts1(vf)
+        strategy = probdiffeq.strategy_filter()
+        solver = probdiffeq.solver(strategy=strategy, constraint=ts1)
+        error = probdiffeq.error_state_std(constraint=ts1)
+        control = ivpsolve.control_proportional_integral()
+        solve_fn = ivpsolve.solve_adaptive_terminal_values(
+            solver=solver, error=error, control=control, clip_dt=True
+        )
+
+        solution = solve_fn(iwp, t0=t0, t1=t1, atol=1e-3 * tol, rtol=tol)
+
+        return jax.block_until_ready(solution.u.mean[0])
+
+    return param_to_solution
+
+
+def solver_scipy(*, method: str) -> Callable:
+    """Construct a solver that wraps SciPy's solution routines."""
+
+    def vf_scipy(_t, u):
+        """Viscous Burgers equation, zero Dirichlet BC, conservative advection."""
+        dx = 1.0 / N
+        u_bc = np.pad(u, 1)  # zero Dirichlet ghosts
+        u_left = u_bc[:-2]
+        u_right = u_bc[2:]
+        flux = u_bc**2 / 2.0
+
+        fluxterm = (flux[2:] - flux[:-2]) / (2.0 * dx)
+        laplacian = (u_right - 2.0 * u + u_left) / dx**2
+        return -fluxterm + NU * laplacian
+
+    x = np.linspace(0.0, 1.0, N + 1, endpoint=True)[1:-1]
+    u0 = jnp.sin(3 * jnp.pi * x) ** 3 * (1 - x) ** 1.5
+    time_span = np.asarray([0.0, 1.0])
+
+    def param_to_solution(tol):
+        solution = scipy.integrate.solve_ivp(
+            vf_scipy,
+            y0=u0,
+            t_span=time_span,
+            t_eval=time_span,
+            atol=1e-3 * tol,
+            rtol=tol,
+            method=method,
+        )
+        return jnp.asarray(solution.y[:, -1])
+
+    return param_to_solution
+
+
+main()

--- a/probdiffeq/_probdiffeq/solvers.py
+++ b/probdiffeq/_probdiffeq/solvers.py
@@ -945,6 +945,12 @@ class error_state_std(ErrorEstimator):
 
     """
 
+    # Reasons to use this estimator (show this in experiments):
+    #   - Works for all constraints (including DAEs etc.)
+    #   - Makes the error match the tolerance better.
+    #     (Hypothesis: residuals tend to be a bit larger than the state, so the error overestimates.)
+    #   - Makes the matfree solvers more reliable, especially at extreme tols.
+
     # TODO: make the experimental-warning into a decorator
     def __init__(
         self,

--- a/probdiffeq/_probdiffeq/ssm_impl_matfree.py
+++ b/probdiffeq/_probdiffeq/ssm_impl_matfree.py
@@ -138,9 +138,10 @@ class MatfreeLinopLstSq(Linop):
             # Cholesky-vector products
             return materialized_vecmat_dn(self.cholesky_x, Ats)
 
-        # TODO: turn "D" into a damping factor?
+        # TODO: let users control the tol?
+        tol = 10 * np.finfo_eps(vec.dtype)
         damp = self.linop_constraint.damp
-        lstsq_sol = linalg.lstsq_lsmr(vecmat, vec, x0=x0_flat, damp=damp)
+        lstsq_sol = linalg.lstsq_lsmr(vecmat, vec, x0=x0_flat, damp=damp, tol=tol)
         Av = materialized_matvec_dn(self.cholesky_x, lstsq_sol)
         return Av, jvp_cached
 
@@ -170,11 +171,9 @@ class MatfreeLatentCond(ssm_impl_api.AbstractLatentCond):
         # TODO: we currently ignore the damping factor & the noise...
 
         # Ensemble Cholesky: P P^\top = (A C Xi) (A C Xi)^\top
-        # but alternatively, Hutchinson:
-        # P P^\top =
         keys = random.split(self.key, num=self.num_ensembles)
-        ensembles = func.vmap(rv.sample_flat)(keys)  # d, n
-        ensembles = np.transpose(ensembles, axes=(0, 2, 1))  # n, d
+        ensembles = func.vmap(rv.sample_flat)(keys)  # s, d, n
+        ensembles = np.transpose(ensembles, axes=(0, 2, 1))  # s, n, d
 
         def mv(x):
             Ax, _jvp = self.A.matvec_nd(x, jvp_cached=jvp)
@@ -185,9 +184,10 @@ class MatfreeLatentCond(ssm_impl_api.AbstractLatentCond):
         return blockdiag.BlockDiagNormal(obs_mean, C, self.noise.tree_flatten)
 
     def revert(self, rv, /, *, solve_triu: Callable):
-        del solve_triu  # unused
+        del solve_triu  # unused # TODO: should this be LSMR?
         assert isinstance(self.A, MatfreeLinopResidualConstraint)
-        # TODO: we currently ignore the noise (it is encoded in the damping factor)
+        # TODO: we currently ignore the noise
+        #       (instead, we use what is encoded in the damping factor)
 
         # Observed mean
         Am, jvp = self.A.matvec_dn(rv.mean_flat, jvp_cached=None)
@@ -202,8 +202,8 @@ class MatfreeLatentCond(ssm_impl_api.AbstractLatentCond):
 
         # Posterior covariance via probing/ensembles
         keys = random.split(self.key, num=self.num_ensembles)
-        ensembles = func.vmap(rv.sample_flat)(keys)  # d, n
-        ensembles = np.transpose(ensembles, axes=(0, 2, 1))  # n, d
+        ensembles = func.vmap(rv.sample_flat)(keys)  # s, d, n
+        ensembles = np.transpose(ensembles, axes=(0, 2, 1))  # s, n, d
 
         def matvec_nd(p_nd):
             Ap_nd, _jvp = self.A.matvec_nd(p_nd, jvp_cached=jvp)
@@ -372,7 +372,7 @@ class state_space_model_matfree(ssm_impl_api.StateSpaceModel):
 
 
 def blockdiag_cholesky_from_ensembles(ensembles_smd, bias: bool):
-    S, _n, _d = ensembles_smd.shape
+    S, n, _d = ensembles_smd.shape
 
     # Center the ensembles
     ensembles_smd -= ensembles_smd.mean(axis=0, keepdims=True)
@@ -385,10 +385,9 @@ def blockdiag_cholesky_from_ensembles(ensembles_smd, bias: bool):
 
     # The QR decomposition is why we assume S >= n,
     # so let's check it briefly:
-    _S, m, _d = ensembles_smd.shape
-    if m > S:
+    if n > S:
         msg = "The function requires at least as many ensembles as Taylor coefficients."
-        msg += f" Received: S={S} < m={m}, which violates this assumption."
+        msg += f" Received: S={S} < n={n}, which violates this assumption."
         raise ValueError(msg)
 
     # Assume ensembles are shape (S, n, d), so we batch along d

--- a/probdiffeq/backend/linalg.py
+++ b/probdiffeq/backend/linalg.py
@@ -61,8 +61,8 @@ def lstsq_svd(matrix, rhs, /):
     return jnp.linalg.lstsq(matrix, rhs)[0]
 
 
-def lstsq_lsmr(vecmat_fun, rhs, /, *, x0, damp, **lsmr_kwargs):
-    lsmr = lstsq.lsmr(**lsmr_kwargs)
+def lstsq_lsmr(vecmat_fun, rhs, /, *, x0, damp, tol, **lsmr_kwargs):
+    lsmr = lstsq.lsmr(**lsmr_kwargs, atol=tol, btol=tol, ctol=tol)
     sol, _info = lsmr(vecmat_fun, rhs, x0=x0, damp=damp)
     return sol
 

--- a/probdiffeq/util/benchmark_util.py
+++ b/probdiffeq/util/benchmark_util.py
@@ -26,12 +26,17 @@ def workprec(fun, *, precision_fun: Callable, timeit_fun: Callable) -> Callable:
         works_std = []
         precisions = []
         for arg in list_of_args:
+            # TODO: if we do timing and precision jointly (which means hardcoding timing), then
+            # we can cut runtimes of costlier benchmarks where we only afford repeat=1 in half.
             precision = precision_fun(fun(arg).block_until_ready())
-            times = timeit_fun(lambda: fun(arg).block_until_ready())  # noqa: B023
-
             precisions.append(precision)
-            works_mean.append(np.mean(np.asarray(times)))
-            works_std.append(np.std(np.asarray(times), ddof=1))
+
+            times = timeit_fun(lambda: fun(arg).block_until_ready())  # noqa: B023
+            mean = np.mean(np.asarray(times))
+            works_mean.append(mean)
+            if len(times) > 1:
+                std = np.std(np.asarray(times), ddof=1)
+                works_std.append(std)
         return {
             "work_mean": np.asarray(works_mean),
             "work_std": np.asarray(works_std),


### PR DESCRIPTION
Match the "Burgers" example in https://arxiv.org/pdf/2606.08203, but make the problem a little less stiff and a little lower-dimensional so the benchmark runs in ~30 sec instead of minutes.


In the process, fix some issues with LSMR runs in the matfree-ts1.