### PR TITLE
Implement jet-lifting for ODEs

### DIFF
--- a/benchmarks/A0_work-precision-lotka-volterra.py
+++ b/benchmarks/A0_work-precision-lotka-volterra.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Callable
 
-import diffrax
 import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
@@ -16,12 +15,12 @@ from probdiffeq.util import benchmark_util
 # Fail this notebook on NaN detection (to catch those in the CI)
 jax.config.update("jax_debug_nans", True)
 
+# High accuracy requires double precision
+jax.config.update("jax_enable_x64", True)
 
-def main(start=3.0, stop=12.0, step=1.0, repeats=2) -> None:
+
+def main(start=3.0, stop=12.0, step=0.5, repeats=1) -> None:
     """Run the script."""
-    # Set up all the configs
-    jax.config.update("jax_enable_x64", True)
-
     # Simulate once to plot the state
     ts, ys = solve_ivp_once()
 
@@ -39,16 +38,23 @@ def main(start=3.0, stop=12.0, step=1.0, repeats=2) -> None:
 
     # Assemble algorithms
     ts0_iso = solver_probdiffeq(5, constraint_order=0, implementation="isotropic")
+    ts0_iso_jet = solver_probdiffeq_jet(
+        5, constraint_order=0, implementation="isotropic"
+    )
     ts0_bd = solver_probdiffeq(5, constraint_order=0, implementation="blockdiag")
+    ts0_bd_jet = solver_probdiffeq_jet(
+        5, constraint_order=0, implementation="blockdiag"
+    )
     ts1_dense = solver_probdiffeq(8, constraint_order=1, implementation="dense")
+    ts1_dense_jet = solver_probdiffeq_jet(8, constraint_order=1, implementation="dense")
     algorithms = {
-        r"ProbDiffEq: TS0($5$, isotropic)": ts0_iso,
-        r"ProbDiffEq: TS0($5$, blockdiag)": ts0_bd,
-        r"ProbDiffEq: TS1($8$, dense)": ts1_dense,
-        "Diffrax: Tsit5()": solver_diffrax(solver=diffrax.Tsit5()),
-        "Diffrax: Dopri8()": solver_diffrax(solver=diffrax.Dopri8()),
+        r"TS0(5, isotropic)": ts0_iso,
+        r"JetTS0(5, isotropic)": ts0_iso_jet,
+        r"TS0(5, blockdiag)": ts0_bd,
+        r"JetTS0(5, blockdiag)": ts0_bd_jet,
+        r"TS1(8, dense)": ts1_dense,
+        r"JetTS1(8, dense)": ts1_dense_jet,
         "SciPy: 'RK45'": solver_scipy(method="RK45"),
-        "SciPy: 'DOP853'": solver_scipy(method="DOP853"),
     }
 
     # Compute a reference solution
@@ -57,23 +63,24 @@ def main(start=3.0, stop=12.0, step=1.0, repeats=2) -> None:
 
     # Compute all work-precision diagrams
     results = {}
-    for label, algo in tqdm.tqdm(algorithms.items()):
+    pbar = tqdm.tqdm(algorithms.items())
+    for label, algo in pbar:
+        pbar.set_description(label)
         param_to_wp = benchmark_util.workprec(
             algo, precision_fun=precision_fun, timeit_fun=timeit_fun
         )
         results[label] = param_to_wp(tolerances)
 
-    _fig, ax = plt.subplots(figsize=(7, 3))
+    _fig, ax = plt.subplots(figsize=(8, 5), dpi=120, constrained_layout=True)
     for label, wp in results.items():
         ax.loglog(wp["precision"], wp["work_mean"], label=label)
 
+    ax.set_ylabel("Work (avg. wall time)")
     ax.set_title("Work-precision diagram")
     ax.set_xlabel("Precision (relative RMSE)")
-    ax.set_ylabel("Work (avg. wall time)")
     ax.grid(linestyle="dotted", which="both")
-    ax.legend(fontsize="small", loc="center left", bbox_to_anchor=(1, 0.5))
+    ax.legend(fontsize="small")
 
-    plt.tight_layout()
     plt.show()
 
 
@@ -110,9 +117,10 @@ def solver_probdiffeq(
     u0 = jnp.asarray((20.0, 20.0))
     t0, t1 = (0.0, 50.0)
 
+    jetexpand = probdiffeq.jetexpand_ode_padded_scan(num=num_derivatives)
+
     @jax.jit
     def param_to_solution(tol):
-        jetexpand = probdiffeq.jetexpand_ode_padded_scan(num=num_derivatives)
         tcoeffs, _ = jetexpand(vf_probdiffeq, (u0,), t=t0)
 
         ssm = state_space_model(implementation)
@@ -122,17 +130,16 @@ def solver_probdiffeq(
             ts = ssm.constraint_ode_ts0(vf_probdiffeq)
         else:
             ts = ssm.constraint_ode_ts1(vf_probdiffeq)
-        solver = probdiffeq.solver_mle(strategy=strategy, constraint=ts)
-        error = probdiffeq.error_residual_std(constraint=ts)
+        solver = probdiffeq.solver(strategy=strategy, constraint=ts)
+        error = probdiffeq.error_state_std(constraint=ts)
 
         control = ivpsolve.control_proportional_integral()
         solve = ivpsolve.solve_adaptive_terminal_values(
             error=error, solver=solver, control=control
         )
-        dt0 = ivpsolve.dt0(vf_probdiffeq, (u0,), t=t0)
 
         # Build a solver
-        solution = solve(iwp, t0=t0, t1=t1, dt0=dt0, atol=1e-2 * tol, rtol=tol)
+        solution = solve(iwp, t0=t0, t1=t1, atol=1e-2 * tol, rtol=tol)
 
         # Return the terminal value
         return jax.block_until_ready(solution.u.mean[0])
@@ -149,12 +156,13 @@ def solver_probdiffeq(
     return param_to_solution
 
 
-def solver_diffrax(*, solver) -> Callable:
-    """Construct a solver that wraps Diffrax' solution routines."""
+def solver_probdiffeq_jet(
+    num_derivatives: int, implementation, constraint_order: int
+) -> Callable:
+    """Construct a solver that wraps ProbDiffEq's solution routines."""
 
-    @diffrax.ODETerm
-    @jax.jit
-    def vf_diffrax(_t, y, _args):
+    @probdiffeq.ode
+    def vf_probdiffeq(y, /, *, t):  # noqa: ARG001
         """Lotka--Volterra dynamics."""
         dy1 = 0.5 * y[0] - 0.05 * y[0] * y[1]
         dy2 = -0.5 * y[1] + 0.05 * y[0] * y[1]
@@ -163,22 +171,40 @@ def solver_diffrax(*, solver) -> Callable:
     u0 = jnp.asarray((20.0, 20.0))
     t0, t1 = (0.0, 50.0)
 
+    vf_probdiffeq = vf_probdiffeq.jet_lift(lift_by=num_derivatives - 1)
+
     @jax.jit
     def param_to_solution(tol):
-        controller = diffrax.PIDController(atol=1e-3 * tol, rtol=tol)
-        saveat = diffrax.SaveAt(t0=False, t1=True, ts=None)
-        solution = diffrax.diffeqsolve(
-            vf_diffrax,
-            y0=u0,
-            t0=t0,
-            t1=t1,
-            saveat=saveat,
-            stepsize_controller=controller,
-            dt0=None,
-            max_steps=10_000,
-            solver=solver,
+
+        ssm = state_space_model(implementation)
+        iwp = ssm.prior_wiener_integrated([u0], diffuse_derivatives=num_derivatives)
+        strategy = probdiffeq.strategy_filter()
+        if constraint_order == 0:
+            ts = ssm.constraint_ode_ts0(vf_probdiffeq)
+        else:
+            ts = ssm.constraint_ode_ts1(vf_probdiffeq)
+        solver = probdiffeq.solver(strategy=strategy, constraint=ts, constraint_init=ts)
+        error = probdiffeq.error_state_std(constraint=ts)
+
+        control = ivpsolve.control_proportional_integral()
+        solve = ivpsolve.solve_adaptive_terminal_values(
+            error=error, solver=solver, control=control
         )
-        return jax.block_until_ready(solution.ys[0, :])
+
+        # Build a solver
+        solution = solve(iwp, t0=t0, t1=t1, atol=1e-2 * tol, rtol=tol)
+
+        # Return the terminal value
+        return jax.block_until_ready(solution.u.mean[0])
+
+    def state_space_model(implementation):
+        match implementation:
+            case "blockdiag":
+                return probdiffeq.state_space_model_blockdiag()
+            case "dense":
+                return probdiffeq.state_space_model_dense()
+            case "isotropic":
+                return probdiffeq.state_space_model_isotropic()
 
     return param_to_solution
 

--- a/benchmarks/A0_work-precision-lotka-volterra.py
+++ b/benchmarks/A0_work-precision-lotka-volterra.py
@@ -19,7 +19,7 @@ jax.config.update("jax_debug_nans", True)
 jax.config.update("jax_enable_x64", True)
 
 
-def main(start=3.0, stop=12.0, step=0.5, repeats=1) -> None:
+def main(start=3.0, stop=12.0, step=1.0, repeats=1) -> None:
     """Run the script."""
     # Simulate once to plot the state
     ts, ys = solve_ivp_once()
@@ -45,15 +45,11 @@ def main(start=3.0, stop=12.0, step=0.5, repeats=1) -> None:
     ts0_bd_jet = solver_probdiffeq_jet(
         5, constraint_order=0, implementation="blockdiag"
     )
-    ts1_dense = solver_probdiffeq(8, constraint_order=1, implementation="dense")
-    ts1_dense_jet = solver_probdiffeq_jet(8, constraint_order=1, implementation="dense")
     algorithms = {
         r"TS0(5, isotropic)": ts0_iso,
         r"JetTS0(5, isotropic)": ts0_iso_jet,
         r"TS0(5, blockdiag)": ts0_bd,
         r"JetTS0(5, blockdiag)": ts0_bd_jet,
-        r"TS1(8, dense)": ts1_dense,
-        r"JetTS1(8, dense)": ts1_dense_jet,
         "SciPy: 'RK45'": solver_scipy(method="RK45"),
     }
 

--- a/benchmarks/A3_work-precision-vanderpol.py
+++ b/benchmarks/A3_work-precision-vanderpol.py
@@ -17,7 +17,7 @@ from probdiffeq.util import benchmark_util
 jax.config.update("jax_debug_nans", True)
 
 
-def main(start=4.0, stop=10.0, step=0.25, repeats=2) -> None:
+def main(start=6.0, stop=10.0, step=0.25, repeats=2) -> None:
     """Run the script."""
     # Set up all the configs
     jax.config.update("jax_enable_x64", True)
@@ -41,7 +41,9 @@ def main(start=4.0, stop=10.0, step=0.25, repeats=2) -> None:
     # Assemble algorithms
     algorithms = {
         "TS1(4)": solver_probdiffeq(num_derivatives=4),
-        "TS1(8)": solver_probdiffeq(num_derivatives=8),
+        "JetTS1(4)": solver_probdiffeq_jet(num_derivatives=4),
+        "TS1(6)": solver_probdiffeq(num_derivatives=6),
+        "JetTS1(6)": solver_probdiffeq_jet(num_derivatives=6),
         "SciPy('LSODA')": solver_scipy(method="LSODA"),
     }
 
@@ -100,14 +102,9 @@ def solver_probdiffeq(*, num_derivatives: int) -> Callable:
     """Construct a solver that wraps ProbDiffEq's solution routines."""
 
     @probdiffeq.ode_order_two
-    def vf_probdiffeq(u, du, *, t):  # noqa: ARG001
+    def vf(u, du, *, t):  # noqa: ARG001
         """Van-der-Pol dynamics as a second-order differential equation."""
         return 1e5 * ((1.0 - u**2) * du - u)
-
-    @probdiffeq.residual_acceleration
-    def residual(u, du, ddu, /, *, t):
-        """Evaluate a residual to solve the 2nd-order problem directly."""
-        return ddu - vf_probdiffeq(u, du, t=t)
 
     t0, t1 = 0.0, 3.0
     u0, du0 = (jnp.asarray(2.0), jnp.asarray(0.0))
@@ -117,11 +114,48 @@ def solver_probdiffeq(*, num_derivatives: int) -> Callable:
     def param_to_solution(tol):
         # Build a solver
         jetexpand = probdiffeq.jetexpand_ode_padded_scan(num=num_derivatives - 1)
-        tcoeffs, _ = jetexpand(vf_probdiffeq, (u0, du0), t=t0)
+        tcoeffs, _ = jetexpand(vf, (u0, du0), t=t0)
 
         ssm = probdiffeq.state_space_model_dense()
         iwp = ssm.prior_wiener_integrated(tcoeffs)
-        ts = ssm.constraint_residual(residual)
+        ts = ssm.constraint_ode_ts1(vf)
+        strategy = probdiffeq.strategy_filter()
+
+        solver = probdiffeq.solver_dynamic(strategy=strategy, constraint=ts)
+        error = probdiffeq.error_state_std(constraint=ts)
+
+        control = ivpsolve.control_proportional_integral()
+        solve = ivpsolve.solve_adaptive_terminal_values(
+            solver=solver, error=error, control=control
+        )
+        solution = solve(iwp, t0=t0, t1=t1, atol=1e-3 * tol, rtol=tol)
+        return jax.block_until_ready(solution.u.mean[0])
+
+    return param_to_solution
+
+
+def solver_probdiffeq_jet(*, num_derivatives: int) -> Callable:
+    """Construct a solver that wraps ProbDiffEq's solution routines."""
+
+    @probdiffeq.ode_order_two
+    def vf(u, du, *, t):  # noqa: ARG001
+        """Van-der-Pol dynamics as a second-order differential equation."""
+        return 1e5 * ((1.0 - u**2) * du - u)
+
+    vf = vf.jet_lift(lift_by=num_derivatives - 2)
+    t0, t1 = 0.0, 3.0
+    u0, du0 = (jnp.asarray(2.0), jnp.asarray(0.0))
+    t0, t1 = (0.0, 6.3)
+
+    @jax.jit
+    def param_to_solution(tol):
+        # Build a solver
+
+        ssm = probdiffeq.state_space_model_dense()
+        iwp = ssm.prior_wiener_integrated(
+            (u0, du0), diffuse_derivatives=num_derivatives - 1
+        )
+        ts = ssm.constraint_ode_ts1(vf)
         strategy = probdiffeq.strategy_filter()
 
         solver = probdiffeq.solver_dynamic(strategy=strategy, constraint=ts)

--- a/benchmarks/B0_work-precision-dae-robertson.py
+++ b/benchmarks/B0_work-precision-dae-robertson.py
@@ -1,6 +1,5 @@
 """Walltime | Robertson DAE."""
 
-import functools
 import statistics
 from collections.abc import Callable
 
@@ -170,7 +169,6 @@ def solver_ode(*, num_derivatives: int, time_span) -> Callable:
 def solver_residual(*, num_derivatives: int, time_span) -> Callable:
     """Construct a method that solves Robertson as a DAE."""
 
-    @functools.partial(probdiffeq.residual_jet_lift, lift_by=num_derivatives - 1)
     @probdiffeq.residual_velocity
     def differential(u, du, /, *, t):
         del t
@@ -182,12 +180,13 @@ def solver_residual(*, num_derivatives: int, time_span) -> Callable:
         f1 = k1 * y[0] - k2 * y[1] ** 2 - k3 * y[1] * y[2]
         return jnp.stack([f0, f1])
 
-    @functools.partial(probdiffeq.residual_jet_lift, lift_by=num_derivatives)
     @probdiffeq.residual_position
     def algebraic(u, *, t):
         del t
         return u[0] + u[1] + u[2] - 1
 
+    differential = differential.jet_lift(lift_by=num_derivatives - 1)
+    algebraic = algebraic.jet_lift(lift_by=num_derivatives)
     residual = probdiffeq.residual_from_stack(differential, algebraic)
 
     @jax.jit

--- a/examples/E3_learn_DAEs.py
+++ b/examples/E3_learn_DAEs.py
@@ -6,8 +6,6 @@ This example estimates the unknown initial conditions from synthetic observation
 by minimising the negative log-marginal-likelihood via gradient descent.
 """
 
-import functools
-
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -50,7 +48,6 @@ def main(
 ) -> None:
     """Run the script."""
 
-    @functools.partial(probdiffeq.residual_jet_lift, lift_by=2)
     @probdiffeq.residual_velocity
     def differential(u, du, /, *, t):
         del t
@@ -62,12 +59,13 @@ def main(
         f1 = k1 * y[0] - k2 * y[1] ** 2 - k3 * y[1] * y[2]
         return jnp.stack([f0, f1])
 
-    @functools.partial(probdiffeq.residual_jet_lift, lift_by=3)
     @probdiffeq.residual_position
     def algebraic(u, *, t):
         del t
         return u[0] + u[1] + u[2] - 1
 
+    differential = differential.jet_lift(lift_by=2)
+    algebraic = algebraic.jet_lift(lift_by=3)
     residual = probdiffeq.residual_from_stack(differential, algebraic)
 
     def while_loop(cond, body, init):

--- a/probdiffeq/_ivpsolve/stepsize_initialisers.py
+++ b/probdiffeq/_ivpsolve/stepsize_initialisers.py
@@ -6,7 +6,7 @@ __all__ = ["dt0", "dt0_adaptive"]
 
 def dt0(vf, initial_values: Sequence, /, scale=0.01, nugget=1e-5, **vf_kwargs):
     """Propose an initial time-step."""
-    if vf.is_jet_extended:
+    if vf.is_jet_lifted:
         raise ValueError
 
     [f0] = vf.vector_field(jet_coords=initial_values, **vf_kwargs)
@@ -36,7 +36,7 @@ def dt0_adaptive(
     if len(initial_values) > 1:
         raise ValueError
 
-    if vf.is_jet_extended:
+    if vf.is_jet_lifted:
         raise ValueError
 
     y0 = initial_values[0]

--- a/probdiffeq/_ivpsolve/stepsize_initialisers.py
+++ b/probdiffeq/_ivpsolve/stepsize_initialisers.py
@@ -6,7 +6,10 @@ __all__ = ["dt0", "dt0_adaptive"]
 
 def dt0(vf, initial_values: Sequence, /, scale=0.01, nugget=1e-5, **vf_kwargs):
     """Propose an initial time-step."""
-    f0 = vf(*initial_values, **vf_kwargs)
+    if vf.is_jet_extended:
+        raise ValueError
+
+    [f0] = vf.vector_field(jet_coords=initial_values, **vf_kwargs)
 
     u0, *_ = initial_values
     u0, _ = tree.ravel_pytree(u0)
@@ -32,9 +35,13 @@ def dt0_adaptive(
 
     if len(initial_values) > 1:
         raise ValueError
+
+    if vf.is_jet_extended:
+        raise ValueError
+
     y0 = initial_values[0]
 
-    f0 = vf(*initial_values, t=t0)
+    [f0] = vf.vector_field(jet_coords=initial_values, t=t0)
 
     y0, unravel = tree.ravel_pytree(y0)
     f0, _ = tree.ravel_pytree(f0)
@@ -45,7 +52,7 @@ def dt0_adaptive(
     dt0 = np.where((d0 < 1e-5) | (d1 < 1e-5), 1e-6, 0.01 * d0 / d1)
 
     y1 = y0 + dt0 * f0
-    f1 = vf(unravel(y1), t=t0 + dt0)
+    [f1] = vf.vector_field(jet_coords=(unravel(y1),), t=t0 + dt0)
     f1, _ = tree.ravel_pytree(f1)
     d2 = linalg.vector_norm((f1 - f0) / scale) / dt0
 

--- a/probdiffeq/_probdiffeq/jet_expansion_algorithms.py
+++ b/probdiffeq/_probdiffeq/jet_expansion_algorithms.py
@@ -66,6 +66,9 @@ def jetexpand_ode_padded_scan(*, num: int) -> JetExpansionAlg[problems.JetOde]:
         if num == 0:
             return list(inits), {}
 
+        if vf.is_jet_extended:
+            raise ValueError
+
         # Number of positional arguments in f
         num_arguments = len(inits)
 
@@ -130,6 +133,9 @@ def jetexpand_ode_unroll(*, num: int) -> JetExpansionAlg[problems.JetOde]:
         if num == 0:
             return list(inits), {}
 
+        if vf.is_jet_extended:
+            raise ValueError
+
         # Number of positional arguments in f
         num_arguments = len(inits)
 
@@ -152,6 +158,10 @@ def jetexpand_ode_coefficient_increment(*, num_arguments):
     def increment(
         vf: problems.JetOde, taylor_coeffs: Sequence[T], *, t: float
     ) -> list[T]:
+
+        if vf.is_jet_extended:
+            raise ValueError
+
         def vf_with_kwargs(*u: *tuple[T, ...]) -> T:
             [output] = vf.vector_field(jet_coords=u, t=t)
             return output
@@ -181,8 +191,11 @@ def jetexpand_ode_via_jvp(*, num: int) -> JetExpansionAlg[problems.JetOde]:
         if num == 0:
             return list(inits), {}
 
+        if vf.is_jet_extended:
+            raise ValueError
+
         def vf_wrapped(*jet_coords):
-            [vfx] = vf(*jet_coords, t=t)
+            [vfx] = vf.vector_field(jet_coords=jet_coords, t=t)
             return vfx
 
         g_n, g_0 = vf_wrapped, vf_wrapped
@@ -231,6 +244,10 @@ def jetexpand_ode_doubling_unroll(
     def expand(
         vf: problems.JetOde, inits: Sequence[T], /, *, t: float
     ) -> tuple[list[T], dict]:
+
+        if vf.is_jet_extended:
+            raise ValueError
+
         inits = tree.tree_map(np.asarray, inits)
 
         double = jetexpand_ode_coefficient_double()

--- a/probdiffeq/_probdiffeq/jet_expansion_algorithms.py
+++ b/probdiffeq/_probdiffeq/jet_expansion_algorithms.py
@@ -66,7 +66,7 @@ def jetexpand_ode_padded_scan(*, num: int) -> JetExpansionAlg[problems.JetOde]:
         if num == 0:
             return list(inits), {}
 
-        if vf.is_jet_extended:
+        if vf.is_jet_lifted:
             raise ValueError
 
         # Number of positional arguments in f
@@ -133,7 +133,7 @@ def jetexpand_ode_unroll(*, num: int) -> JetExpansionAlg[problems.JetOde]:
         if num == 0:
             return list(inits), {}
 
-        if vf.is_jet_extended:
+        if vf.is_jet_lifted:
             raise ValueError
 
         # Number of positional arguments in f
@@ -159,7 +159,7 @@ def jetexpand_ode_coefficient_increment(*, num_arguments):
         vf: problems.JetOde, taylor_coeffs: Sequence[T], *, t: float
     ) -> list[T]:
 
-        if vf.is_jet_extended:
+        if vf.is_jet_lifted:
             raise ValueError
 
         def vf_with_kwargs(*u: *tuple[T, ...]) -> T:
@@ -191,7 +191,7 @@ def jetexpand_ode_via_jvp(*, num: int) -> JetExpansionAlg[problems.JetOde]:
         if num == 0:
             return list(inits), {}
 
-        if vf.is_jet_extended:
+        if vf.is_jet_lifted:
             raise ValueError
 
         def vf_wrapped(*jet_coords):
@@ -245,7 +245,7 @@ def jetexpand_ode_doubling_unroll(
         vf: problems.JetOde, inits: Sequence[T], /, *, t: float
     ) -> tuple[list[T], dict]:
 
-        if vf.is_jet_extended:
+        if vf.is_jet_lifted:
             raise ValueError
 
         inits = tree.tree_map(np.asarray, inits)

--- a/probdiffeq/_probdiffeq/jet_expansion_algorithms.py
+++ b/probdiffeq/_probdiffeq/jet_expansion_algorithms.py
@@ -70,7 +70,7 @@ def jetexpand_ode_padded_scan(*, num: int) -> JetExpansionAlg[problems.JetOde]:
         num_arguments = len(inits)
 
         # Initial Taylor series (u_0, u_1, ..., u_k)
-        primals = vf.vector_field(jet_coords=inits, t=t)
+        [primals] = vf.vector_field(jet_coords=inits, t=t)
         taylor_coeffs = [*inits, primals]
 
         # Early exit for num=1.
@@ -153,7 +153,8 @@ def jetexpand_ode_coefficient_increment(*, num_arguments):
         vf: problems.JetOde, taylor_coeffs: Sequence[T], *, t: float
     ) -> list[T]:
         def vf_with_kwargs(*u: *tuple[T, ...]) -> T:
-            return vf.vector_field(jet_coords=u, t=t)
+            [output] = vf.vector_field(jet_coords=u, t=t)
+            return output
 
         primals, series = utilities.jet_coords_to_primals_and_series(
             taylor_coeffs, num_arguments

--- a/probdiffeq/_probdiffeq/jet_expansion_algorithms.py
+++ b/probdiffeq/_probdiffeq/jet_expansion_algorithms.py
@@ -136,7 +136,7 @@ def jetexpand_ode_unroll(*, num: int) -> JetExpansionAlg[problems.JetOde]:
         increment = jetexpand_ode_coefficient_increment(num_arguments=num_arguments)
 
         # Initial Taylor series (u_0, u_1, ..., u_k)
-        primals = vf.vector_field(jet_coords=inits, t=t)
+        [primals] = vf.vector_field(jet_coords=inits, t=t)
         taylor_coeffs = [*inits, primals]
 
         for _ in range(num - 1):
@@ -181,10 +181,13 @@ def jetexpand_ode_via_jvp(*, num: int) -> JetExpansionAlg[problems.JetOde]:
         if num == 0:
             return list(inits), {}
 
-        vf_wrapped = func.partial(vf, t=t)
+        def vf_wrapped(*jet_coords):
+            [vfx] = vf(*jet_coords, t=t)
+            return vfx
+
         g_n, g_0 = vf_wrapped, vf_wrapped
 
-        taylor_coeffs = [*inits, vf(*inits, t=t)]
+        taylor_coeffs = [*inits, vf_wrapped(*inits)]
         for _ in range(num - 1):
             g_n = _fwd_recursion_iterate(fun_n=g_n, fun_0=g_0)
             taylor_coeffs = [*taylor_coeffs, g_n(*inits)]
@@ -295,11 +298,13 @@ def jetexpand_ode_coefficient_double() -> JetExpansionAlg[problems.JetOde]:
         """
         zeros = np.zeros_like(c[0])
 
+        def vf_wrapped(*u):
+            [vfx] = vf.vector_field(jet_coords=u, t=t)
+            return vfx
+
         coeffs_emb = [*c] + [zeros] * degree
         p, *s = coeffs_emb
-        p_new, s_new = func.jet(
-            lambda *u: vf.vector_field(jet_coords=u, t=t), (p,), (s,), is_tcoeff=True
-        )
+        p_new, s_new = func.jet(vf_wrapped, (p,), (s,), is_tcoeff=True)
         return np.stack([p_new, *s_new])
 
     return double

--- a/probdiffeq/_probdiffeq/problems.py
+++ b/probdiffeq/_probdiffeq/problems.py
@@ -118,14 +118,23 @@ class ProtocolODEOrderTwo(Protocol[T]):
 
 class JetOde(JetAbstract, Generic[T]):
     def __init__(
-        self, vector_field, jacobian: jacobians.Jacobian, num_tcoeffs_in_args: int
+        self,
+        vector_field,
+        jacobian: jacobians.Jacobian,
+        num_tcoeffs_in_args: int,
+        tcoeff_indices_output: list[int],
     ):
         super().__init__(jacobian=jacobian, num_tcoeffs_in_args=num_tcoeffs_in_args)
         self.vector_field = vector_field
+        self.tcoeff_indices_output = tcoeff_indices_output
 
     def __call__(self, *jet_coords: *tuple[T], t: Array) -> T:
         # jet_coords = (u(t), u'(t), u''(t), ..., u^(K)(t))
         return self.vector_field(jet_coords=jet_coords, t=t)
+
+    @property
+    def tcoeff_indices_input(self) -> list[int]:
+        return list(range(self.num_tcoeffs_in_args))
 
 
 class JetOdeAutonomous(JetOde[T]):
@@ -154,7 +163,12 @@ def ode(func: ProtocolODEFirstOrder, /, *, jacobian: jacobians.Jacobian | None =
     if jacobian is None:
         jacobian = jacobians.jacobian_monte_carlo_rev()
 
-    return JetOde(jetfunc, jacobian=jacobian, num_tcoeffs_in_args=1)
+    # TODO: turn the num_tcoeffs_in_args argument into tcoeff_indices_input.
+    #       However, this requires manipulating the jet_lift logic to handle
+    #       inputs like (2, 4, 5). For now, this is too complicated for me.
+    return JetOde(
+        jetfunc, jacobian=jacobian, num_tcoeffs_in_args=1, tcoeff_indices_output=[1]
+    )
 
 
 def ode_order_two(

--- a/probdiffeq/_probdiffeq/problems.py
+++ b/probdiffeq/_probdiffeq/problems.py
@@ -187,7 +187,7 @@ class _JetOdeCommon(JetAbstract, Generic[T]):
     def __call__(self, *jet_coords: *tuple[T], t: Array) -> T:
         # jet_coords = (u(t), u'(t), u''(t), ..., u^(K)(t))
 
-        if self.is_jet_extended:
+        if self.is_jet_lifted:
             raise ValueError
 
         [fx] = self.vector_field(jet_coords=jet_coords, t=t)
@@ -198,8 +198,8 @@ class _JetOdeCommon(JetAbstract, Generic[T]):
         return list(range(self.num_tcoeffs_in_args))
 
     @property
-    def is_jet_extended(self):
-        """Whether or not the ODE is the result of Jet-extension.
+    def is_jet_lifted(self):
+        """Whether or not the ODE is the result of Jet-lifting.
 
         If true, some functionality is no longer available.
         For example, jet initialisation or stepsize initialisation,
@@ -210,7 +210,7 @@ class _JetOdeCommon(JetAbstract, Generic[T]):
 
 class JetOde(_JetOdeCommon, Generic[T]):
     def jet_lift_max(self, *, num_tcoeffs: int) -> "JetOde":
-        if self.is_jet_extended:
+        if self.is_jet_lifted:
             raise ValueError
         [output_idx] = self.tcoeff_indices_output
         assert output_idx >= self.num_tcoeffs_in_args

--- a/probdiffeq/_probdiffeq/problems.py
+++ b/probdiffeq/_probdiffeq/problems.py
@@ -106,11 +106,12 @@ class JetAbstract:
     def __repr__(self):
         return f"{self.__class__.__name__}(num_tcoeffs_in_args={self.num_tcoeffs_in_args}, jacobian={self.jacobian})"
 
-    def _lift(self, fun, /, *, lift_by: int):
+    def lift(self, fun, /, *, lift_by: int):
+        """Lift a function on k-jet coordinates to one on (k+m)-jet coordinates."""
 
-        def residual_lifted(*, jet_coords: Sequence[T], t) -> Sequence[T]:
+        def fun_lifted(*, jet_coords: Sequence[T], t) -> Sequence[T]:
 
-            # Check that the lift_by argument is feasible
+            # Check that the lift_by argument is feasible:
             lift_by_upper = len(jet_coords) - self.num_tcoeffs_in_args
             if lift_by < 0 or lift_by > lift_by_upper:
                 msg = "The provided jet-order is incompatible with the residual order."
@@ -159,7 +160,7 @@ class JetAbstract:
             coeffs_out = [primals, *series]
             return [unravel_outputs(c) for c in coeffs_out]
 
-        return residual_lifted
+        return fun_lifted
 
 
 class ProtocolODEFirstOrder(Protocol[T]):
@@ -198,12 +199,24 @@ class JetOde(JetAbstract, Generic[T]):
         """Lift a function on k-jet coordinates to one on (k+m)-jet coordinates."""
         if not isinstance(lift_by, int):
             raise TypeError
-        vf_lifted = self._lift(self.vector_field, lift_by=lift_by)
+
+        if len(self.tcoeff_indices_output) != 1:
+            msg = "Jet-lifting is only implemented for ODEs with a single output Taylor coefficient."
+            raise NotImplementedError(msg)
+
+        vf_lifted = self.lift(self.vector_field, lift_by=lift_by)
         order = self.num_tcoeffs_in_args + lift_by
 
         # TODO: If we call this on the *Autonomous subclass,
         #       we lose the fact that the lifted function is autonomous.
-        return JetOde(vf_lifted, num_tcoeffs_in_args=order, jacobian=self.jacobian)
+        [idx] = self.tcoeff_indices_output
+        tcoeff_indices_output = [idx + ell for ell in range(lift_by + 1)]
+        return JetOde(
+            vf_lifted,
+            num_tcoeffs_in_args=order,
+            jacobian=self.jacobian,
+            tcoeff_indices_output=tcoeff_indices_output,
+        )
 
 
 class JetOdeAutonomous(JetOde[T]):
@@ -218,6 +231,9 @@ class JetOdeAutonomous(JetOde[T]):
 
         super().__init__(
             vector_field, jacobian=jacobian, num_tcoeffs_in_args=num_tcoeffs_in_args
+        )
+        assert False, (
+            "Fix: jet-lifting for ODEs and autonomous ODEs differs, so rethink the subclass construction"
         )
         self.autonomous = autonomous
 
@@ -347,7 +363,7 @@ class JetResidual(JetAbstract):
         """Lift a function on k-jet coordinates to one on (k+m)-jet coordinates."""
         if not isinstance(lift_by, int):
             raise TypeError
-        residual_lifted = self._lift(self.residual_function, lift_by=lift_by)
+        residual_lifted = self.lift(self.residual_function, lift_by=lift_by)
         order = self.num_tcoeffs_in_args + lift_by
         return JetResidual(
             residual_lifted, num_tcoeffs_in_args=order, jacobian=self.jacobian

--- a/probdiffeq/_probdiffeq/problems.py
+++ b/probdiffeq/_probdiffeq/problems.py
@@ -203,6 +203,12 @@ class _JetOdeCommon(JetAbstract, Generic[T]):
 
     @property
     def is_jet_extended(self):
+        """Whether or not the ODE is the result of Jet-extension.
+
+        If true, some functionality is no longer available.
+        For example, jet initialisation or stepsize initialisation,
+        both of which assume "traditional" vector field signatures.
+        """
         return len(self.tcoeff_indices_output) > 1
 
 

--- a/probdiffeq/_probdiffeq/problems.py
+++ b/probdiffeq/_probdiffeq/problems.py
@@ -191,13 +191,19 @@ class _JetOdeCommon(JetAbstract, Generic[T]):
     def __repr__(self):
         return f"{self.__class__.__name__}(num_tcoeffs_in_args={self.num_tcoeffs_in_args}, jacobian={self.jacobian}, tcoeff_indices_output={self.tcoeff_indices_output})"
 
-    def __call__(self, *jet_coords: *tuple[T], t: Array) -> T:
-        # jet_coords = (u(t), u'(t), u''(t), ..., u^(K)(t))
-        return self.vector_field(jet_coords=jet_coords, t=t)
+    # TODO: call if self.is_jet_extended: raise ValueError in here once uncommenting
+    # def __call__(self, *jet_coords: *tuple[T], t: Array) -> T:
+    #     # jet_coords = (u(t), u'(t), u''(t), ..., u^(K)(t))
+    #     [fx] = self.vector_field(jet_coords=jet_coords, t=t)
+    #     return fx
 
     @property
     def tcoeff_indices_input(self) -> list[int]:
         return list(range(self.num_tcoeffs_in_args))
+
+    @property
+    def is_jet_extended(self):
+        return len(self.tcoeff_indices_output) > 1
 
 
 class JetOde(_JetOdeCommon, Generic[T]):
@@ -253,7 +259,7 @@ def ode(func: ProtocolODEFirstOrder, /, *, jacobian: jacobians.Jacobian | None =
     """Construct a description of an ODE u' = f(u, t)."""
 
     def jetfunc(*, jet_coords: Sequence[T], t: float) -> list[T]:
-        (y,) = jet_coords
+        [y] = jet_coords
         return [func(y, t=t)]
 
     if jacobian is None:

--- a/probdiffeq/_probdiffeq/problems.py
+++ b/probdiffeq/_probdiffeq/problems.py
@@ -198,7 +198,7 @@ class _JetOdeCommon(JetAbstract, Generic[T]):
 
 
 class JetOde(_JetOdeCommon, Generic[T]):
-    def jet_lift(self, *, lift_by: int) -> "JetResidual":
+    def jet_lift(self, *, lift_by: int) -> "JetOde":
         """Lift a function on k-jet coordinates to one on (k+m)-jet coordinates."""
         if not isinstance(lift_by, int):
             raise TypeError
@@ -249,7 +249,7 @@ class JetOdeAutonomous(_JetOdeCommon, Generic[T]):
 def ode(func: ProtocolODEFirstOrder, /, *, jacobian: jacobians.Jacobian | None = None):
     """Construct a description of an ODE u' = f(u, t)."""
 
-    def jetfunc(*, jet_coords: Sequence[T], t: float) -> T:
+    def jetfunc(*, jet_coords: Sequence[T], t: float) -> list[T]:
         (y,) = jet_coords
         return [func(y, t=t)]
 
@@ -266,7 +266,7 @@ def ode_order_two(
 ):
     """Construct a description of an ODE u'' = f(u, u', t)."""
 
-    def jetfunc(*, jet_coords: Sequence[T], t: float) -> T:
+    def jetfunc(*, jet_coords: Sequence[T], t: float) -> list[T]:
         (y, dy) = jet_coords
         return [func(y, dy, t=t)]
 
@@ -286,13 +286,18 @@ def ode_order_arbitrary(
 ):
     """Construct a description of an ODE of arbitrary order."""
 
-    def jetfunc(*, jet_coords: Sequence[T], t: float) -> T:
-        return func(*jet_coords[:num_tcoeffs_in_args], t=t)
+    def jetfunc(*, jet_coords: Sequence[T], t: float) -> list[T]:
+        return [func(*jet_coords[:num_tcoeffs_in_args], t=t)]
 
     if jacobian is None:
         jacobian = jacobians.jacobian_monte_carlo_rev()
 
-    return JetOde(jetfunc, jacobian=jacobian, num_tcoeffs_in_args=num_tcoeffs_in_args)
+    return JetOde(
+        jetfunc,
+        jacobian=jacobian,
+        num_tcoeffs_in_args=num_tcoeffs_in_args,
+        tcoeff_indices_output=[num_tcoeffs_in_args],
+    )
 
 
 class ProtocolODEAutonomous(Protocol[T]):
@@ -399,7 +404,7 @@ def residual_position(
     # No implementation difference between ode and implicit, but
     # we don't want to force the user to think in terms of jet functions
     # so we offer these wrappers.
-    def jetfunc(*, jet_coords: Sequence[T], t: float) -> T:
+    def jetfunc(*, jet_coords: Sequence[T], t: float) -> list[T]:
         (y,) = jet_coords
         return [func(y, t=t)]
 
@@ -436,7 +441,7 @@ def residual_velocity(
     # No implementation difference between ode and implicit, but
     # we don't want to force the user to think in terms of jet functions
     # so we offer these wrappers.
-    def jetfunc(*, jet_coords: Sequence[T], t: float) -> T:
+    def jetfunc(*, jet_coords: Sequence[T], t: float) -> list[T]:
         (y, dy) = jet_coords
         return [func(y, dy, t=t)]
 
@@ -460,7 +465,7 @@ def residual_acceleration(
     # No implementation difference between ode and implicit, but
     # we don't want to force the user to think in terms of jet functions
     # so we offer these wrappers.
-    def jetfunc(*, jet_coords: Sequence[T], t: float) -> T:
+    def jetfunc(*, jet_coords: Sequence[T], t: float) -> list[T]:
         (y, dy, ddy) = jet_coords
         return [func(y, dy, ddy, t=t)]
 

--- a/probdiffeq/_probdiffeq/problems.py
+++ b/probdiffeq/_probdiffeq/problems.py
@@ -18,7 +18,7 @@ Examples
 ...     return y
 >>>
 >>> print(f)
-JetOde(num_tcoeffs_in_args=1, jacobian=jacobian_monte_carlo_rev(seed=1, num_probes=10))
+JetOde(num_tcoeffs_in_args=1, jacobian=jacobian_monte_carlo_rev(seed=1, num_probes=10), tcoeff_indices_output=[1])
 
 
 Higher-order problems:
@@ -28,7 +28,7 @@ Higher-order problems:
 ...     return y + dy
 >>>
 >>> print(f)
-JetOde(num_tcoeffs_in_args=2, jacobian=jacobian_monte_carlo_rev(seed=1, num_probes=10))
+JetOde(num_tcoeffs_in_args=2, jacobian=jacobian_monte_carlo_rev(seed=1, num_probes=10), tcoeff_indices_output=[2])
 
 General constraints:
 
@@ -189,7 +189,7 @@ class _JetOdeCommon(JetAbstract, Generic[T]):
         self.tcoeff_indices_output = tcoeff_indices_output
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(num_tcoeffs_in_args={self.num_tcoeffs_in_args}, jacobian={self.jacobian}, tcoeff_indices_output={self.tcoeff_indices_output}, vector_field={self.vector_field})"
+        return f"{self.__class__.__name__}(num_tcoeffs_in_args={self.num_tcoeffs_in_args}, jacobian={self.jacobian}, tcoeff_indices_output={self.tcoeff_indices_output})"
 
     def __call__(self, *jet_coords: *tuple[T], t: Array) -> T:
         # jet_coords = (u(t), u'(t), u''(t), ..., u^(K)(t))

--- a/probdiffeq/_probdiffeq/problems.py
+++ b/probdiffeq/_probdiffeq/problems.py
@@ -79,7 +79,6 @@ __all__ = [
     "residual_acceleration",
     "residual_from_ode",
     "residual_from_stack",
-    "residual_jet_lift",
     "residual_position",
     "residual_velocity",
 ]
@@ -278,6 +277,52 @@ class JetResidual(JetAbstract):
         # jet_coords = (u(t), u'(t), u''(t), ..., u^(K)(t))
         return self.residual_function(jet_coords=jet_coords, t=t)
 
+    def jet_lift(self, *, lift_by: int) -> "JetResidual":
+        """Lift a function on k-jet coordinates to one on (k+m)-jet coordinates."""
+        if not isinstance(lift_by, int):
+            raise TypeError
+
+        def residual_lifted(*, jet_coords: Sequence[T], t) -> Sequence[T]:
+            tcoeffs_all = jet_coords
+            _, unravel_one = tree.ravel_pytree(tcoeffs_all[0])
+
+            lift_by_upper = len(tcoeffs_all) - self.num_tcoeffs_in_args
+            if lift_by < 0 or lift_by > lift_by_upper:
+                msg = "The provided jet-order is incompatible with the residual order."
+                msg += f" Expected: 0 <= lift_by <= {lift_by_upper}."
+                msg += f" Received: lift_by == {lift_by}."
+                raise ValueError(msg)
+            order = self.num_tcoeffs_in_args + lift_by
+            tcoeffs = tcoeffs_all[:order]
+
+            # Flatten the residual because jax.jet is a bit high maintenance :)
+            def jet_call(*y):
+                y_tree = [unravel_one(s) for s in y]
+                fx = self.residual_function(jet_coords=y_tree, t=t)
+                return tree.ravel_pytree(fx)[0]
+
+            flat = [tree.ravel_pytree(s)[0] for s in tcoeffs]
+
+            ps, ss = utilities.jet_coords_to_primals_and_series(
+                flat, self.num_tcoeffs_in_args
+            )
+
+            if len(tree.tree_leaves(ss)) == 0:
+                fx = jet_call(*ps)
+
+                # Return a sequence to be compatible with Taylor-coeff logic,
+                # but don't bother unflattening the content
+                # because the result will be compared to zero anyway
+                return [fx]
+
+            primals, series = func.jet(jet_call, ps, ss, is_tcoeff=False)
+            return [primals, *series]
+
+        order = self.num_tcoeffs_in_args + lift_by
+        return JetResidual(
+            residual_lifted, num_tcoeffs_in_args=order, jacobian=self.jacobian
+        )
+
 
 class ProtocolResidualPosition(Protocol[T_contra]):
     def __call__(self, u: T_contra, /, *, t: float) -> Any: ...
@@ -376,51 +421,4 @@ def residual_from_ode(ode: "JetOde") -> JetResidual:
 
     return JetResidual(
         jetfunc, jacobian=ode.jacobian, num_tcoeffs_in_args=ode.num_tcoeffs_in_args + 1
-    )
-
-
-def residual_jet_lift(residual: JetResidual, lift_by: int) -> JetResidual:
-    """Lift a function on k-jet coordinates to one on (k+m)-jet coordinates."""
-    if not isinstance(lift_by, int):
-        raise TypeError
-
-    def residual_lifted(*, jet_coords: Sequence[T], t) -> Sequence[T]:
-        tcoeffs_all = jet_coords
-        _, unravel_one = tree.ravel_pytree(tcoeffs_all[0])
-
-        lift_by_upper = len(tcoeffs_all) - residual.num_tcoeffs_in_args
-        if lift_by < 0 or lift_by > lift_by_upper:
-            msg = "The provided jet-order is incompatible with the residual order."
-            msg += f" Expected: 0 <= lift_by <= {lift_by_upper}."
-            msg += f" Received: lift_by == {lift_by}."
-            raise ValueError(msg)
-        order = residual.num_tcoeffs_in_args + lift_by
-        tcoeffs = tcoeffs_all[:order]
-
-        # Flatten the residual because jax.jet is a bit high maintenance :)
-        def jet_call(*y):
-            y_tree = [unravel_one(s) for s in y]
-            fx = residual.residual_function(jet_coords=y_tree, t=t)
-            return tree.ravel_pytree(fx)[0]
-
-        flat = [tree.ravel_pytree(s)[0] for s in tcoeffs]
-
-        ps, ss = utilities.jet_coords_to_primals_and_series(
-            flat, residual.num_tcoeffs_in_args
-        )
-
-        if len(tree.tree_leaves(ss)) == 0:
-            fx = jet_call(*ps)
-
-            # Return a sequence to be compatible with Taylor-coeff logic,
-            # but don't bother unflattening the content
-            # because the result will be compared to zero anyway
-            return [fx]
-
-        primals, series = func.jet(jet_call, ps, ss, is_tcoeff=False)
-        return [primals, *series]
-
-    order = residual.num_tcoeffs_in_args + lift_by
-    return JetResidual(
-        residual_lifted, num_tcoeffs_in_args=order, jacobian=residual.jacobian
     )

--- a/probdiffeq/_probdiffeq/problems.py
+++ b/probdiffeq/_probdiffeq/problems.py
@@ -55,7 +55,7 @@ JetResidual(num_tcoeffs_in_args=2, jacobian=jacobian_monte_carlo_rev(seed=1, num
 """
 
 from probdiffeq._probdiffeq import jacobians, utilities
-from probdiffeq.backend import func, tree
+from probdiffeq.backend import func, np, tree
 from probdiffeq.backend.typing import Any, Array, Generic, Protocol, Sequence, TypeVar
 
 __all__ = [
@@ -106,6 +106,61 @@ class JetAbstract:
     def __repr__(self):
         return f"{self.__class__.__name__}(num_tcoeffs_in_args={self.num_tcoeffs_in_args}, jacobian={self.jacobian})"
 
+    def _lift(self, fun, /, *, lift_by: int):
+
+        def residual_lifted(*, jet_coords: Sequence[T], t) -> Sequence[T]:
+
+            # Check that the lift_by argument is feasible
+            lift_by_upper = len(jet_coords) - self.num_tcoeffs_in_args
+            if lift_by < 0 or lift_by > lift_by_upper:
+                msg = "The provided jet-order is incompatible with the residual order."
+                msg += f" Expected: 0 <= lift_by <= {lift_by_upper}."
+                msg += f" Received: lift_by == {lift_by}."
+                raise ValueError(msg)
+            order = self.num_tcoeffs_in_args + lift_by
+            tcoeffs = jet_coords[:order]
+
+            # Learn how to unflatten the outputs. We need this for
+            # the output types to be consistent with the original
+            # pytree structure (needed especially for ODE jet-lifting)
+            out_like = func.eval_shape(
+                fun, jet_coords=jet_coords[: self.num_tcoeffs_in_args], t=t
+            )
+            out_like = tree.tree_map(np.zeros_like, out_like)
+            _, unravel_outputs = tree.ravel_pytree(out_like)
+
+            # Flatten the residual because jax.experimental.jet is a bit high maintenance :)
+            _, unravel_inputs = tree.ravel_pytree(jet_coords[0])
+            flat = [tree.ravel_pytree(s)[0] for s in tcoeffs]
+
+            def jet_call(*y):
+                y_tree = [unravel_inputs(s) for s in y]
+                fx = fun(jet_coords=y_tree, t=t)
+                return tree.ravel_pytree(fx)[0]
+
+            # Process the Taylor-coefficient list into the primals/series combination
+            # needed for jax.experimental.jet
+            ps, ss = utilities.jet_coords_to_primals_and_series(
+                flat, self.num_tcoeffs_in_args
+            )
+
+            # If there are no series, then we can just call the function directly and return the result.
+            if len(tree.tree_leaves(ss)) == 0:
+                fx = jet_call(*ps)
+
+                # Return a sequence to be compatible with Taylor-coeff logic,
+                # but don't bother unflattening the content
+                # because the result will be compared to zero anyway
+                return [unravel_outputs(fx)]
+
+            # Call the jet, combine the primals and series,
+            # and return the result as a sequence of Taylor coefficients
+            primals, series = func.jet(jet_call, ps, ss, is_tcoeff=False)
+            coeffs_out = [primals, *series]
+            return [unravel_outputs(c) for c in coeffs_out]
+
+        return residual_lifted
+
 
 class ProtocolODEFirstOrder(Protocol[T]):
     def __call__(self, u: T, /, *, t: float) -> T: ...
@@ -138,6 +193,17 @@ class JetOde(JetAbstract, Generic[T]):
     @property
     def tcoeff_indices_input(self) -> list[int]:
         return list(range(self.num_tcoeffs_in_args))
+
+    def jet_lift(self, *, lift_by: int) -> "JetResidual":
+        """Lift a function on k-jet coordinates to one on (k+m)-jet coordinates."""
+        if not isinstance(lift_by, int):
+            raise TypeError
+        vf_lifted = self._lift(self.vector_field, lift_by=lift_by)
+        order = self.num_tcoeffs_in_args + lift_by
+
+        # TODO: If we call this on the *Autonomous subclass,
+        #       we lose the fact that the lifted function is autonomous.
+        return JetOde(vf_lifted, num_tcoeffs_in_args=order, jacobian=self.jacobian)
 
 
 class JetOdeAutonomous(JetOde[T]):
@@ -281,43 +347,7 @@ class JetResidual(JetAbstract):
         """Lift a function on k-jet coordinates to one on (k+m)-jet coordinates."""
         if not isinstance(lift_by, int):
             raise TypeError
-
-        def residual_lifted(*, jet_coords: Sequence[T], t) -> Sequence[T]:
-            tcoeffs_all = jet_coords
-            _, unravel_one = tree.ravel_pytree(tcoeffs_all[0])
-
-            lift_by_upper = len(tcoeffs_all) - self.num_tcoeffs_in_args
-            if lift_by < 0 or lift_by > lift_by_upper:
-                msg = "The provided jet-order is incompatible with the residual order."
-                msg += f" Expected: 0 <= lift_by <= {lift_by_upper}."
-                msg += f" Received: lift_by == {lift_by}."
-                raise ValueError(msg)
-            order = self.num_tcoeffs_in_args + lift_by
-            tcoeffs = tcoeffs_all[:order]
-
-            # Flatten the residual because jax.jet is a bit high maintenance :)
-            def jet_call(*y):
-                y_tree = [unravel_one(s) for s in y]
-                fx = self.residual_function(jet_coords=y_tree, t=t)
-                return tree.ravel_pytree(fx)[0]
-
-            flat = [tree.ravel_pytree(s)[0] for s in tcoeffs]
-
-            ps, ss = utilities.jet_coords_to_primals_and_series(
-                flat, self.num_tcoeffs_in_args
-            )
-
-            if len(tree.tree_leaves(ss)) == 0:
-                fx = jet_call(*ps)
-
-                # Return a sequence to be compatible with Taylor-coeff logic,
-                # but don't bother unflattening the content
-                # because the result will be compared to zero anyway
-                return [fx]
-
-            primals, series = func.jet(jet_call, ps, ss, is_tcoeff=False)
-            return [primals, *series]
-
+        residual_lifted = self._lift(self.residual_function, lift_by=lift_by)
         order = self.num_tcoeffs_in_args + lift_by
         return JetResidual(
             residual_lifted, num_tcoeffs_in_args=order, jacobian=self.jacobian

--- a/probdiffeq/_probdiffeq/problems.py
+++ b/probdiffeq/_probdiffeq/problems.py
@@ -209,6 +209,24 @@ class _JetOdeCommon(JetAbstract, Generic[T]):
 
 
 class JetOde(_JetOdeCommon, Generic[T]):
+    def jet_lift_max(self, *, num_tcoeffs: int) -> "JetOde":
+        if self.is_jet_extended:
+            raise ValueError
+        [output_idx] = self.tcoeff_indices_output
+        assert output_idx >= self.num_tcoeffs_in_args
+
+        # E.g. for second-order ODE with three-coeff priors:
+        #   output_idx = 2
+        #   num_tcoeffs = 3 (state, position, velocity)
+        #   -> lift_by = 0, because all states are observed directly
+        # For second-order ODE with five-coeff priors:
+        #   output_idx = 2
+        #   num_tcoeffs = 5
+        #   -> lift_by = 2, because without jet extension,
+        #   the two highest derivatives remain unobserved
+        lift_by = num_tcoeffs - output_idx - 1
+        return self.jet_lift(lift_by=lift_by)
+
     def jet_lift(self, *, lift_by: int) -> "JetOde":
         """Lift a function on k-jet coordinates to one on (k+m)-jet coordinates."""
         if not isinstance(lift_by, int):
@@ -253,7 +271,10 @@ class JetOdeAutonomous(_JetOdeCommon, Generic[T]):
         )
         self.autonomous = autonomous
 
-    def jet_lift(self, *, lift_by: int) -> "JetResidual":
+    def jet_lift_max(self, *, num_tcoeffs: int):
+        raise NotImplementedError
+
+    def jet_lift(self, *, lift_by: int):
         raise NotImplementedError
 
 
@@ -391,6 +412,9 @@ class JetResidual(JetAbstract):
         """Make the vector field callable like the original user function to hide the "sophisticated" API."""
         # jet_coords = (u(t), u'(t), u''(t), ..., u^(K)(t))
         return self.residual_function(jet_coords=jet_coords, t=t)
+
+    def jet_lift_max(self, *, num_tcoeffs: int) -> "JetResidual":
+        return self.jet_lift(lift_by=num_tcoeffs - self.num_tcoeffs_in_args)
 
     def jet_lift(self, *, lift_by: int) -> "JetResidual":
         """Lift a function on k-jet coordinates to one on (k+m)-jet coordinates."""

--- a/probdiffeq/_probdiffeq/problems.py
+++ b/probdiffeq/_probdiffeq/problems.py
@@ -125,7 +125,7 @@ class JetAbstract:
             # Learn how to unflatten the outputs. We need this for
             # the output types to be consistent with the original
             # pytree structure (needed especially for ODE jet-lifting)
-            out_like = func.eval_shape(
+            [out_like] = func.eval_shape(
                 fun, jet_coords=jet_coords[: self.num_tcoeffs_in_args], t=t
             )
             out_like = tree.tree_map(np.zeros_like, out_like)
@@ -187,6 +187,9 @@ class _JetOdeCommon(JetAbstract, Generic[T]):
         super().__init__(jacobian=jacobian, num_tcoeffs_in_args=num_tcoeffs_in_args)
         self.vector_field = vector_field
         self.tcoeff_indices_output = tcoeff_indices_output
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(num_tcoeffs_in_args={self.num_tcoeffs_in_args}, jacobian={self.jacobian}, tcoeff_indices_output={self.tcoeff_indices_output}, vector_field={self.vector_field})"
 
     def __call__(self, *jet_coords: *tuple[T], t: Array) -> T:
         # jet_coords = (u(t), u'(t), u''(t), ..., u^(K)(t))
@@ -475,7 +478,7 @@ def residual_acceleration(
     return JetResidual(jetfunc, jacobian=jacobian, num_tcoeffs_in_args=3)
 
 
-def residual_from_ode(ode: "JetOde") -> JetResidual:
+def residual_from_ode(ode: JetOde) -> JetResidual:
     """Construct a JetResidual from a JetOde.
 
     The residual is u^(k) - f(u, u', ..., t) = 0.

--- a/probdiffeq/_probdiffeq/problems.py
+++ b/probdiffeq/_probdiffeq/problems.py
@@ -268,12 +268,14 @@ def ode_order_two(
 
     def jetfunc(*, jet_coords: Sequence[T], t: float) -> T:
         (y, dy) = jet_coords
-        return func(y, dy, t=t)
+        return [func(y, dy, t=t)]
 
     if jacobian is None:
         jacobian = jacobians.jacobian_monte_carlo_rev()
 
-    return JetOde(jetfunc, jacobian=jacobian, num_tcoeffs_in_args=2)
+    return JetOde(
+        jetfunc, jacobian=jacobian, num_tcoeffs_in_args=2, tcoeff_indices_output=[2]
+    )
 
 
 # No typing because arbitrary order is difficult to type (unlike ode and ode_order_two)
@@ -333,7 +335,9 @@ def ode_autonomous_order_two(
     if jacobian is None:
         jacobian = jacobians.jacobian_monte_carlo_rev()
 
-    return JetOdeAutonomous(autonomous, jacobian=jacobian, num_tcoeffs_in_args=2)
+    return JetOdeAutonomous(
+        autonomous, jacobian=jacobian, num_tcoeffs_in_args=2, tcoeff_indices_output=[2]
+    )
 
 
 # No typing because arbitrary order is difficult to type (unlike ode and ode_order_two)
@@ -351,7 +355,10 @@ def ode_autonomous_order_arbitrary(
         jacobian = jacobians.jacobian_monte_carlo_rev()
 
     return JetOdeAutonomous(
-        autonomous, jacobian=jacobian, num_tcoeffs_in_args=num_tcoeffs_in_args
+        autonomous,
+        jacobian=jacobian,
+        num_tcoeffs_in_args=num_tcoeffs_in_args,
+        tcoeff_indices_output=[num_tcoeffs_in_args],
     )
 
 

--- a/probdiffeq/_probdiffeq/problems.py
+++ b/probdiffeq/_probdiffeq/problems.py
@@ -63,13 +63,6 @@ __all__ = [
     "JetOde",
     "JetOdeAutonomous",
     "JetResidual",
-    "ProtocolODEAutonomous",
-    "ProtocolODEAutonomousOrderTwo",
-    "ProtocolODEFirstOrder",
-    "ProtocolODEOrderTwo",
-    "ProtocolResidualAcceleration",
-    "ProtocolResidualPosition",
-    "ProtocolResidualVelocity",
     "ode",
     "ode_autonomous",
     "ode_autonomous_order_arbitrary",
@@ -164,11 +157,11 @@ class JetAbstract:
         return fun_lifted
 
 
-class ProtocolODEFirstOrder(Protocol[T]):
+class _ProtocolODEFirstOrder(Protocol[T]):
     def __call__(self, u: T, /, *, t: float) -> T: ...
 
 
-class ProtocolODEOrderTwo(Protocol[T]):
+class _ProtocolODEOrderTwo(Protocol[T]):
     def __call__(self, u: T, du: T, /, *, t: float) -> T: ...
 
 
@@ -191,11 +184,14 @@ class _JetOdeCommon(JetAbstract, Generic[T]):
     def __repr__(self):
         return f"{self.__class__.__name__}(num_tcoeffs_in_args={self.num_tcoeffs_in_args}, jacobian={self.jacobian}, tcoeff_indices_output={self.tcoeff_indices_output})"
 
-    # TODO: call if self.is_jet_extended: raise ValueError in here once uncommenting
-    # def __call__(self, *jet_coords: *tuple[T], t: Array) -> T:
-    #     # jet_coords = (u(t), u'(t), u''(t), ..., u^(K)(t))
-    #     [fx] = self.vector_field(jet_coords=jet_coords, t=t)
-    #     return fx
+    def __call__(self, *jet_coords: *tuple[T], t: Array) -> T:
+        # jet_coords = (u(t), u'(t), u''(t), ..., u^(K)(t))
+
+        if self.is_jet_extended:
+            raise ValueError
+
+        [fx] = self.vector_field(jet_coords=jet_coords, t=t)
+        return fx
 
     @property
     def tcoeff_indices_input(self) -> list[int]:
@@ -261,7 +257,7 @@ class JetOdeAutonomous(_JetOdeCommon, Generic[T]):
         raise NotImplementedError
 
 
-def ode(func: ProtocolODEFirstOrder, /, *, jacobian: jacobians.Jacobian | None = None):
+def ode(func: _ProtocolODEFirstOrder, /, *, jacobian: jacobians.Jacobian | None = None):
     """Construct a description of an ODE u' = f(u, t)."""
 
     def jetfunc(*, jet_coords: Sequence[T], t: float) -> list[T]:
@@ -277,7 +273,7 @@ def ode(func: ProtocolODEFirstOrder, /, *, jacobian: jacobians.Jacobian | None =
 
 
 def ode_order_two(
-    func: ProtocolODEOrderTwo, /, *, jacobian: jacobians.Jacobian | None = None
+    func: _ProtocolODEOrderTwo, /, *, jacobian: jacobians.Jacobian | None = None
 ):
     """Construct a description of an ODE u'' = f(u, u', t)."""
 
@@ -315,12 +311,12 @@ def ode_order_arbitrary(
     )
 
 
-class ProtocolODEAutonomous(Protocol[T]):
+class _ProtocolODEAutonomous(Protocol[T]):
     def __call__(self, u: T, /) -> T: ...
 
 
 def ode_autonomous(
-    func: ProtocolODEAutonomous, /, *, jacobian: jacobians.Jacobian | None = None
+    func: _ProtocolODEAutonomous, /, *, jacobian: jacobians.Jacobian | None = None
 ):
     """Construct a description of an autonomous ODE u' = f(u)."""
 
@@ -336,12 +332,12 @@ def ode_autonomous(
     )
 
 
-class ProtocolODEAutonomousOrderTwo(Protocol[T]):
+class _ProtocolODEAutonomousOrderTwo(Protocol[T]):
     def __call__(self, u: T, du: T, /) -> T: ...
 
 
 def ode_autonomous_order_two(
-    func: ProtocolODEAutonomousOrderTwo,
+    func: _ProtocolODEAutonomousOrderTwo,
     /,
     *,
     jacobian: jacobians.Jacobian | None = None,
@@ -407,12 +403,12 @@ class JetResidual(JetAbstract):
         )
 
 
-class ProtocolResidualPosition(Protocol[T_contra]):
+class _ProtocolResidualPosition(Protocol[T_contra]):
     def __call__(self, u: T_contra, /, *, t: float) -> Any: ...
 
 
 def residual_position(
-    func: ProtocolResidualPosition, /, *, jacobian: jacobians.Jacobian | None = None
+    func: _ProtocolResidualPosition, /, *, jacobian: jacobians.Jacobian | None = None
 ) -> JetResidual:
     """Construct a description of a residual f(u, t) = 0."""
 
@@ -444,12 +440,12 @@ def residual_from_stack(*residual_stack: *tuple[JetResidual, ...]) -> JetResidua
     return JetResidual(jetfunc, jacobian=jacobian, num_tcoeffs_in_args=num_args)
 
 
-class ProtocolResidualVelocity(Protocol[T_contra]):
+class _ProtocolResidualVelocity(Protocol[T_contra]):
     def __call__(self, u: T_contra, du: T_contra, /, *, t: float) -> Any: ...
 
 
 def residual_velocity(
-    func: ProtocolResidualVelocity, /, *, jacobian: jacobians.Jacobian | None = None
+    func: _ProtocolResidualVelocity, /, *, jacobian: jacobians.Jacobian | None = None
 ) -> JetResidual:
     """Construct a description of a residual f(u, du, t) = 0."""
 
@@ -466,14 +462,17 @@ def residual_velocity(
     return JetResidual(jetfunc, jacobian=jacobian, num_tcoeffs_in_args=2)
 
 
-class ProtocolResidualAcceleration(Protocol[T_contra]):
+class _ProtocolResidualAcceleration(Protocol[T_contra]):
     def __call__(
         self, u: T_contra, du: T_contra, ddu: T_contra, /, *, t: float
     ) -> Any: ...
 
 
 def residual_acceleration(
-    func: ProtocolResidualAcceleration, /, *, jacobian: jacobians.Jacobian | None = None
+    func: _ProtocolResidualAcceleration,
+    /,
+    *,
+    jacobian: jacobians.Jacobian | None = None,
 ) -> JetResidual:
     """Construct a description of a residual f(u, du, ddu, t) = 0."""
 

--- a/probdiffeq/_probdiffeq/problems.py
+++ b/probdiffeq/_probdiffeq/problems.py
@@ -124,6 +124,10 @@ class JetOde(JetAbstract, Generic[T]):
         num_tcoeffs_in_args: int,
         tcoeff_indices_output: list[int],
     ):
+        # TODO: turn the num_tcoeffs_in_args argument into tcoeff_indices_input.
+        #       However, this requires manipulating the jet_lift logic to handle
+        #       inputs like (2, 4, 5). There is a well-defined solution,
+        #       but, for now, spelling out this solution is too complicated for me.
         super().__init__(jacobian=jacobian, num_tcoeffs_in_args=num_tcoeffs_in_args)
         self.vector_field = vector_field
         self.tcoeff_indices_output = tcoeff_indices_output
@@ -163,9 +167,6 @@ def ode(func: ProtocolODEFirstOrder, /, *, jacobian: jacobians.Jacobian | None =
     if jacobian is None:
         jacobian = jacobians.jacobian_monte_carlo_rev()
 
-    # TODO: turn the num_tcoeffs_in_args argument into tcoeff_indices_input.
-    #       However, this requires manipulating the jet_lift logic to handle
-    #       inputs like (2, 4, 5). For now, this is too complicated for me.
     return JetOde(
         jetfunc, jacobian=jacobian, num_tcoeffs_in_args=1, tcoeff_indices_output=[1]
     )

--- a/probdiffeq/_probdiffeq/problems.py
+++ b/probdiffeq/_probdiffeq/problems.py
@@ -118,6 +118,7 @@ class JetAbstract:
                 msg += f" Expected: 0 <= lift_by <= {lift_by_upper}."
                 msg += f" Received: lift_by == {lift_by}."
                 raise ValueError(msg)
+
             order = self.num_tcoeffs_in_args + lift_by
             tcoeffs = jet_coords[:order]
 
@@ -171,7 +172,7 @@ class ProtocolODEOrderTwo(Protocol[T]):
     def __call__(self, u: T, du: T, /, *, t: float) -> T: ...
 
 
-class JetOde(JetAbstract, Generic[T]):
+class _JetOdeCommon(JetAbstract, Generic[T]):
     def __init__(
         self,
         vector_field,
@@ -195,6 +196,8 @@ class JetOde(JetAbstract, Generic[T]):
     def tcoeff_indices_input(self) -> list[int]:
         return list(range(self.num_tcoeffs_in_args))
 
+
+class JetOde(_JetOdeCommon, Generic[T]):
     def jet_lift(self, *, lift_by: int) -> "JetResidual":
         """Lift a function on k-jet coordinates to one on (k+m)-jet coordinates."""
         if not isinstance(lift_by, int):
@@ -207,8 +210,6 @@ class JetOde(JetAbstract, Generic[T]):
         vf_lifted = self.lift(self.vector_field, lift_by=lift_by)
         order = self.num_tcoeffs_in_args + lift_by
 
-        # TODO: If we call this on the *Autonomous subclass,
-        #       we lose the fact that the lifted function is autonomous.
         [idx] = self.tcoeff_indices_output
         tcoeff_indices_output = [idx + ell for ell in range(lift_by + 1)]
         return JetOde(
@@ -219,23 +220,30 @@ class JetOde(JetAbstract, Generic[T]):
         )
 
 
-class JetOdeAutonomous(JetOde[T]):
+class JetOdeAutonomous(_JetOdeCommon, Generic[T]):
     """An autonomous ODE u^(k) = f(u, u', ...) where f does not depend on t."""
 
     def __init__(
-        self, autonomous, jacobian: jacobians.Jacobian, num_tcoeffs_in_args: int
+        self,
+        autonomous,
+        jacobian: jacobians.Jacobian,
+        num_tcoeffs_in_args: int,
+        tcoeff_indices_output: list[int],
     ):
         def vector_field(*, jet_coords, t):
             del t
             return autonomous(jet_coords=jet_coords)
 
         super().__init__(
-            vector_field, jacobian=jacobian, num_tcoeffs_in_args=num_tcoeffs_in_args
-        )
-        assert False, (
-            "Fix: jet-lifting for ODEs and autonomous ODEs differs, so rethink the subclass construction"
+            vector_field,
+            jacobian=jacobian,
+            num_tcoeffs_in_args=num_tcoeffs_in_args,
+            tcoeff_indices_output=tcoeff_indices_output,
         )
         self.autonomous = autonomous
+
+    def jet_lift(self, *, lift_by: int) -> "JetResidual":
+        raise NotImplementedError
 
 
 def ode(func: ProtocolODEFirstOrder, /, *, jacobian: jacobians.Jacobian | None = None):
@@ -243,7 +251,7 @@ def ode(func: ProtocolODEFirstOrder, /, *, jacobian: jacobians.Jacobian | None =
 
     def jetfunc(*, jet_coords: Sequence[T], t: float) -> T:
         (y,) = jet_coords
-        return func(y, t=t)
+        return [func(y, t=t)]
 
     if jacobian is None:
         jacobian = jacobians.jacobian_monte_carlo_rev()
@@ -301,7 +309,9 @@ def ode_autonomous(
     if jacobian is None:
         jacobian = jacobians.jacobian_monte_carlo_rev()
 
-    return JetOdeAutonomous(autonomous, jacobian=jacobian, num_tcoeffs_in_args=1)
+    return JetOdeAutonomous(
+        autonomous, jacobian=jacobian, num_tcoeffs_in_args=1, tcoeff_indices_output=[1]
+    )
 
 
 class ProtocolODEAutonomousOrderTwo(Protocol[T]):
@@ -384,7 +394,7 @@ def residual_position(
     # so we offer these wrappers.
     def jetfunc(*, jet_coords: Sequence[T], t: float) -> T:
         (y,) = jet_coords
-        return func(y, t=t)
+        return [func(y, t=t)]
 
     if jacobian is None:
         jacobian = jacobians.jacobian_monte_carlo_rev()
@@ -421,7 +431,7 @@ def residual_velocity(
     # so we offer these wrappers.
     def jetfunc(*, jet_coords: Sequence[T], t: float) -> T:
         (y, dy) = jet_coords
-        return func(y, dy, t=t)
+        return [func(y, dy, t=t)]
 
     if jacobian is None:
         jacobian = jacobians.jacobian_monte_carlo_rev()
@@ -445,7 +455,7 @@ def residual_acceleration(
     # so we offer these wrappers.
     def jetfunc(*, jet_coords: Sequence[T], t: float) -> T:
         (y, dy, ddy) = jet_coords
-        return func(y, dy, ddy, t=t)
+        return [func(y, dy, ddy, t=t)]
 
     if jacobian is None:
         jacobian = jacobians.jacobian_monte_carlo_rev()
@@ -460,7 +470,7 @@ def residual_from_ode(ode: "JetOde") -> JetResidual:
     """
 
     def jetfunc(*, jet_coords: Sequence[T], t: float) -> T:
-        output = jet_coords[ode.num_tcoeffs_in_args]
+        output = [jet_coords[i] for i in ode.tcoeff_indices_output]
         inputs = jet_coords[: ode.num_tcoeffs_in_args]
         vf_eval = ode.vector_field(jet_coords=inputs, t=t)
         return tree.tree_map(lambda a, b: a - b, output, vf_eval)

--- a/probdiffeq/_probdiffeq/solvers.py
+++ b/probdiffeq/_probdiffeq/solvers.py
@@ -979,6 +979,15 @@ class error_residual_std(ErrorEstimator):
         if self.error_per_unit_step:
             n += 1
 
+        if reference.shape != error.shape:
+            msg = f"The error-estimate and reference have different shapes ({error.shape} vs {reference.shape})."
+            msg += (
+                " This is typically caused by using the residual-based error estimator"
+            )
+            msg += " for non-standard constraints, e.g., DAEs or jet-extended ODEs."
+            msg += " Try using state-based error estimators or exchange the error-norm computation."
+            raise ValueError(msg)
+
         error_abs = error * dt**n / np.factorial(n)
         error_norm = self.error_norm(error_abs, reference, atol=atol, rtol=rtol)
 

--- a/probdiffeq/_probdiffeq/solvers.py
+++ b/probdiffeq/_probdiffeq/solvers.py
@@ -979,7 +979,7 @@ class error_residual_std(ErrorEstimator):
         if self.error_per_unit_step:
             n += 1
 
-        if reference.shape != error.shape:
+        if error.shape not in [(1,), reference.shape]:
             msg = f"The error-estimate and reference have different shapes ({error.shape} vs {reference.shape})."
             msg += (
                 " This is typically caused by using the residual-based error estimator"

--- a/probdiffeq/_probdiffeq/ssm_impl_api.py
+++ b/probdiffeq/_probdiffeq/ssm_impl_api.py
@@ -533,7 +533,12 @@ class StateSpaceModel(abc.ABC):
         """
         raise NotImplementedError
 
-    def constraint_ode_ts1(self, ode: problems.JetOde, /) -> AbstractResidual:
+    def constraint_ode_ts1(
+        self,
+        ode: problems.JetOde,
+        /,
+        taylor_point: "taylor_points.TaylorPoint | None" = None,
+    ) -> AbstractResidual:
         r"""Create an ODE constraint and linearise with a first-order Taylor approximation.
 
         This constraint handles ODEs of the form
@@ -550,7 +555,7 @@ class StateSpaceModel(abc.ABC):
             raise TypeError(ode)
 
         residual = problems.residual_from_ode(ode)
-        return self.constraint_residual(residual)
+        return self.constraint_residual(residual, taylor_point=taylor_point)
 
     @abc.abstractmethod
     def constraint_residual(

--- a/probdiffeq/_probdiffeq/ssm_impl_api.py
+++ b/probdiffeq/_probdiffeq/ssm_impl_api.py
@@ -398,6 +398,7 @@ class StateSpaceModel(abc.ABC):
             autonomous,
             jacobian=jacobians.jacobian_monte_carlo_fwd(),
             num_tcoeffs_in_args=len(tcoeffs) + diffuse_derivatives,
+            tcoeff_indices_output=len(tcoeffs) + diffuse_derivatives + 1,
         )
         return self.prior_exponential(
             ode,
@@ -429,6 +430,7 @@ class StateSpaceModel(abc.ABC):
             autonomous,
             jacobian=jacobians.jacobian_monte_carlo_fwd(),
             num_tcoeffs_in_args=len(tcoeffs_mean) + diffuse_derivatives,
+            tcoeff_indices_output=len(tcoeffs_mean) + diffuse_derivatives + 1,
         )
         return self.prior_exponential_diffuse(
             ode,
@@ -465,6 +467,7 @@ class StateSpaceModel(abc.ABC):
             autonomous,
             jacobian=jacobians.jacobian_monte_carlo_fwd(),
             num_tcoeffs_in_args=len(tcoeffs) + diffuse_derivatives,
+            tcoeff_indices_output=len(tcoeffs) + diffuse_derivatives + 1,
         )
         return self.prior_exponential(
             ode,
@@ -501,6 +504,7 @@ class StateSpaceModel(abc.ABC):
             autonomous,
             jacobian=jacobians.jacobian_monte_carlo_fwd(),
             num_tcoeffs_in_args=len(tcoeffs_mean) + diffuse_derivatives,
+            tcoeff_indices_output=len(tcoeffs_mean) + diffuse_derivatives + 1,
         )
         return self.prior_exponential_diffuse(
             ode,

--- a/probdiffeq/_probdiffeq/ssm_impl_api.py
+++ b/probdiffeq/_probdiffeq/ssm_impl_api.py
@@ -391,14 +391,14 @@ class StateSpaceModel(abc.ABC):
     ) -> AbstractPrior:
         """Construct an integrated Ornstein-Uhlenbeck prior."""
 
-        def autonomous(*, jet_coords):
-            return linop(jet_coords[-1])
+        def autonomous(*, jet_coords: list) -> list:
+            return [linop(jet_coords[-1])]
 
         ode: problems.JetOdeAutonomous = problems.JetOdeAutonomous(
             autonomous,
             jacobian=jacobians.jacobian_monte_carlo_fwd(),
             num_tcoeffs_in_args=len(tcoeffs) + diffuse_derivatives,
-            tcoeff_indices_output=len(tcoeffs) + diffuse_derivatives + 1,
+            tcoeff_indices_output=[len(tcoeffs) + diffuse_derivatives + 1],
         )
         return self.prior_exponential(
             ode,
@@ -423,14 +423,14 @@ class StateSpaceModel(abc.ABC):
     ) -> AbstractPrior:
         """Construct a diffuse integrated Ornstein-Uhlenbeck prior."""
 
-        def autonomous(*, jet_coords):
-            return linop(jet_coords[-1])
+        def autonomous(*, jet_coords: list) -> list:
+            return [linop(jet_coords[-1])]
 
         ode: problems.JetOdeAutonomous = problems.JetOdeAutonomous(
             autonomous,
             jacobian=jacobians.jacobian_monte_carlo_fwd(),
             num_tcoeffs_in_args=len(tcoeffs_mean) + diffuse_derivatives,
-            tcoeff_indices_output=len(tcoeffs_mean) + diffuse_derivatives + 1,
+            tcoeff_indices_output=[len(tcoeffs_mean) + diffuse_derivatives + 1],
         )
         return self.prior_exponential_diffuse(
             ode,
@@ -455,19 +455,19 @@ class StateSpaceModel(abc.ABC):
     ) -> AbstractPrior:
         """Construct an integrated Ornstein-Uhlenbeck prior."""
 
-        def autonomous(*, jet_coords):
+        def autonomous(*, jet_coords: list) -> list:
             D = len(jet_coords)
             z = np.sqrt(2 * (D - 0.5)) / length_scale
             scaled = [
                 np.comb(D, i) * z ** (D - i) * d for i, d in enumerate(jet_coords)
             ]
-            return -sum(scaled)
+            return [-sum(scaled)]
 
         ode: problems.JetOdeAutonomous = problems.JetOdeAutonomous(
             autonomous,
             jacobian=jacobians.jacobian_monte_carlo_fwd(),
             num_tcoeffs_in_args=len(tcoeffs) + diffuse_derivatives,
-            tcoeff_indices_output=len(tcoeffs) + diffuse_derivatives + 1,
+            tcoeff_indices_output=[len(tcoeffs) + diffuse_derivatives + 1],
         )
         return self.prior_exponential(
             ode,
@@ -492,19 +492,19 @@ class StateSpaceModel(abc.ABC):
     ) -> AbstractPrior:
         """Construct a diffuse integrated Ornstein-Uhlenbeck prior."""
 
-        def autonomous(*, jet_coords):
+        def autonomous(*, jet_coords: list) -> list:
             D = len(jet_coords)
             z = np.sqrt(2 * (D - 0.5)) / length_scale
             scaled = [
                 np.comb(D, i) * z ** (D - i) * d for i, d in enumerate(jet_coords)
             ]
-            return -sum(scaled)
+            return [-sum(scaled)]
 
         ode: problems.JetOdeAutonomous = problems.JetOdeAutonomous(
             autonomous,
             jacobian=jacobians.jacobian_monte_carlo_fwd(),
             num_tcoeffs_in_args=len(tcoeffs_mean) + diffuse_derivatives,
-            tcoeff_indices_output=len(tcoeffs_mean) + diffuse_derivatives + 1,
+            tcoeff_indices_output=[len(tcoeffs_mean) + diffuse_derivatives + 1],
         )
         return self.prior_exponential_diffuse(
             ode,

--- a/probdiffeq/_probdiffeq/ssm_impl_blockdiag.py
+++ b/probdiffeq/_probdiffeq/ssm_impl_blockdiag.py
@@ -283,9 +283,13 @@ class BlockDiagNormal(ssm_impl_api.AbstractTreeNormal[BlockDiagTreeFlatten]):
         return self.residual_whitened_rms_flat(u_latent)
 
     def residual_whitened_rms_flat(self, u_latent, /):
-        mean = np.reshape(self.mean_flat - u_latent, (-1,))
-        cholesky = np.reshape(self.cholesky_flat, (-1,))
-        return mean / cholesky / np.sqrt(mean.size)
+
+        def rms_scalar(u, m, c):
+            dx = u - m
+            w = linalg.solve_tril(c, dx)
+            return linalg.vector_norm(w) / np.sqrt(m.size)
+
+        return func.vmap(rms_scalar)(u_latent, self.mean_flat, self.cholesky_flat)
 
     def rescale_cholesky(self, factor, /):
         cholesky = factor[..., None, None] * self.cholesky_flat

--- a/probdiffeq/_probdiffeq/ssm_impl_blockdiag.py
+++ b/probdiffeq/_probdiffeq/ssm_impl_blockdiag.py
@@ -129,15 +129,16 @@ class BlockDiagOdeTs0(ssm_impl_api.AbstractOde):
     def linearize(self, rv, state: None, *, damp: float, t):
         del state
 
-        jet_coords = rv.mean[: self.ode.num_tcoeffs_in_args]
-        fx = self.ode.vector_field(jet_coords=jet_coords, t=t)
+        fx = self.ode.vector_field(
+            jet_coords=rv.mean[: self.ode.num_tcoeffs_in_args], t=t
+        )
         fx = tree.tree_map(lambda s: -s, fx)
-        bias = BlockDiagNormal.from_dirac([fx], damp=damp)
+        bias = BlockDiagNormal.from_dirac(fx, damp=damp)
 
-        def a1(s):
-            return s[[self.ode.num_tcoeffs_in_args], ...]
+        def derivative_selector(s):
+            return s[np.asarray(self.ode.tcoeff_indices_output), ...]
 
-        linop = func.vmap(func.jacrev(a1))(rv.mean_flat)
+        linop = func.vmap(func.jacrev(derivative_selector))(rv.mean_flat)
 
         cond = BlockDiagLatentCond.from_linop_and_noise(linop, bias)
         return cond, None
@@ -150,13 +151,18 @@ class BlockDiagResidual(ssm_impl_api.AbstractResidual):
         return self.residual.jacobian.init_jacobian_handler()
 
     def linearize(self, rv, state, *, damp: float, t):
-        rv0 = BlockDiagNormal.from_dirac([rv.mean[0]], damp=0.0)
+        # Understand the output pytree structure
+        jet_coords = rv.mean[: self.residual.num_tcoeffs_in_args]
+        output_like = func.eval_shape(
+            self.residual.residual_function, jet_coords=jet_coords, t=t
+        )
+        rv_output = BlockDiagNormal.from_dirac(output_like, damp=0.0)
 
         def residual_flat(u):
             u_tree = rv.tree_flatten.unflatten_array(u.T)
             u_tree = u_tree[: self.residual.num_tcoeffs_in_args]
             r_tree = self.residual.residual_function(jet_coords=u_tree, t=t)
-            return rv0.tree_flatten.flatten_tree([r_tree]).T
+            return rv_output.tree_flatten.flatten_tree(r_tree).T
 
         fx, J_diag, state = self.residual.jacobian.calculate_diagonal_along_d(
             residual_flat, rv.mean_flat.T, state
@@ -170,8 +176,8 @@ class BlockDiagResidual(ssm_impl_api.AbstractResidual):
         diff = np.einsum("din,dn->di", linop, rv.mean_flat)
         fx = fx - diff
 
-        fx = rv0.tree_flatten.unflatten_array(fx)
-        bias = BlockDiagNormal.from_dirac([fx], damp=damp)
+        fx = rv_output.tree_flatten.unflatten_array(fx)
+        bias = BlockDiagNormal.from_dirac(fx, damp=damp)
         cond = BlockDiagLatentCond.from_linop_and_noise(linop, bias)
         return cond, state
 

--- a/probdiffeq/_probdiffeq/ssm_impl_blockdiag.py
+++ b/probdiffeq/_probdiffeq/ssm_impl_blockdiag.py
@@ -156,6 +156,7 @@ class BlockDiagResidual(ssm_impl_api.AbstractResidual):
         output_like = func.eval_shape(
             self.residual.residual_function, jet_coords=jet_coords, t=t
         )
+        output_like = tree.tree_map(np.zeros_like, output_like)
         rv_output = BlockDiagNormal.from_dirac(output_like, damp=0.0)
 
         def residual_flat(u):

--- a/probdiffeq/_probdiffeq/ssm_impl_dense.py
+++ b/probdiffeq/_probdiffeq/ssm_impl_dense.py
@@ -259,30 +259,6 @@ class DenseOdeTs0(ssm_impl_api.AbstractOde):
         return cond, None
 
 
-# class DenseOdeTs0Old(ssm_impl_api.AbstractOde):
-#     """Dense ODE linearization via TS0 (zeroth-degree Taylor series: evaluate at the prior mean, no Jacobian)."""
-
-#     def init_linearization(self) -> None:
-#         return None
-
-#     def linearize(self, rv: DenseNormal, state: None, *, damp: float, t):
-#         del state
-
-#         def derivative_selector(m: Array) -> Array:
-#             """Select the n-th derivative from the Taylor coefficient stack."""
-#             m0 = rv.tree_flatten.unflatten_array(m)[self.ode.num_tcoeffs_in_args]
-#             return tree.ravel_pytree(m0)[0]
-
-#         Ms = rv.mean
-#         assert False
-#         fm = self.ode.vector_field(jet_coords=Ms[: self.ode.num_tcoeffs_in_args], t=t)
-#         fx = tree.tree_map(lambda s: -s, [fm])
-#         linop = func.jacrev(derivative_selector)(rv.mean_flat)
-#         noise = DenseNormal.from_dirac(fx, damp=damp)
-#         cond = DenseLatentCond.from_linop_and_noise(linop, noise)
-#         return cond, None
-
-
 class DenseResidual(ssm_impl_api.AbstractResidual):
     """Construct a dense implementation of residual-TS1 linearization."""
 

--- a/probdiffeq/_probdiffeq/ssm_impl_dense.py
+++ b/probdiffeq/_probdiffeq/ssm_impl_dense.py
@@ -245,17 +245,42 @@ class DenseOdeTs0(ssm_impl_api.AbstractOde):
 
         def derivative_selector(m: Array) -> Array:
             """Select the n-th derivative from the Taylor coefficient stack."""
-            m0 = rv.tree_flatten.unflatten_array(m)[self.ode.num_tcoeffs_in_args]
+            m_tree = rv.tree_flatten.unflatten_array(m)
+            m0 = [m_tree[i] for i in self.ode.tcoeff_indices_output]
             return tree.ravel_pytree(m0)[0]
 
-        Ms = rv.mean
-
-        fm = self.ode.vector_field(jet_coords=Ms[: self.ode.num_tcoeffs_in_args], t=t)
-        fx = tree.tree_map(lambda s: -s, [fm])
+        jet_coords = [rv.mean[i] for i in self.ode.tcoeff_indices_input]
+        fm = self.ode.vector_field(jet_coords=jet_coords, t=t)
+        fx = tree.tree_map(lambda s: -s, fm)
         linop = func.jacrev(derivative_selector)(rv.mean_flat)
         noise = DenseNormal.from_dirac(fx, damp=damp)
         cond = DenseLatentCond.from_linop_and_noise(linop, noise)
+
         return cond, None
+
+
+# class DenseOdeTs0Old(ssm_impl_api.AbstractOde):
+#     """Dense ODE linearization via TS0 (zeroth-degree Taylor series: evaluate at the prior mean, no Jacobian)."""
+
+#     def init_linearization(self) -> None:
+#         return None
+
+#     def linearize(self, rv: DenseNormal, state: None, *, damp: float, t):
+#         del state
+
+#         def derivative_selector(m: Array) -> Array:
+#             """Select the n-th derivative from the Taylor coefficient stack."""
+#             m0 = rv.tree_flatten.unflatten_array(m)[self.ode.num_tcoeffs_in_args]
+#             return tree.ravel_pytree(m0)[0]
+
+#         Ms = rv.mean
+#         assert False
+#         fm = self.ode.vector_field(jet_coords=Ms[: self.ode.num_tcoeffs_in_args], t=t)
+#         fx = tree.tree_map(lambda s: -s, [fm])
+#         linop = func.jacrev(derivative_selector)(rv.mean_flat)
+#         noise = DenseNormal.from_dirac(fx, damp=damp)
+#         cond = DenseLatentCond.from_linop_and_noise(linop, noise)
+#         return cond, None
 
 
 class DenseResidual(ssm_impl_api.AbstractResidual):

--- a/probdiffeq/_probdiffeq/ssm_impl_isotropic.py
+++ b/probdiffeq/_probdiffeq/ssm_impl_isotropic.py
@@ -194,17 +194,19 @@ class IsotropicNormal(ssm_impl_api.AbstractTreeNormal[IsotropicTreeFlatten]):
         return self.tree_flatten.unflatten_array_scalar(std_flat)
 
     def residual_whitened_rms_tree(self, u):
-        if self.cholesky_flat.size > 1:
-            raise ValueError
         u_latent = self.tree_flatten.flatten_tree(u)
         return self.residual_whitened_rms_flat(u_latent)
 
     def residual_whitened_rms_flat(self, u_latent, /):
-        residual_white = (self.mean_flat - u_latent) / self.cholesky_flat
-        residual_white_matrix = linalg.qr_r(residual_white.T)
-        return np.reshape(
-            np.abs(residual_white_matrix) / np.sqrt(self.mean_flat.size), ()
-        )
+
+        residual_white = self.mean_flat - u_latent
+        residual_white = linalg.solve_tril(self.cholesky_flat, residual_white)
+
+        residual_white = np.reshape(residual_white, (-1, 1))
+        residual_white_matrix = linalg.qr_r(residual_white)
+        residual_white_matrix = np.reshape(residual_white_matrix, ())
+
+        return np.abs(residual_white_matrix) / np.sqrt(self.mean_flat.size)
 
     def rescale_cholesky(self, factor, /):
         cholesky = factor[..., None, None] * self.cholesky_flat

--- a/probdiffeq/_probdiffeq/ssm_impl_isotropic.py
+++ b/probdiffeq/_probdiffeq/ssm_impl_isotropic.py
@@ -32,6 +32,9 @@ class IsotropicTreeFlatten(ssm_impl_api.AbstractTreeFlatten):
     # The below function exclusively reshapes arrays
     unravel_leaf: Any
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}(treedef={self.treedef})"
+
     def flatten_tree(self, x):
 
         def is_leaf(s):
@@ -306,6 +309,7 @@ class IsotropicOdeTs0(ssm_impl_api.AbstractOde):
     def linearize(self, rv, state, *, damp: float, t):
         jet_coords = rv.mean[: self.ode.num_tcoeffs_in_args]
         fx_tree = self.ode.vector_field(jet_coords=jet_coords, t=t)
+
         fx = tree.tree_map(lambda s: -s, fx_tree)
 
         bias = IsotropicNormal.from_dirac(fx, damp=damp)

--- a/probdiffeq/_probdiffeq/ssm_impl_isotropic.py
+++ b/probdiffeq/_probdiffeq/ssm_impl_isotropic.py
@@ -301,20 +301,19 @@ class IsotropicOdeTs0(ssm_impl_api.AbstractOde):
     def init_linearization(self) -> None:
         return None
 
-    def linearize(self, rv, state: None, *, damp: float, t):
-        del state
-        Ms = rv.mean
-        jet_coords = Ms[: self.ode.num_tcoeffs_in_args]
+    def linearize(self, rv, state, *, damp: float, t):
+        jet_coords = rv.mean[: self.ode.num_tcoeffs_in_args]
         fx_tree = self.ode.vector_field(jet_coords=jet_coords, t=t)
         fx = tree.tree_map(lambda s: -s, fx_tree)
 
-        bias = IsotropicNormal.from_dirac([fx], damp=damp)
+        bias = IsotropicNormal.from_dirac(fx, damp=damp)
 
-        linop = func.jacrev(lambda s: s[[self.ode.num_tcoeffs_in_args], ...])(
-            rv.mean_flat[..., 0]
-        )
+        def derivative_selector(s):
+            return s[np.asarray(self.ode.tcoeff_indices_output)]
+
+        linop = func.jacrev(derivative_selector)(rv.mean_flat[..., 0])
         cond = IsotropicLatentCond.from_linop_and_noise(linop, bias)
-        return cond, None
+        return cond, state
 
 
 class IsotropicResidual(ssm_impl_api.AbstractResidual):
@@ -324,12 +323,19 @@ class IsotropicResidual(ssm_impl_api.AbstractResidual):
         return self.residual.jacobian.init_jacobian_handler()
 
     def linearize(self, rv, state, *, damp: float, t):
+        # Understand the output pytree structure
+        jet_coords = rv.mean[: self.residual.num_tcoeffs_in_args]
+        output_like = func.eval_shape(
+            self.residual.residual_function, jet_coords=jet_coords, t=t
+        )
+        output_like = tree.tree_map(np.zeros_like, output_like)
+        rv_output = IsotropicNormal.from_dirac(output_like, damp=0.0)
 
         def residual_flat(s_stack):
-            s_tree = rv.tree_flatten.unflatten_array(s_stack)
-            s_tree = s_tree[: self.residual.num_tcoeffs_in_args]
-            fs = self.residual.residual_function(jet_coords=s_tree, t=t)
-            return tree.ravel_pytree(fs)[0][None, :]
+            u_tree = rv.tree_flatten.unflatten_array(s_stack)
+            u_tree = u_tree[: self.residual.num_tcoeffs_in_args]
+            r_tree = self.residual.residual_function(jet_coords=u_tree, t=t)
+            return rv_output.tree_flatten.flatten_tree(r_tree)
 
         _n, d = rv.mean_flat.shape
 
@@ -341,9 +347,7 @@ class IsotropicResidual(ssm_impl_api.AbstractResidual):
         linop = J_trace
         fx = fx - linop @ rv.mean_flat
 
-        m0_tree = rv.mean[:1]
-        rv0 = IsotropicNormal.from_dirac(m0_tree, damp=0.0)
-        fx = rv0.tree_flatten.unflatten_array(fx)
+        fx = rv_output.tree_flatten.unflatten_array(fx)
 
         noise = IsotropicNormal.from_dirac(fx, damp=damp)
         cond = IsotropicLatentCond.from_linop_and_noise(linop, noise)

--- a/probdiffeq/backend/func.py
+++ b/probdiffeq/backend/func.py
@@ -52,8 +52,8 @@ def grad(func):
     return jax.grad(func)
 
 
-def eval_shape(func, *args):
-    return jax.eval_shape(func, *args)
+def eval_shape(func, *args, **kwargs):
+    return jax.eval_shape(func, *args, **kwargs)
 
 
 def stop_gradient(x, /):

--- a/probdiffeq/backend/ode.py
+++ b/probdiffeq/backend/ode.py
@@ -18,7 +18,7 @@ def odeint_and_save_at(vf, y0: tuple, /, save_at, *, atol, rtol):
     def vf_wrapped(y, t):
         # forward (sign=+1): s = t,  returns vf(y, t=s)
         # reversed (sign=-1): s = -t, returns -vf(y, t=-s)
-        vfx = vf(y, t=sign * t)
+        [vfx] = vf.vector_field(jet_coords=(y,), t=sign * t)
         return jax.tree_util.tree_map(lambda s: sign * s, vfx)
 
     sol = jax.experimental.ode.odeint(

--- a/tests/test_ivpsolve/test_solve_adaptive_save_at.py
+++ b/tests/test_ivpsolve/test_solve_adaptive_save_at.py
@@ -156,7 +156,8 @@ def case_factory_constraint_residual_ts1(ivp):
 
     @func.partial(probdiffeq.residual_velocity, jacobian=jacobian)
     def residual(u, du, /, *, t):
-        return tree.tree_map(lambda a, b: a - b, [du], vf(u, t=t))
+        vfu = vf.vector_field(jet_coords=(u,), t=t)
+        return tree.tree_map(lambda a, b: a - b, [du], vfu)
 
     def constraint_fn(ssm, vf):
         try:

--- a/tests/test_ivpsolve/test_solve_adaptive_save_at_ode.py
+++ b/tests/test_ivpsolve/test_solve_adaptive_save_at_ode.py
@@ -156,7 +156,7 @@ def case_factory_constraint_residual_ts1(ivp):
 
     @func.partial(probdiffeq.residual_velocity, jacobian=jacobian)
     def residual(u, du, /, *, t):
-        return tree.tree_map(lambda a, b: a - b, du, vf(u, t=t))
+        return tree.tree_map(lambda a, b: a - b, [du], vf(u, t=t))
 
     def constraint_fn(ssm, vf):
         try:

--- a/tests/test_probdiffeq/test_constraints/test_dae.py
+++ b/tests/test_probdiffeq/test_constraints/test_dae.py
@@ -47,14 +47,12 @@ def solve_ode(inits, num):
 def solve_dae(inits, num):
     """Solve the SIR model as a DAE."""
 
-    @func.partial(probdiffeq.residual_jet_lift, lift_by=num)
     @probdiffeq.residual_position
     def algebraic(u, /, *, t):
         del t
         N = 1.0  # total population
         return u[0] + u[1] + u[2] - N
 
-    @func.partial(probdiffeq.residual_jet_lift, lift_by=num - 1)
     @probdiffeq.residual_velocity
     def differential(u, du, /, *, t):
         del t
@@ -69,6 +67,8 @@ def solve_dae(inits, num):
 
         return np.stack([F1, F2])
 
+    algebraic = algebraic.jet_lift(lift_by=num)
+    differential = differential.jet_lift(lift_by=num - 1)
     residual = probdiffeq.residual_from_stack(differential, algebraic)
 
     jetexpand = probdiffeq.jetexpand_residual(num=num)

--- a/tests/test_probdiffeq/test_constraints/test_jet_lift_ode.py
+++ b/tests/test_probdiffeq/test_constraints/test_jet_lift_ode.py
@@ -1,6 +1,9 @@
 from probdiffeq import ivpsolve, probdiffeq
 from probdiffeq.backend import func, np, ode, testing
 
+# TODO: make all existing tests pass, then add cases here to cover the remainders.
+# (Eg higher order ODEs?)
+
 
 @testing.case
 def case_ssm_dense():
@@ -13,12 +16,18 @@ def case_constraint_ts0():
     return lambda ssm, ode: ssm.constraint_ode_ts0(ode)
 
 
-@testing.parametrize_with_cases("ssm", cases=".", prefix="case_ssm_")
-@testing.parametrize_with_cases("constraint", cases=".", prefix="case_constraint_")
+@testing.case
+def case_ode_lotka_volterra():
+    return ode.ivp_lotka_volterra()
+
+
 @testing.parametrize("lift_by", [0, 1, 2])  # max: num_derivatives - 1
 @testing.parametrize("num_derivatives", [3])
-def test_jet_lift_ode_works(ssm, constraint, lift_by, num_derivatives) -> None:
-    vf, u0, (t0, t1) = ode.ivp_lotka_volterra()
+@testing.parametrize_with_cases("ssm", cases=".", prefix="case_ssm_")
+@testing.parametrize_with_cases("constraint", cases=".", prefix="case_constraint_")
+@testing.parametrize_with_cases("ode", cases=".", prefix="case_ode_")
+def test_jet_lift_ode_works(ssm, constraint, ode, lift_by, num_derivatives) -> None:
+    vf, u0, (t0, t1) = ode
 
     # Generate a solver
     ts = np.linspace(t0, t1, num=50, endpoint=True)

--- a/tests/test_probdiffeq/test_constraints/test_jet_lift_ode.py
+++ b/tests/test_probdiffeq/test_constraints/test_jet_lift_ode.py
@@ -20,6 +20,12 @@ def case_ssm_blockdiag():
 
 
 @testing.case
+def case_ssm_isotropic():
+    """Construct an isotropic SSM."""
+    return probdiffeq.state_space_model_isotropic()
+
+
+@testing.case
 def case_constraint_ts0():
     """Construct a TS0 constraint."""
     return lambda ssm, ode: ssm.constraint_ode_ts0(ode)

--- a/tests/test_probdiffeq/test_constraints/test_jet_lift_ode.py
+++ b/tests/test_probdiffeq/test_constraints/test_jet_lift_ode.py
@@ -14,9 +14,21 @@ def case_ssm_dense():
 
 
 @testing.case
+def case_ssm_blockdiag():
+    """Construct a block-diagonal SSM."""
+    return probdiffeq.state_space_model_blockdiag()
+
+
+@testing.case
 def case_constraint_ts0():
     """Construct a TS0 constraint."""
     return lambda ssm, ode: ssm.constraint_ode_ts0(ode)
+
+
+@testing.case
+def case_constraint_ts1():
+    """Construct a TS0 constraint."""
+    return lambda ssm, ode: ssm.constraint_ode_ts1(ode)
 
 
 @testing.case
@@ -42,7 +54,10 @@ def test_jet_lift_ode_does_not_reduce_accuracy(
 
     # Build an ODE and a jet-lifted ODE
     # TODO: assert that jet_lift has a good error message if lift_by is too large
-    vf = probdiffeq.ode(vf)
+
+    # Materialize the Jacobian to ensure that trace-estimation errors
+    # are not the culprits for failing tests
+    vf = probdiffeq.ode(vf, jacobian=probdiffeq.jacobian_materialize())
     vf_lifted = vf.jet_lift(lift_by=lift_by)
 
     jetexpand = probdiffeq.jetexpand_ode_padded_scan(num=num_derivatives)

--- a/tests/test_probdiffeq/test_constraints/test_jet_lift_ode.py
+++ b/tests/test_probdiffeq/test_constraints/test_jet_lift_ode.py
@@ -1,0 +1,31 @@
+from probdiffeq import ivpsolve, probdiffeq
+from probdiffeq.backend import func, np, ode, testing
+
+
+@testing.case
+def case_ssm_dense():
+    """Construct a dense SSM."""
+    return probdiffeq.state_space_model_dense()
+
+
+@testing.parametrize_with_cases("ssm", cases=".", prefix="case_ssm_")
+def test_jet_lift_ode_works(ssm) -> None:
+    vf, u0, (t0, t1) = ode.ivp_lotka_volterra()
+
+    # Generate a solver
+    vf = probdiffeq.ode(vf)
+    jetexpand = probdiffeq.jetexpand_ode_padded_scan(num=2)
+    tcoeffs, _ = jetexpand(vf, u0, t=t0)
+
+    iwp = ssm.prior_wiener_integrated(tcoeffs)
+    ts0 = ssm.constraint_ode_ts0(vf)
+
+    # Compute a save-at solution
+    ts = np.linspace(t0, t1 / 2.0, num=75, endpoint=True)
+    strategy = probdiffeq.strategy_filter()
+    solver = probdiffeq.solver(strategy=strategy, constraint=ts0)
+    solve = ivpsolve.solve_fixed_grid(solver=solver)
+    solution = func.jit(solve)(iwp, grid=ts)
+
+    print(solution.u.mean)
+    assert False

--- a/tests/test_probdiffeq/test_constraints/test_jet_lift_ode.py
+++ b/tests/test_probdiffeq/test_constraints/test_jet_lift_ode.py
@@ -9,15 +9,21 @@ def case_ssm_dense():
 
 
 @testing.parametrize_with_cases("ssm", cases=".", prefix="case_ssm_")
-def test_jet_lift_ode_works(ssm) -> None:
+@testing.parametrize("lift_by", [0, 1, 2])  # max: num_derivatives - 1
+@testing.parametrize("num_derivatives", [3])
+def test_jet_lift_ode_works(ssm, lift_by, num_derivatives) -> None:
     vf, u0, (t0, t1) = ode.ivp_lotka_volterra()
 
     # Generate a solver
-    ts = np.linspace(t0, t1 / 2.0, num=75, endpoint=True)
+    ts = np.linspace(t0, t1, num=50, endpoint=True)
     strategy = probdiffeq.strategy_filter()
 
+    # Build an ODE and a jet-lifted ODE
+    # TODO: assert that jet_lift has a good error message if lift_by is too large
     vf = probdiffeq.ode(vf)
-    jetexpand = probdiffeq.jetexpand_ode_padded_scan(num=2)
+    vf_lifted = vf.jet_lift(lift_by=lift_by)
+
+    jetexpand = probdiffeq.jetexpand_ode_padded_scan(num=num_derivatives)
     tcoeffs, _ = jetexpand(vf, u0, t=t0)
     iwp = ssm.prior_wiener_integrated(tcoeffs)
 
@@ -28,11 +34,11 @@ def test_jet_lift_ode_works(ssm) -> None:
     solution_ts0 = func.jit(solve)(iwp, grid=ts)
 
     # Compute a jet-lifted solution
-    ts0 = ssm.constraint_ode_ts0(vf.jet_lift(lift_by=2))
+    ts0 = ssm.constraint_ode_ts0(vf_lifted)
     solver = probdiffeq.solver(strategy=strategy, constraint=ts0)
     solve = ivpsolve.solve_fixed_grid(solver=solver)
     solution_jet_lift = func.jit(solve)(iwp, grid=ts)
 
-    print(solution_jet_lift.u.mean)
-    assert testing.allclose(solution_ts0.u.mean, solution_jet_lift.u.mean)
-    assert False
+    assert testing.allclose(
+        solution_ts0.u.mean[0], solution_jet_lift.u.mean[0], atol=1e-3, rtol=1e-3
+    )

--- a/tests/test_probdiffeq/test_constraints/test_jet_lift_ode.py
+++ b/tests/test_probdiffeq/test_constraints/test_jet_lift_ode.py
@@ -8,10 +8,16 @@ def case_ssm_dense():
     return probdiffeq.state_space_model_dense()
 
 
+@testing.case
+def case_constraint_ts0():
+    return lambda ssm, ode: ssm.constraint_ode_ts0(ode)
+
+
 @testing.parametrize_with_cases("ssm", cases=".", prefix="case_ssm_")
+@testing.parametrize_with_cases("constraint", cases=".", prefix="case_constraint_")
 @testing.parametrize("lift_by", [0, 1, 2])  # max: num_derivatives - 1
 @testing.parametrize("num_derivatives", [3])
-def test_jet_lift_ode_works(ssm, lift_by, num_derivatives) -> None:
+def test_jet_lift_ode_works(ssm, constraint, lift_by, num_derivatives) -> None:
     vf, u0, (t0, t1) = ode.ivp_lotka_volterra()
 
     # Generate a solver
@@ -28,13 +34,13 @@ def test_jet_lift_ode_works(ssm, lift_by, num_derivatives) -> None:
     iwp = ssm.prior_wiener_integrated(tcoeffs)
 
     # Compute a reference solution
-    ts0 = ssm.constraint_ode_ts0(vf)
+    ts0 = constraint(ssm, vf)
     solver = probdiffeq.solver(strategy=strategy, constraint=ts0)
     solve = ivpsolve.solve_fixed_grid(solver=solver)
     solution_ts0 = func.jit(solve)(iwp, grid=ts)
 
     # Compute a jet-lifted solution
-    ts0 = ssm.constraint_ode_ts0(vf_lifted)
+    ts0 = constraint(ssm, vf_lifted)
     solver = probdiffeq.solver(strategy=strategy, constraint=ts0)
     solve = ivpsolve.solve_fixed_grid(solver=solver)
     solution_jet_lift = func.jit(solve)(iwp, grid=ts)

--- a/tests/test_probdiffeq/test_constraints/test_jet_lift_ode.py
+++ b/tests/test_probdiffeq/test_constraints/test_jet_lift_ode.py
@@ -1,3 +1,5 @@
+"""Tests for jet-lifting functionality for ODEs."""
+
 from probdiffeq import ivpsolve, probdiffeq
 from probdiffeq.backend import func, np, ode, testing
 
@@ -13,11 +15,13 @@ def case_ssm_dense():
 
 @testing.case
 def case_constraint_ts0():
+    """Construct a TS0 constraint."""
     return lambda ssm, ode: ssm.constraint_ode_ts0(ode)
 
 
 @testing.case
 def case_ode_lotka_volterra():
+    """Construct a Lotka-Volterra ODE."""
     return ode.ivp_lotka_volterra()
 
 
@@ -26,7 +30,10 @@ def case_ode_lotka_volterra():
 @testing.parametrize_with_cases("ssm", cases=".", prefix="case_ssm_")
 @testing.parametrize_with_cases("constraint", cases=".", prefix="case_constraint_")
 @testing.parametrize_with_cases("ode", cases=".", prefix="case_ode_")
-def test_jet_lift_ode_works(ssm, constraint, ode, lift_by, num_derivatives) -> None:
+def test_jet_lift_ode_does_not_reduce_accuracy(
+    ssm, constraint, ode, lift_by, num_derivatives
+):
+    """Test that jet-lifting an ODE does not reduce accuracy."""
     vf, u0, (t0, t1) = ode
 
     # Generate a solver

--- a/tests/test_probdiffeq/test_constraints/test_jet_lift_ode.py
+++ b/tests/test_probdiffeq/test_constraints/test_jet_lift_ode.py
@@ -43,7 +43,7 @@ def case_ode_lotka_volterra():
     return ode.ivp_lotka_volterra()
 
 
-@testing.parametrize("lift_by", [0, 1, 2])  # max: num_derivatives - 1
+@testing.parametrize("lift_by", [0, 1, 2, "max"])  # max: num_derivatives - 1
 @testing.parametrize("num_derivatives", [3])
 @testing.parametrize_with_cases("ssm", cases=".", prefix="case_ssm_")
 @testing.parametrize_with_cases("constraint", cases=".", prefix="case_constraint_")
@@ -64,7 +64,10 @@ def test_jet_lift_ode_does_not_reduce_accuracy(
     # Materialize the Jacobian to ensure that trace-estimation errors
     # are not the culprits for failing tests
     vf = probdiffeq.ode(vf, jacobian=probdiffeq.jacobian_materialize())
-    vf_lifted = vf.jet_lift(lift_by=lift_by)
+    if lift_by == "max":
+        vf_lifted = vf.jet_lift_max(num_tcoeffs=num_derivatives + 1)
+    else:
+        vf_lifted = vf.jet_lift(lift_by=lift_by)
 
     jetexpand = probdiffeq.jetexpand_ode_padded_scan(num=num_derivatives)
     tcoeffs, _ = jetexpand(vf, u0, t=t0)

--- a/tests/test_probdiffeq/test_constraints/test_jet_lift_ode.py
+++ b/tests/test_probdiffeq/test_constraints/test_jet_lift_ode.py
@@ -73,14 +73,16 @@ def test_jet_lift_ode_does_not_reduce_accuracy(
     # Compute a reference solution
     ts0 = constraint(ssm, vf)
     solver = probdiffeq.solver(strategy=strategy, constraint=ts0)
-    solve = ivpsolve.solve_fixed_grid(solver=solver)
-    solution_ts0 = func.jit(solve)(iwp, grid=ts)
+    error = probdiffeq.error_state_std(constraint=ts0)
+    solve = ivpsolve.solve_adaptive_save_at(solver=solver, error=error)
+    solution_ts0 = func.jit(solve)(iwp, save_at=ts, atol=1e-5, rtol=1e-5)
 
     # Compute a jet-lifted solution
     ts0 = constraint(ssm, vf_lifted)
     solver = probdiffeq.solver(strategy=strategy, constraint=ts0)
-    solve = ivpsolve.solve_fixed_grid(solver=solver)
-    solution_jet_lift = func.jit(solve)(iwp, grid=ts)
+    error = probdiffeq.error_state_std(constraint=ts0)
+    solve = ivpsolve.solve_adaptive_save_at(solver=solver, error=error)
+    solution_jet_lift = func.jit(solve)(iwp, save_at=ts, atol=1e-5, rtol=1e-5)
 
     assert testing.allclose(
         solution_ts0.u.mean[0], solution_jet_lift.u.mean[0], atol=1e-3, rtol=1e-3

--- a/tests/test_probdiffeq/test_constraints/test_jet_lift_ode.py
+++ b/tests/test_probdiffeq/test_constraints/test_jet_lift_ode.py
@@ -13,19 +13,26 @@ def test_jet_lift_ode_works(ssm) -> None:
     vf, u0, (t0, t1) = ode.ivp_lotka_volterra()
 
     # Generate a solver
+    ts = np.linspace(t0, t1 / 2.0, num=75, endpoint=True)
+    strategy = probdiffeq.strategy_filter()
+
     vf = probdiffeq.ode(vf)
     jetexpand = probdiffeq.jetexpand_ode_padded_scan(num=2)
     tcoeffs, _ = jetexpand(vf, u0, t=t0)
-
     iwp = ssm.prior_wiener_integrated(tcoeffs)
-    ts0 = ssm.constraint_ode_ts0(vf)
 
-    # Compute a save-at solution
-    ts = np.linspace(t0, t1 / 2.0, num=75, endpoint=True)
-    strategy = probdiffeq.strategy_filter()
+    # Compute a reference solution
+    ts0 = ssm.constraint_ode_ts0(vf)
     solver = probdiffeq.solver(strategy=strategy, constraint=ts0)
     solve = ivpsolve.solve_fixed_grid(solver=solver)
-    solution = func.jit(solve)(iwp, grid=ts)
+    solution_ts0 = func.jit(solve)(iwp, grid=ts)
 
-    print(solution.u.mean)
+    # Compute a jet-lifted solution
+    ts0 = ssm.constraint_ode_ts0(vf.jet_lift(lift_by=2))
+    solver = probdiffeq.solver(strategy=strategy, constraint=ts0)
+    solve = ivpsolve.solve_fixed_grid(solver=solver)
+    solution_jet_lift = func.jit(solve)(iwp, grid=ts)
+
+    print(solution_jet_lift.u.mean)
+    assert testing.allclose(solution_ts0.u.mean, solution_jet_lift.u.mean)
     assert False

--- a/tests/test_probdiffeq/test_constraints/test_jet_lift_residual.py
+++ b/tests/test_probdiffeq/test_constraints/test_jet_lift_residual.py
@@ -128,9 +128,6 @@ def case_residual_jet_lift_residual(residual):
     return constraint_residual
 
 
-# TODO: move jet_lift to the Residual class?!
-
-
 @testing.parametrize_with_cases("jet_factory", cases=".", prefix="case_residual_")
 @testing.parametrize("lift_by", [0, "max"])
 @testing.parametrize("ssm_factory", [probdiffeq.state_space_model_dense])

--- a/tests/test_probdiffeq/test_constraints/test_jet_lift_residual.py
+++ b/tests/test_probdiffeq/test_constraints/test_jet_lift_residual.py
@@ -126,17 +126,20 @@ def case_residual_jet_lift_residual(residual):
     return constraint_residual
 
 
-@testing.parametrize_with_cases("jet_factory", cases=".", prefix="case_jet_")
+# TODO: move jet_lift to the Residual class?!
+
+
+@testing.parametrize_with_cases("jet_factory", cases=".", prefix="case_residual_")
 @testing.parametrize("lift_by", [0, "max"])
 @testing.parametrize("ssm_factory", [probdiffeq.state_space_model_dense])
-def test_posterior_linearisation_matches_closed_form_recursion(
+def test_jet_lift_plus_posterior_linearisation_matches_jet_expansion(
     residual: Root,
     jet_factory: Callable,
     expected: list,
     lift_by: int | Literal["max"],
     ssm_factory,
 ):
-    """Assert that jet-lifted posterior linearization matches the ODE recursion."""
+    """Assert that posterior linearisation + jet-lifted residuals recover jet expansions."""
     derivatives = len(expected) - 1
     ssm = ssm_factory()
     iwp = ssm.prior_wiener_integrated([residual.u0], diffuse_derivatives=derivatives)
@@ -157,7 +160,7 @@ def test_posterior_linearisation_matches_closed_form_recursion(
         assert testing.allclose(received[: 2 + lift_by], expected[: 2 + lift_by])
 
 
-@testing.parametrize_with_cases("jet_factory", cases=".", prefix="case_jet_")
+@testing.parametrize_with_cases("jet_factory", cases=".", prefix="case_residual_")
 @testing.parametrize("wrong_lift_by", [-1, 4, 100])
 @testing.parametrize("ssm_factory", [probdiffeq.state_space_model_dense])
 def test_wrong_lift_by_raises_error(

--- a/tests/test_probdiffeq/test_constraints/test_jet_lift_residual.py
+++ b/tests/test_probdiffeq/test_constraints/test_jet_lift_residual.py
@@ -6,7 +6,7 @@ from probdiffeq.backend.typing import Array, Callable, Literal
 
 
 @structs.dataclass
-class Root:
+class ResidualFixture:
     """Different APIs for one and the same residual-finding problem.
 
     Its purpose is to enable different jet-constraints to solve the same
@@ -22,8 +22,8 @@ class Root:
 
 
 @testing.fixture(name="residual")
-def fixture_residual_sir():
-    """Construct the SIR model as a Root struct with ODE and DAE residuals."""
+def fixture_residual_sir() -> ResidualFixture:
+    """Construct the SIR model as a ResidualFixture with ODE and DAE residuals."""
 
     def residual(u, du, /, *, t):
         linear = imex_linear(u, du, t=t)
@@ -73,7 +73,7 @@ def fixture_residual_sir():
 
     u0 = np.asarray([0.99, 0.01, 0.0])
     t0 = 0.0
-    return Root(
+    return ResidualFixture(
         residual=residual,
         residual_differential=dae_differential,
         residual_algebraic=dae_algebraic,
@@ -83,9 +83,9 @@ def fixture_residual_sir():
     )
 
 
-@testing.fixture(name="expected")
+@testing.fixture(name="true_tcoeffs")
 @testing.parametrize("derivatives", [5])
-def fixture_expected(residual, derivatives):
+def fixture_true_tcoeffs(residual: ResidualFixture, derivatives: int) -> list:
     """Compute expected jet expansion coefficients via the ODE vector field."""
 
     @probdiffeq.ode
@@ -98,7 +98,7 @@ def fixture_expected(residual, derivatives):
 
 
 @testing.case()
-def case_residual_jet_lift_dae(residual):
+def case_residual_jet_lift_dae(residual: ResidualFixture) -> Callable:
     """Use the DAE residual with separate differential and algebraic parts."""
     taylor_point = probdiffeq.taylor_point_maximum_a_posteriori()
 
@@ -122,7 +122,7 @@ def case_residual_jet_lift_dae(residual):
 
 
 @testing.case()
-def case_residual_jet_lift_residual(residual):
+def case_residual_jet_lift_residual(residual: ResidualFixture) -> Callable:
     """Use the implicit residual formulation."""
     taylor_point = probdiffeq.taylor_point_maximum_a_posteriori()
 
@@ -139,17 +139,15 @@ def case_residual_jet_lift_residual(residual):
 
 @testing.parametrize_with_cases("jet_factory", cases=".", prefix="case_residual_")
 @testing.parametrize("lift_by", [0, 1, 2, "max"])
-@testing.parametrize("ssm_factory", [probdiffeq.state_space_model_dense])
-def test_jet_lift_plus_posterior_linearisation_matches_jet_expansion(
-    residual: Root,
+def test_jet_lift_with_taylor_map_yields_true_tcoeffs(
+    residual: ResidualFixture,
+    true_tcoeffs: list,
     jet_factory: Callable,
-    expected: list,
     lift_by: int | Literal["max"],
-    ssm_factory,
 ):
     """Assert that posterior linearisation + jet-lifted residuals recover jet expansions."""
-    derivatives = len(expected) - 1
-    ssm = ssm_factory()
+    ssm = probdiffeq.state_space_model_dense()
+    derivatives = len(true_tcoeffs) - 1
     iwp = ssm.prior_wiener_integrated([residual.u0], diffuse_derivatives=derivatives)
 
     constraint = jet_factory(ssm=ssm, lift_by=lift_by, num_tcoeffs=derivatives + 1)
@@ -162,20 +160,19 @@ def test_jet_lift_plus_posterior_linearisation_matches_jet_expansion(
     updated = reverted.apply_flat(0.0)
     received = updated.mean
     if lift_by == "max":
-        assert testing.allclose(received, expected)
+        assert testing.allclose(received, true_tcoeffs)
     else:
-        assert testing.allclose(received[: 2 + lift_by], expected[: 2 + lift_by])
+        assert testing.allclose(received[: 2 + lift_by], true_tcoeffs[: 2 + lift_by])
 
 
 @testing.parametrize_with_cases("jet_factory", cases=".", prefix="case_residual_")
 @testing.parametrize("wrong_lift_by", [-1, 4, 100])
-@testing.parametrize("ssm_factory", [probdiffeq.state_space_model_dense])
 def test_wrong_lift_by_raises_error(
-    residual: Root, jet_factory: Callable, wrong_lift_by, ssm_factory
+    residual: ResidualFixture, jet_factory: Callable, wrong_lift_by: int
 ):
     """Assert that an out-of-range lift-by index raises a ValueError."""
     # 5 Taylor coefficients + residual-orders of 2 (constraints depend on u and du).
-    ssm = ssm_factory()
+    ssm = probdiffeq.state_space_model_dense()
     iwp = ssm.prior_wiener_integrated([residual.u0], diffuse_derivatives=4)
     constraint = jet_factory(ssm=ssm, lift_by=wrong_lift_by, num_tcoeffs=4 + 1)
 

--- a/tests/test_probdiffeq/test_constraints/test_jet_lift_residual.py
+++ b/tests/test_probdiffeq/test_constraints/test_jet_lift_residual.py
@@ -84,7 +84,7 @@ def fixture_residual_sir():
 
 
 @testing.fixture(name="expected")
-@testing.parametrize("derivatives", [1, 5])
+@testing.parametrize("derivatives", [5])
 def fixture_expected(residual, derivatives):
     """Compute expected jet expansion coefficients via the ODE vector field."""
 
@@ -102,12 +102,18 @@ def case_residual_jet_lift_dae(residual):
     """Use the DAE residual with separate differential and algebraic parts."""
     taylor_point = probdiffeq.taylor_point_maximum_a_posteriori()
 
-    def constraint_residual(ssm, lift_by: int):
+    def constraint_residual(ssm, lift_by: int | Literal["max"], num_tcoeffs):
         differential = probdiffeq.residual_velocity(residual.residual_differential)
-        differential = differential.jet_lift(lift_by=lift_by)
 
         algebraic = probdiffeq.residual_position(residual.residual_algebraic)
-        algebraic = algebraic.jet_lift(lift_by=lift_by + 1)
+
+        if lift_by == "max":
+            differential = differential.jet_lift_max(num_tcoeffs=num_tcoeffs)
+            algebraic = algebraic.jet_lift_max(num_tcoeffs=num_tcoeffs)
+        else:
+            differential = differential.jet_lift(lift_by=lift_by)
+            algebraic = algebraic.jet_lift(lift_by=lift_by + 1)
+
         residual_stack = probdiffeq.residual_from_stack(differential, algebraic)
 
         return ssm.constraint_residual(residual_stack, taylor_point=taylor_point)
@@ -120,16 +126,19 @@ def case_residual_jet_lift_residual(residual):
     """Use the implicit residual formulation."""
     taylor_point = probdiffeq.taylor_point_maximum_a_posteriori()
 
-    def constraint_residual(ssm, lift_by: int):
+    def constraint_residual(ssm, lift_by: int | Literal["max"], num_tcoeffs):
         implicit = probdiffeq.residual_velocity(residual.residual)
-        implicit = implicit.jet_lift(lift_by=lift_by)
+        if lift_by == "max":
+            implicit = implicit.jet_lift_max(num_tcoeffs=num_tcoeffs)
+        else:
+            implicit = implicit.jet_lift(lift_by=lift_by)
         return ssm.constraint_residual(implicit, taylor_point=taylor_point)
 
     return constraint_residual
 
 
 @testing.parametrize_with_cases("jet_factory", cases=".", prefix="case_residual_")
-@testing.parametrize("lift_by", [0, "max"])
+@testing.parametrize("lift_by", [0, 1, 2, "max"])
 @testing.parametrize("ssm_factory", [probdiffeq.state_space_model_dense])
 def test_jet_lift_plus_posterior_linearisation_matches_jet_expansion(
     residual: Root,
@@ -143,8 +152,7 @@ def test_jet_lift_plus_posterior_linearisation_matches_jet_expansion(
     ssm = ssm_factory()
     iwp = ssm.prior_wiener_integrated([residual.u0], diffuse_derivatives=derivatives)
 
-    lift_by = len(expected) - 2 if lift_by == "max" else lift_by
-    constraint = jet_factory(ssm=ssm, lift_by=lift_by)
+    constraint = jet_factory(ssm=ssm, lift_by=lift_by, num_tcoeffs=derivatives + 1)
 
     cstate = constraint.init_linearization()
     fx, cstate = constraint.linearize(iwp.init, cstate, damp=0.0, t=residual.t0)
@@ -169,7 +177,7 @@ def test_wrong_lift_by_raises_error(
     # 5 Taylor coefficients + residual-orders of 2 (constraints depend on u and du).
     ssm = ssm_factory()
     iwp = ssm.prior_wiener_integrated([residual.u0], diffuse_derivatives=4)
-    constraint = jet_factory(ssm=ssm, lift_by=wrong_lift_by)
+    constraint = jet_factory(ssm=ssm, lift_by=wrong_lift_by, num_tcoeffs=4 + 1)
 
     cstate = constraint.init_linearization()
     with testing.raises(ValueError, match="Received"):

--- a/tests/test_probdiffeq/test_constraints/test_jet_lift_residual.py
+++ b/tests/test_probdiffeq/test_constraints/test_jet_lift_residual.py
@@ -97,16 +97,17 @@ def fixture_expected(residual, derivatives):
     return coeffs
 
 
+@testing.case()
 def case_residual_jet_lift_dae(residual):
     """Use the DAE residual with separate differential and algebraic parts."""
     taylor_point = probdiffeq.taylor_point_maximum_a_posteriori()
 
     def constraint_residual(ssm, lift_by: int):
         differential = probdiffeq.residual_velocity(residual.residual_differential)
-        differential = probdiffeq.residual_jet_lift(differential, lift_by=lift_by)
+        differential = differential.jet_lift(lift_by=lift_by)
 
         algebraic = probdiffeq.residual_position(residual.residual_algebraic)
-        algebraic = probdiffeq.residual_jet_lift(algebraic, lift_by=lift_by + 1)
+        algebraic = algebraic.jet_lift(lift_by=lift_by + 1)
         residual_stack = probdiffeq.residual_from_stack(differential, algebraic)
 
         return ssm.constraint_residual(residual_stack, taylor_point=taylor_point)
@@ -114,13 +115,14 @@ def case_residual_jet_lift_dae(residual):
     return constraint_residual
 
 
+@testing.case()
 def case_residual_jet_lift_residual(residual):
     """Use the implicit residual formulation."""
     taylor_point = probdiffeq.taylor_point_maximum_a_posteriori()
 
     def constraint_residual(ssm, lift_by: int):
         implicit = probdiffeq.residual_velocity(residual.residual)
-        implicit = probdiffeq.residual_jet_lift(implicit, lift_by=lift_by)
+        implicit = implicit.jet_lift(lift_by=lift_by)
         return ssm.constraint_residual(implicit, taylor_point=taylor_point)
 
     return constraint_residual

--- a/tests/test_probdiffeq/test_constraints/test_ts1_vs_residual.py
+++ b/tests/test_probdiffeq/test_constraints/test_ts1_vs_residual.py
@@ -11,7 +11,8 @@ def test_residual_matches_ts1(seed: int):
     @probdiffeq.residual_velocity
     def f(u, du, /, *, t):
         """Evaluate the residual corresponding to the ODE."""
-        return du - vf(u, t=t)
+        [vfx] = vf(u, t=t)
+        return du - vfx
 
     @probdiffeq.ode
     def vf(y, *, t):

--- a/tests/test_probdiffeq/test_constraints/test_ts1_vs_residual.py
+++ b/tests/test_probdiffeq/test_constraints/test_ts1_vs_residual.py
@@ -11,7 +11,7 @@ def test_residual_matches_ts1(seed: int):
     @probdiffeq.residual_velocity
     def f(u, du, /, *, t):
         """Evaluate the residual corresponding to the ODE."""
-        [vfx] = vf(u, t=t)
+        [vfx] = vf.vector_field(jet_coords=(u,), t=t)
         return du - vfx
 
     @probdiffeq.ode

--- a/tests/test_probdiffeq/test_jetexpand/test_residual.py
+++ b/tests/test_probdiffeq/test_jetexpand/test_residual.py
@@ -14,12 +14,8 @@ def test_residual_init_matches_expectation_on_sir_model(num):
     expected, _ = jetexpand_ode(vf_ode, y0, t=0.0)
 
     # Residual via DAE
-    differential_lifted = probdiffeq.residual_jet_lift(
-        differential, lift_by=len(expected) - 2
-    )
-    algebraic_lifted = probdiffeq.residual_jet_lift(
-        algebraic, lift_by=len(expected) - 1
-    )
+    differential_lifted = differential.jet_lift(lift_by=len(expected) - 2)
+    algebraic_lifted = algebraic.jet_lift(lift_by=len(expected) - 1)
     residual = probdiffeq.residual_from_stack(differential_lifted, algebraic_lifted)
 
     # Jet expansion

--- a/tests/test_probdiffeq/test_solver_uses_constraint_init.py
+++ b/tests/test_probdiffeq/test_solver_uses_constraint_init.py
@@ -34,7 +34,6 @@ def test_output_matches_reference(
     """Assert that the solver uses the constraint init to set the first-step state accurately."""
     vf, (u0,), (t0, t1) = ivp
 
-    @func.partial(probdiffeq.residual_jet_lift, lift_by=derivatives - 1)
     @probdiffeq.residual_velocity
     def residual(u, du, /, *, t):
         return tree.tree_map(
@@ -50,6 +49,8 @@ def test_output_matches_reference(
     def residual_nonlinear(u, _du, *, t):
         vfu = vf(u, t=t)
         return tree.tree_map(lambda a: -a, vfu)
+
+    residual = residual.jet_lift(lift_by=derivatives - 1)
 
     jetexpand = probdiffeq.jetexpand_ode_padded_scan(num=derivatives)
     expected, _ = jetexpand(probdiffeq.ode(vf), [u0], t=t0)


### PR DESCRIPTION
Breaking, because `residual_jet_lift(residual, **kwargs)` is now `residual.jet_lift(**kwargs)`. Otherwise, backwards compatible.