### PR TITLE
Enhance workprecision functionality

### DIFF
--- a/benchmarks/A0_work-precision-lotka-volterra.py
+++ b/benchmarks/A0_work-precision-lotka-volterra.py
@@ -19,7 +19,7 @@ jax.config.update("jax_debug_nans", True)
 jax.config.update("jax_enable_x64", True)
 
 
-def main(start=3.0, stop=12.0, step=1.0, repeats=0) -> None:
+def main(start=3.0, stop=12.0, step=1.0, repeats=2) -> None:
     """Run the script."""
     # Simulate once to plot the state
     ts, ys = solve_ivp_once()
@@ -61,22 +61,21 @@ def main(start=3.0, stop=12.0, step=1.0, repeats=0) -> None:
     }
 
     # Compute all work-precision diagrams
-    results = {}
+    _fig, ax = plt.subplots(figsize=(8, 3), dpi=120, constrained_layout=True)
     pbar = tqdm.tqdm(algorithms.items())
     for label, algo in pbar:
         pbar.set_description(label)
-        param_to_wp = benchmark_util.workprec(algo, num_repeats=repeats)
-        results[label] = param_to_wp(tolerances)
-
-    _fig, ax = plt.subplots(figsize=(8, 5), dpi=120, constrained_layout=True)
-    for label, wp in results.items():
+        param_to_wp = benchmark_util.workprec(algo, num_timing_calls=repeats)
+        wp = param_to_wp(tolerances)
         ax.loglog(wp.precision.mean(axis=-1), wp.work.mean(axis=-1), ".-", label=label)
 
     ax.set_ylabel("Work (avg. wall time)")
     ax.set_title("Work-precision diagram")
     ax.set_xlabel("Precision (relative RMSE)")
     ax.grid(linestyle="dotted", which="both")
-    ax.legend(fontsize="small")
+    ax.legend(
+        fontsize="small", loc="center left", frameon=False, bbox_to_anchor=(1, 0.5)
+    )
 
     plt.show()
 

--- a/benchmarks/A0_work-precision-lotka-volterra.py
+++ b/benchmarks/A0_work-precision-lotka-volterra.py
@@ -61,7 +61,7 @@ def main(start=3.0, stop=12.0, step=1.0, repeats=2) -> None:
     }
 
     # Compute all work-precision diagrams
-    _fig, ax = plt.subplots(figsize=(8, 3), dpi=120, constrained_layout=True)
+    _fig, ax = plt.subplots(figsize=(8, 4), dpi=120, constrained_layout=True)
     pbar = tqdm.tqdm(algorithms.items())
     for label, algo in pbar:
         pbar.set_description(label)
@@ -73,9 +73,7 @@ def main(start=3.0, stop=12.0, step=1.0, repeats=2) -> None:
     ax.set_title("Work-precision diagram")
     ax.set_xlabel("Precision (relative RMSE)")
     ax.grid(linestyle="dotted", which="both")
-    ax.legend(
-        fontsize="small", loc="center left", frameon=False, bbox_to_anchor=(1, 0.5)
-    )
+    ax.legend(loc="center left", frameon=False, bbox_to_anchor=(1, 0.5))
 
     plt.show()
 

--- a/benchmarks/A0_work-precision-lotka-volterra.py
+++ b/benchmarks/A0_work-precision-lotka-volterra.py
@@ -67,7 +67,7 @@ def main(start=3.0, stop=12.0, step=1.0, repeats=2) -> None:
         pbar.set_description(label)
         param_to_wp = benchmark_util.workprec(algo, num_timing_calls=repeats)
         wp = param_to_wp(tolerances)
-        ax.loglog(wp.precision.mean(axis=-1), wp.work.mean(axis=-1), ".-", label=label)
+        ax.loglog(wp.precision, wp.work.mean(axis=-1), ".-", label=label)
 
     ax.set_ylabel("Work (avg. wall time)")
     ax.set_title("Work-precision diagram")

--- a/benchmarks/A0_work-precision-lotka-volterra.py
+++ b/benchmarks/A0_work-precision-lotka-volterra.py
@@ -19,7 +19,7 @@ jax.config.update("jax_debug_nans", True)
 jax.config.update("jax_enable_x64", True)
 
 
-def main(start=3.0, stop=12.0, step=1.0, repeats=1) -> None:
+def main(start=3.0, stop=12.0, step=1.0, repeats=0) -> None:
     """Run the script."""
     # Simulate once to plot the state
     ts, ys = solve_ivp_once()
@@ -34,42 +34,43 @@ def main(start=3.0, stop=12.0, step=1.0, repeats=1) -> None:
 
     # Read configuration from command line
     tolerances = benchmark_util.setup_tolerances(start=start, stop=stop, step=step)
-    timeit_fun = benchmark_util.setup_timeit(repeats=repeats)
+
+    # Compute a reference solution
+    reference = solver_scipy(method="BDF", precision_fun=lambda x: x)(1e-13)
+    precision_fun = benchmark_util.rmse_relative(reference)
 
     # Assemble algorithms
-    ts0_iso = solver_probdiffeq(5, constraint_order=0, implementation="isotropic")
-    ts0_iso_jet = solver_probdiffeq_jet(
-        5, constraint_order=0, implementation="isotropic"
+    ts0_iso = solver_probdiffeq(
+        5, constraint_order=0, implementation="isotropic", precision_fun=precision_fun
     )
-    ts0_bd = solver_probdiffeq(5, constraint_order=0, implementation="blockdiag")
+    ts0_iso_jet = solver_probdiffeq_jet(
+        5, constraint_order=0, implementation="isotropic", precision_fun=precision_fun
+    )
+    ts0_bd = solver_probdiffeq(
+        5, constraint_order=0, implementation="blockdiag", precision_fun=precision_fun
+    )
     ts0_bd_jet = solver_probdiffeq_jet(
-        5, constraint_order=0, implementation="blockdiag"
+        5, constraint_order=0, implementation="blockdiag", precision_fun=precision_fun
     )
     algorithms = {
         r"TS0(5, isotropic)": ts0_iso,
         r"JetTS0(5, isotropic)": ts0_iso_jet,
         r"TS0(5, blockdiag)": ts0_bd,
         r"JetTS0(5, blockdiag)": ts0_bd_jet,
-        "SciPy: 'RK45'": solver_scipy(method="RK45"),
+        "SciPy: 'RK45'": solver_scipy(method="RK45", precision_fun=precision_fun),
     }
-
-    # Compute a reference solution
-    reference = solver_scipy(method="BDF")(1e-13)
-    precision_fun = benchmark_util.rmse_relative(reference)
 
     # Compute all work-precision diagrams
     results = {}
     pbar = tqdm.tqdm(algorithms.items())
     for label, algo in pbar:
         pbar.set_description(label)
-        param_to_wp = benchmark_util.workprec(
-            algo, precision_fun=precision_fun, timeit_fun=timeit_fun
-        )
+        param_to_wp = benchmark_util.workprec(algo, num_repeats=repeats)
         results[label] = param_to_wp(tolerances)
 
     _fig, ax = plt.subplots(figsize=(8, 5), dpi=120, constrained_layout=True)
     for label, wp in results.items():
-        ax.loglog(wp["precision"], wp["work_mean"], label=label)
+        ax.loglog(wp.precision.mean(axis=-1), wp.work.mean(axis=-1), ".-", label=label)
 
     ax.set_ylabel("Work (avg. wall time)")
     ax.set_title("Work-precision diagram")
@@ -99,7 +100,7 @@ def solve_ivp_once():
 
 
 def solver_probdiffeq(
-    num_derivatives: int, implementation, constraint_order: int
+    num_derivatives: int, implementation, constraint_order: int, precision_fun
 ) -> Callable:
     """Construct a solver that wraps ProbDiffEq's solution routines."""
 
@@ -138,7 +139,7 @@ def solver_probdiffeq(
         solution = solve(iwp, t0=t0, t1=t1, atol=1e-2 * tol, rtol=tol)
 
         # Return the terminal value
-        return jax.block_until_ready(solution.u.mean[0])
+        return precision_fun(solution.u.mean[0])
 
     def state_space_model(implementation):
         match implementation:
@@ -153,7 +154,7 @@ def solver_probdiffeq(
 
 
 def solver_probdiffeq_jet(
-    num_derivatives: int, implementation, constraint_order: int
+    num_derivatives: int, implementation, constraint_order: int, precision_fun
 ) -> Callable:
     """Construct a solver that wraps ProbDiffEq's solution routines."""
 
@@ -191,7 +192,7 @@ def solver_probdiffeq_jet(
         solution = solve(iwp, t0=t0, t1=t1, atol=1e-2 * tol, rtol=tol)
 
         # Return the terminal value
-        return jax.block_until_ready(solution.u.mean[0])
+        return precision_fun(solution.u.mean[0])
 
     def state_space_model(implementation):
         match implementation:
@@ -205,7 +206,7 @@ def solver_probdiffeq_jet(
     return param_to_solution
 
 
-def solver_scipy(*, method: str) -> Callable:
+def solver_scipy(*, method: str, precision_fun) -> Callable:
     """Construct a solver that wraps SciPy's solution routines."""
 
     def vf_scipy(_t, y):
@@ -227,7 +228,7 @@ def solver_scipy(*, method: str) -> Callable:
             rtol=tol,
             method=method,
         )
-        return jnp.asarray(solution.y[:, -1])
+        return precision_fun(jnp.asarray(solution.y[:, -1]))
 
     return param_to_solution
 

--- a/benchmarks/A0_work-precision-lotka-volterra.py
+++ b/benchmarks/A0_work-precision-lotka-volterra.py
@@ -33,7 +33,7 @@ def main(start=3.0, stop=12.0, step=1.0, repeats=2) -> None:
     plt.show()
 
     # Read configuration from command line
-    tolerances = benchmark_util.setup_tolerances(start=start, stop=stop, step=step)
+    tolerances = 0.1 ** jnp.arange(start, stop, step=step)
 
     # Compute a reference solution
     reference = solver_scipy(method="BDF", precision_fun=lambda x: x)(1e-13)

--- a/benchmarks/A1_work-precision-pleiades.py
+++ b/benchmarks/A1_work-precision-pleiades.py
@@ -38,12 +38,12 @@ def main(start=3.0, stop=11.0, step=1.0, repeats=1) -> None:
     plt.show()
 
     # Read configuration from command line
-    tolerances = benchmark_util.setup_tolerances(start=start, stop=stop, step=step)
+    tolerances = 0.1 ** jnp.arange(start, stop, step=step)
 
     # Compute a reference solution
     reference = solver_scipy(
         method="LSODA", use_numba=False, precision_fun=lambda x: x
-    )(1e-14)
+    )(1e-12)
     precision_fun = benchmark_util.rmse_absolute(reference)
 
     # Assemble algorithms

--- a/benchmarks/A1_work-precision-pleiades.py
+++ b/benchmarks/A1_work-precision-pleiades.py
@@ -48,12 +48,8 @@ def main(start=3.0, stop=11.0, step=1.0, repeats=1) -> None:
 
     # Assemble algorithms
     algorithms = {
-        r"ProbDiffEq: TS0($5$)": solver_probdiffeq(
-            num_derivatives=5, precision_fun=precision_fun
-        ),
-        r"ProbDiffEq: TS0($8$)": solver_probdiffeq(
-            num_derivatives=8, precision_fun=precision_fun
-        ),
+        r"TS0($5$)": solver_probdiffeq(num_derivatives=5, precision_fun=precision_fun),
+        r"TS0($8$)": solver_probdiffeq(num_derivatives=8, precision_fun=precision_fun),
         "SciPy: 'RK45'": solver_scipy(
             method="RK45", use_numba=False, precision_fun=precision_fun
         ),
@@ -75,7 +71,7 @@ def main(start=3.0, stop=11.0, step=1.0, repeats=1) -> None:
     }
 
     # Compute all work-precision diagrams
-    _fig, ax = plt.subplots(figsize=(8, 3))
+    _fig, ax = plt.subplots(figsize=(8, 4))
     pbar = tqdm.tqdm(algorithms.items())
     for label, algo in pbar:
         pbar.set_description(label)
@@ -87,9 +83,7 @@ def main(start=3.0, stop=11.0, step=1.0, repeats=1) -> None:
     ax.set_xlabel("Precision (relative RMSE)")
     ax.set_ylabel("Work (avg. wall time)")
     ax.grid(linestyle="dotted", which="both")
-    ax.legend(
-        fontsize="small", loc="center left", frameon=False, bbox_to_anchor=(1, 0.5)
-    )
+    ax.legend(loc="center left", frameon=False, bbox_to_anchor=(1, 0.5))
 
     plt.tight_layout()
     plt.show()

--- a/benchmarks/A1_work-precision-pleiades.py
+++ b/benchmarks/A1_work-precision-pleiades.py
@@ -77,7 +77,7 @@ def main(start=3.0, stop=11.0, step=1.0, repeats=1) -> None:
         pbar.set_description(label)
         param_to_wp = benchmark_util.workprec(algo, num_timing_calls=repeats)
         wp = param_to_wp(tolerances)
-        ax.loglog(wp.precision.mean(axis=-1), wp.work.mean(axis=-1), ".-", label=label)
+        ax.loglog(wp.precision, wp.work.mean(axis=-1), ".-", label=label)
 
     ax.set_title("Work-precision diagram")
     ax.set_xlabel("Precision (relative RMSE)")

--- a/benchmarks/A1_work-precision-pleiades.py
+++ b/benchmarks/A1_work-precision-pleiades.py
@@ -18,7 +18,7 @@ from probdiffeq.util import benchmark_util
 jax.config.update("jax_debug_nans", True)
 
 
-def main(start=3.0, stop=11.0, step=0.5, repeats=2) -> None:
+def main(start=3.0, stop=11.0, step=1.0, repeats=1) -> None:
     """Run the script."""
     # Set up all the configs
     jax.config.update("jax_enable_x64", True)
@@ -39,36 +39,51 @@ def main(start=3.0, stop=11.0, step=0.5, repeats=2) -> None:
 
     # Read configuration from command line
     tolerances = benchmark_util.setup_tolerances(start=start, stop=stop, step=step)
-    timeit_fun = benchmark_util.setup_timeit(repeats=repeats)
+
+    # Compute a reference solution
+    reference = solver_scipy(
+        method="LSODA", use_numba=False, precision_fun=lambda x: x
+    )(1e-14)
+    precision_fun = benchmark_util.rmse_absolute(reference)
 
     # Assemble algorithms
     algorithms = {
-        r"ProbDiffEq: TS0($5$)": solver_probdiffeq(num_derivatives=5),
-        r"ProbDiffEq: TS0($8$)": solver_probdiffeq(num_derivatives=8),
-        "SciPy: 'RK45'": solver_scipy(method="RK45", use_numba=False),
-        "SciPy: 'DOP853'": solver_scipy(method="DOP853", use_numba=False),
-        "SciPy: 'RK45' (+numba)": solver_scipy(method="RK45", use_numba=True),
-        "SciPy: 'DOP853' (+numba)": solver_scipy(method="DOP853", use_numba=True),
-        "Diffrax: Tsit5()": solver_diffrax(solver=diffrax.Tsit5()),
-        "Diffrax: Dopri8()": solver_diffrax(solver=diffrax.Dopri8()),
+        r"ProbDiffEq: TS0($5$)": solver_probdiffeq(
+            num_derivatives=5, precision_fun=precision_fun
+        ),
+        r"ProbDiffEq: TS0($8$)": solver_probdiffeq(
+            num_derivatives=8, precision_fun=precision_fun
+        ),
+        "SciPy: 'RK45'": solver_scipy(
+            method="RK45", use_numba=False, precision_fun=precision_fun
+        ),
+        "SciPy: 'DOP853'": solver_scipy(
+            method="DOP853", use_numba=False, precision_fun=precision_fun
+        ),
+        "SciPy: 'RK45' (+numba)": solver_scipy(
+            method="RK45", use_numba=True, precision_fun=precision_fun
+        ),
+        "SciPy: 'DOP853' (+numba)": solver_scipy(
+            method="DOP853", use_numba=True, precision_fun=precision_fun
+        ),
+        "Diffrax: Tsit5()": solver_diffrax(
+            solver=diffrax.Tsit5(), precision_fun=precision_fun
+        ),
+        "Diffrax: Dopri8()": solver_diffrax(
+            solver=diffrax.Dopri8(), precision_fun=precision_fun
+        ),
     }
-
-    # Compute a reference solution
-    reference = solver_scipy(method="LSODA", use_numba=False)(1e-14)
-    precision_fun = benchmark_util.rmse_absolute(reference)
 
     # Compute all work-precision diagrams
     results = {}
     pbar = tqdm.tqdm(algorithms.items())
     for label, algo in pbar:
         pbar.set_description(label)
-        param_to_wp = benchmark_util.workprec(
-            algo, precision_fun=precision_fun, timeit_fun=timeit_fun
-        )
+        param_to_wp = benchmark_util.workprec(algo, num_repeats=repeats)
         results[label] = param_to_wp(tolerances)
     _fig, ax = plt.subplots(figsize=(7, 3))
     for label, wp in results.items():
-        ax.loglog(wp["precision"], wp["work_mean"], label=label)
+        ax.loglog(wp.precision.mean(axis=-1), wp.work.mean(axis=-1), ".-", label=label)
 
     ax.set_title("Work-precision diagram")
     ax.set_xlabel("Precision (relative RMSE)")
@@ -119,7 +134,7 @@ def solve_ivp_once():
     return solution.t, solution.y.T
 
 
-def solver_probdiffeq(*, num_derivatives: int) -> Callable:
+def solver_probdiffeq(*, num_derivatives: int, precision_fun) -> Callable:
     """Construct a solver that wraps ProbDiffEq's solution routines."""
     # fmt: off
     u0 = jnp.asarray(
@@ -174,12 +189,12 @@ def solver_probdiffeq(*, num_derivatives: int) -> Callable:
         solution = solve(iwp, t0=t0, t1=t1, dt0=dt0, atol=1e-3 * tol, rtol=tol)
 
         # Return the terminal value
-        return jax.block_until_ready(solution.u.mean[0])
+        return precision_fun(solution.u.mean[0])
 
     return param_to_solution
 
 
-def solver_diffrax(*, solver) -> Callable:
+def solver_diffrax(*, solver, precision_fun) -> Callable:
     """Construct a solver that wraps Diffrax' solution routines."""
     # fmt: off
     u0 = jnp.asarray(
@@ -223,12 +238,12 @@ def solver_diffrax(*, solver) -> Callable:
             max_steps=10_000,
             solver=solver,
         )
-        return jax.block_until_ready(solution.ys[0, :14])
+        return precision_fun(solution.ys[0, :14])
 
     return param_to_solution
 
 
-def solver_scipy(*, method: str, use_numba: bool) -> Callable:
+def solver_scipy(*, method: str, use_numba: bool, precision_fun) -> Callable:
     """Construct a solver that wraps SciPy's solution routines."""
     # fmt: off
     u0 = np.asarray(
@@ -272,7 +287,7 @@ def solver_scipy(*, method: str, use_numba: bool) -> Callable:
             rtol=tol,
             method=method,
         )
-        return jnp.asarray(solution.y[:14, -1])
+        return precision_fun(jnp.asarray(solution.y[:14, -1]))
 
     return param_to_solution
 

--- a/benchmarks/A1_work-precision-pleiades.py
+++ b/benchmarks/A1_work-precision-pleiades.py
@@ -75,21 +75,21 @@ def main(start=3.0, stop=11.0, step=1.0, repeats=1) -> None:
     }
 
     # Compute all work-precision diagrams
-    results = {}
+    _fig, ax = plt.subplots(figsize=(8, 3))
     pbar = tqdm.tqdm(algorithms.items())
     for label, algo in pbar:
         pbar.set_description(label)
-        param_to_wp = benchmark_util.workprec(algo, num_repeats=repeats)
-        results[label] = param_to_wp(tolerances)
-    _fig, ax = plt.subplots(figsize=(7, 3))
-    for label, wp in results.items():
+        param_to_wp = benchmark_util.workprec(algo, num_timing_calls=repeats)
+        wp = param_to_wp(tolerances)
         ax.loglog(wp.precision.mean(axis=-1), wp.work.mean(axis=-1), ".-", label=label)
 
     ax.set_title("Work-precision diagram")
     ax.set_xlabel("Precision (relative RMSE)")
     ax.set_ylabel("Work (avg. wall time)")
     ax.grid(linestyle="dotted", which="both")
-    ax.legend(fontsize="small", loc="center left", bbox_to_anchor=(1, 0.5))
+    ax.legend(
+        fontsize="small", loc="center left", frameon=False, bbox_to_anchor=(1, 0.5)
+    )
 
     plt.tight_layout()
     plt.show()

--- a/benchmarks/A2_work-precision-hires.py
+++ b/benchmarks/A2_work-precision-hires.py
@@ -41,16 +41,16 @@ def main(start=3.0, stop=10.0, step=1.0, repeats=1) -> None:
 
     # Assemble algorithms
     algorithms = {
-        r"ProbDiffEq: TS1($3$, matfree)": solver_matfree(
+        r"TS1($3$, matfree)": solver_matfree(
             num_derivatives=3, precision_fun=precision_fun
         ),
-        r"ProbDiffEq: TS1($5$, matfree)": solver_matfree(
+        r"TS1($5$, matfree)": solver_matfree(
             num_derivatives=5, precision_fun=precision_fun
         ),
-        r"ProbDiffEq: TS1($5$, dense)": solver_dense(
+        r"TS1($5$, dense)": solver_dense(
             num_derivatives=5, precision_fun=precision_fun
         ),
-        r"ProbDiffEq: TS1($7$, dense)": solver_dense(
+        r"TS1($7$, dense)": solver_dense(
             num_derivatives=7, precision_fun=precision_fun
         ),
         "SciPy: 'LSODA'": solver_scipy(method="LSODA", precision_fun=precision_fun),
@@ -58,7 +58,7 @@ def main(start=3.0, stop=10.0, step=1.0, repeats=1) -> None:
     }
 
     # Compute all work-precision diagrams
-    _fig, ax = plt.subplots(figsize=(8, 3))
+    _fig, ax = plt.subplots(figsize=(8, 4))
     pbar = tqdm.tqdm(algorithms.items())
     for label, algo in pbar:
         pbar.set_description(label)
@@ -70,9 +70,7 @@ def main(start=3.0, stop=10.0, step=1.0, repeats=1) -> None:
     ax.set_xlabel("Precision (relative RMSE)")
     ax.set_ylabel("Work (avg. wall time)")
     ax.grid(linestyle="dotted", which="both")
-    ax.legend(
-        fontsize="small", loc="center left", frameon=False, bbox_to_anchor=(1, 0.5)
-    )
+    ax.legend(loc="center left", frameon=False, bbox_to_anchor=(1, 0.5))
 
     plt.tight_layout()
     plt.show()

--- a/benchmarks/A2_work-precision-hires.py
+++ b/benchmarks/A2_work-precision-hires.py
@@ -64,7 +64,7 @@ def main(start=3.0, stop=10.0, step=1.0, repeats=1) -> None:
         pbar.set_description(label)
         param_to_wp = benchmark_util.workprec(algo, num_timing_calls=repeats)
         wp = param_to_wp(tolerances)
-        ax.loglog(wp.precision.mean(axis=-1), wp.work.mean(axis=-1), ".-", label=label)
+        ax.loglog(wp.precision, wp.work.mean(axis=-1), ".-", label=label)
 
     ax.set_title("Work-precision diagram")
     ax.set_xlabel("Precision (relative RMSE)")

--- a/benchmarks/A2_work-precision-hires.py
+++ b/benchmarks/A2_work-precision-hires.py
@@ -15,12 +15,12 @@ from probdiffeq.util import benchmark_util
 # Fail this notebook on NaN detection (to catch those in the CI)
 jax.config.update("jax_debug_nans", True)
 
+# Stiffness + high accuracy requires f64
+jax.config.update("jax_enable_x64", True)
 
-def main(start=3.0, stop=10.0, step=1.0, repeats=2) -> None:
+
+def main(start=3.0, stop=10.0, step=1.0, repeats=1) -> None:
     """Run the script."""
-    # Set up all the configs
-    jax.config.update("jax_enable_x64", True)
-
     # Simulate once to plot the state
     ts, ys = solve_ivp_once()
 
@@ -34,41 +34,45 @@ def main(start=3.0, stop=10.0, step=1.0, repeats=2) -> None:
 
     # Read configuration from command line
     tolerances = benchmark_util.setup_tolerances(start=start, stop=stop, step=step)
-    timeit_fun = benchmark_util.setup_timeit(repeats=repeats)
+
+    # Compute a reference solution
+    reference = solver_scipy(method="BDF", precision_fun=lambda x: x)(1e-13)
+    precision_fun = benchmark_util.rmse_relative(reference)
 
     # Assemble algorithms
     algorithms = {
-        r"ProbDiffEq: TS1($3$, matfree)": solver_matfree(num_derivatives=3),
-        r"ProbDiffEq: TS1($5$, matfree)": solver_matfree(num_derivatives=5),
-        r"ProbDiffEq: TS1($5$, dense)": solver_dense(num_derivatives=5),
-        r"ProbDiffEq: TS1($7$, dense)": solver_dense(num_derivatives=7),
-        "SciPy: 'LSODA'": solver_scipy(method="LSODA"),
-        "SciPy: 'Radau'": solver_scipy(method="Radau"),
+        r"ProbDiffEq: TS1($3$, matfree)": solver_matfree(
+            num_derivatives=3, precision_fun=precision_fun
+        ),
+        r"ProbDiffEq: TS1($5$, matfree)": solver_matfree(
+            num_derivatives=5, precision_fun=precision_fun
+        ),
+        r"ProbDiffEq: TS1($5$, dense)": solver_dense(
+            num_derivatives=5, precision_fun=precision_fun
+        ),
+        r"ProbDiffEq: TS1($7$, dense)": solver_dense(
+            num_derivatives=7, precision_fun=precision_fun
+        ),
+        "SciPy: 'LSODA'": solver_scipy(method="LSODA", precision_fun=precision_fun),
+        "SciPy: 'Radau'": solver_scipy(method="Radau", precision_fun=precision_fun),
     }
 
-    # Compute a reference solution
-    reference = solver_scipy(method="BDF")(1e-13)
-    precision_fun = benchmark_util.rmse_relative(reference)
-
     # Compute all work-precision diagrams
-    results = {}
+    _fig, ax = plt.subplots(figsize=(8, 3))
     pbar = tqdm.tqdm(algorithms.items())
     for label, algo in pbar:
         pbar.set_description(label)
-        param_to_wp = benchmark_util.workprec(
-            algo, precision_fun=precision_fun, timeit_fun=timeit_fun
-        )
-        results[label] = param_to_wp(tolerances)
-
-    _fig, ax = plt.subplots(figsize=(5, 3))
-    for label, wp in results.items():
-        ax.loglog(wp["precision"], wp["work_mean"], label=label)
+        param_to_wp = benchmark_util.workprec(algo, num_timing_calls=repeats)
+        wp = param_to_wp(tolerances)
+        ax.loglog(wp.precision.mean(axis=-1), wp.work.mean(axis=-1), ".-", label=label)
 
     ax.set_title("Work-precision diagram")
     ax.set_xlabel("Precision (relative RMSE)")
     ax.set_ylabel("Work (avg. wall time)")
     ax.grid(linestyle="dotted", which="both")
-    ax.legend(fontsize="small")
+    ax.legend(
+        fontsize="small", loc="center left", frameon=False, bbox_to_anchor=(1, 0.5)
+    )
 
     plt.tight_layout()
     plt.show()
@@ -101,7 +105,7 @@ def solve_ivp_once():
     return solution.t, solution.y.T
 
 
-def solver_matfree(*, num_derivatives: int) -> Callable:
+def solver_matfree(*, num_derivatives: int, precision_fun) -> Callable:
     """Construct a solver that wraps ProbDiffEq's solution routines."""
 
     @probdiffeq.ode
@@ -144,12 +148,12 @@ def solver_matfree(*, num_derivatives: int) -> Callable:
         solution = solve(iwp, t0=t0, t1=t1, dt0=dt0, atol=1e-3 * tol, rtol=tol)
 
         # Return the terminal value
-        return jax.block_until_ready(solution.u.mean[0])
+        return precision_fun(solution.u.mean[0])
 
     return param_to_solution
 
 
-def solver_dense(*, num_derivatives: int) -> Callable:
+def solver_dense(*, num_derivatives: int, precision_fun) -> Callable:
     """Construct a solver that wraps ProbDiffEq's solution routines."""
 
     @probdiffeq.ode
@@ -189,12 +193,12 @@ def solver_dense(*, num_derivatives: int) -> Callable:
         solution = solve(iwp, t0=t0, t1=t1, dt0=dt0, atol=1e-3 * tol, rtol=tol)
 
         # Return the terminal value
-        return jax.block_until_ready(solution.u.mean[0])
+        return precision_fun(solution.u.mean[0])
 
     return param_to_solution
 
 
-def solver_scipy(*, method: str) -> Callable:
+def solver_scipy(*, method: str, precision_fun) -> Callable:
     """Construct a solver that wraps SciPy's solution routines."""
 
     def vf_scipy(_t, u):
@@ -224,7 +228,7 @@ def solver_scipy(*, method: str) -> Callable:
             rtol=tol,
             method=method,
         )
-        return jnp.asarray(solution.y[:, -1])
+        return precision_fun(solution.y[:, -1])
 
     return param_to_solution
 

--- a/benchmarks/A2_work-precision-hires.py
+++ b/benchmarks/A2_work-precision-hires.py
@@ -33,7 +33,7 @@ def main(start=3.0, stop=10.0, step=1.0, repeats=1) -> None:
     plt.show()
 
     # Read configuration from command line
-    tolerances = benchmark_util.setup_tolerances(start=start, stop=stop, step=step)
+    tolerances = 0.1 ** jnp.arange(start, stop, step=step)
 
     # Compute a reference solution
     reference = solver_scipy(method="BDF", precision_fun=lambda x: x)(1e-13)

--- a/benchmarks/A3_work-precision-vanderpol.py
+++ b/benchmarks/A3_work-precision-vanderpol.py
@@ -64,7 +64,7 @@ def main(start=6.5, stop=10.0, step=0.25, repeats=2) -> None:
         param_to_wp = benchmark_util.workprec(algo, num_timing_calls=repeats)
         wp = param_to_wp(tolerances)
 
-        ax.loglog(wp.precision.mean(axis=-1), wp.work.mean(axis=-1), ".-", label=label)
+        ax.loglog(wp.precision, wp.work.mean(axis=-1), ".-", label=label)
 
     ax.set_title("Work-precision diagram")
     ax.set_xlabel("Precision (relative RMSE)")

--- a/benchmarks/A3_work-precision-vanderpol.py
+++ b/benchmarks/A3_work-precision-vanderpol.py
@@ -17,7 +17,7 @@ from probdiffeq.util import benchmark_util
 jax.config.update("jax_debug_nans", True)
 
 
-def main(start=6.0, stop=10.0, step=0.25, repeats=2) -> None:
+def main(start=6.5, stop=10.0, step=0.25, repeats=2) -> None:
     """Run the script."""
     # Set up all the configs
     jax.config.update("jax_enable_x64", True)
@@ -36,47 +36,41 @@ def main(start=6.0, stop=10.0, step=0.25, repeats=2) -> None:
 
     # Read configuration from command line
     tolerances = benchmark_util.setup_tolerances(start=start, stop=stop, step=step)
-    timeit_fun = benchmark_util.setup_timeit(repeats=repeats)
+
+    # Compute a reference solution
+    reference = solver_scipy(method="LSODA", precision_fun=lambda x: x)(
+        0.1 * tolerances[-1]
+    )
+    precision_fun = benchmark_util.rmse_absolute(reference)
 
     # Assemble algorithms
     algorithms = {
-        "TS1(4)": solver_probdiffeq(num_derivatives=4),
-        "JetTS1(4)": solver_probdiffeq_jet(num_derivatives=4),
-        "TS1(6)": solver_probdiffeq(num_derivatives=6),
-        "JetTS1(6)": solver_probdiffeq_jet(num_derivatives=6),
-        "SciPy('LSODA')": solver_scipy(method="LSODA"),
+        "TS1(4)": solver_probdiffeq(num_derivatives=4, precision_fun=precision_fun),
+        "JetTS1(4)": solver_probdiffeq_jet(
+            num_derivatives=4, precision_fun=precision_fun
+        ),
+        "TS1(6)": solver_probdiffeq(num_derivatives=6, precision_fun=precision_fun),
+        "JetTS1(6)": solver_probdiffeq_jet(
+            num_derivatives=6, precision_fun=precision_fun
+        ),
+        "SciPy('LSODA')": solver_scipy(method="LSODA", precision_fun=precision_fun),
     }
 
-    # Compute a reference solution
-    reference = solver_scipy(method="LSODA")(0.1 * tolerances[-1])
-    precision_fun = benchmark_util.rmse_absolute(reference)
-
     # Compute all work-precision diagrams
-    results = {}
+    _fig, ax = plt.subplots(figsize=(8, 4), dpi=120, constrained_layout=True)
     pbar = tqdm.tqdm(algorithms.items())
     for label, algo in pbar:
         pbar.set_description(label)
-        param_to_wp = benchmark_util.workprec(
-            algo, precision_fun=precision_fun, timeit_fun=timeit_fun
-        )
-        results[label] = param_to_wp(tolerances)
+        param_to_wp = benchmark_util.workprec(algo, num_timing_calls=repeats)
+        wp = param_to_wp(tolerances)
 
-    _fig, ax = plt.subplots(figsize=(8, 5))
-
-    for label, wp in results.items():
-        wdw = 3  # window
-        x, y = wp["precision"], wp["work_mean"]
-        x = jnp.exp(jnp.convolve(jnp.log(x), jnp.ones((wdw,)) / wdw, mode="valid"))
-        y = jnp.exp(jnp.convolve(jnp.log(y), jnp.ones((wdw,)) / wdw, mode="valid"))
-        ax.loglog(x, y, label=label)
+        ax.loglog(wp.precision.mean(axis=-1), wp.work.mean(axis=-1), ".-", label=label)
 
     ax.set_title("Work-precision diagram")
     ax.set_xlabel("Precision (relative RMSE)")
     ax.set_ylabel("Work (avg. wall time)")
     ax.grid(linestyle="dotted", which="both")
-    ax.legend(fontsize="small")
-
-    plt.tight_layout()
+    ax.legend(loc="center left", frameon=False, bbox_to_anchor=(1, 0.5))
     plt.show()
 
 
@@ -98,7 +92,7 @@ def solve_ivp_once():
     return solution.t, solution.y.T
 
 
-def solver_probdiffeq(*, num_derivatives: int) -> Callable:
+def solver_probdiffeq(*, num_derivatives: int, precision_fun) -> Callable:
     """Construct a solver that wraps ProbDiffEq's solution routines."""
 
     @probdiffeq.ode_order_two
@@ -124,17 +118,17 @@ def solver_probdiffeq(*, num_derivatives: int) -> Callable:
         solver = probdiffeq.solver_dynamic(strategy=strategy, constraint=ts)
         error = probdiffeq.error_state_std(constraint=ts)
 
-        control = ivpsolve.control_proportional_integral()
+        control = ivpsolve.control_integral()
         solve = ivpsolve.solve_adaptive_terminal_values(
             solver=solver, error=error, control=control
         )
         solution = solve(iwp, t0=t0, t1=t1, atol=1e-3 * tol, rtol=tol)
-        return jax.block_until_ready(solution.u.mean[0])
+        return precision_fun(solution.u.mean[0])
 
     return param_to_solution
 
 
-def solver_probdiffeq_jet(*, num_derivatives: int) -> Callable:
+def solver_probdiffeq_jet(*, num_derivatives: int, precision_fun) -> Callable:
     """Construct a solver that wraps ProbDiffEq's solution routines."""
 
     @probdiffeq.ode_order_two
@@ -161,17 +155,17 @@ def solver_probdiffeq_jet(*, num_derivatives: int) -> Callable:
         solver = probdiffeq.solver_dynamic(strategy=strategy, constraint=ts)
         error = probdiffeq.error_state_std(constraint=ts)
 
-        control = ivpsolve.control_proportional_integral()
+        control = ivpsolve.control_integral()
         solve = ivpsolve.solve_adaptive_terminal_values(
             solver=solver, error=error, control=control
         )
         solution = solve(iwp, t0=t0, t1=t1, atol=1e-3 * tol, rtol=tol)
-        return jax.block_until_ready(solution.u.mean[0])
+        return precision_fun(solution.u.mean[0])
 
     return param_to_solution
 
 
-def solver_scipy(method: str) -> Callable:
+def solver_scipy(method: str, precision_fun) -> Callable:
     """Construct a solver that wraps SciPy's solution routines."""
 
     @numba.jit(nopython=True)
@@ -192,7 +186,7 @@ def solver_scipy(method: str) -> Callable:
             rtol=tol,
             method=method,
         )
-        return jnp.asarray(solution.y[0, -1])
+        return precision_fun(jnp.asarray(solution.y[0, -1]))
 
     return param_to_solution
 

--- a/benchmarks/A3_work-precision-vanderpol.py
+++ b/benchmarks/A3_work-precision-vanderpol.py
@@ -35,7 +35,7 @@ def main(start=6.5, stop=10.0, step=0.25, repeats=2) -> None:
     plt.show()
 
     # Read configuration from command line
-    tolerances = benchmark_util.setup_tolerances(start=start, stop=stop, step=step)
+    tolerances = 0.1 ** jnp.arange(start, stop, step=step)
 
     # Compute a reference solution
     reference = solver_scipy(method="LSODA", precision_fun=lambda x: x)(

--- a/benchmarks/A4_work-precision-linear-high-dimensional.py
+++ b/benchmarks/A4_work-precision-linear-high-dimensional.py
@@ -33,50 +33,60 @@ def main(start=3.0, stop=10.0, step=0.5, repeats=2) -> None:
 
     # Read configuration from command line
     tolerances = benchmark_util.setup_tolerances(start=start, stop=stop, step=step)
-    timeit_fun = benchmark_util.setup_timeit(repeats=repeats)
+
+    # Compute a reference solution
+    reference = solver_scipy(method="LSODA", precision_fun=lambda x: x)(1e-13)
+    precision_fun = benchmark_util.rmse_relative(reference)
 
     # Assemble algorithms
-    ts0_iso = solver_probdiffeq(4, constraint_order=0, implementation="isotropic")
-    ts0_bd = solver_probdiffeq(4, constraint_order=0, implementation="blockdiag")
-    ts1_bd = solver_probdiffeq(4, constraint_order=1, implementation="blockdiag")
-    ts1_mf = solver_probdiffeq(4, constraint_order=1, implementation="matfree")
+    ts0_iso = solver_probdiffeq(
+        4, constraint_order=0, implementation="isotropic", precision_fun=precision_fun
+    )
+    ts0_bd = solver_probdiffeq(
+        4, constraint_order=0, implementation="blockdiag", precision_fun=precision_fun
+    )
+    ts1_bd = solver_probdiffeq(
+        4, constraint_order=1, implementation="blockdiag", precision_fun=precision_fun
+    )
+    ts1_mf = solver_probdiffeq(
+        4, constraint_order=1, implementation="matfree", precision_fun=precision_fun
+    )
     algorithms = {
         r"TS1, matfree": ts1_mf,
         r"TS1, blockdiag": ts1_bd,
         r"TS0, blockdiag": ts0_bd,
         r"TS0, isotropic": ts0_iso,
-        "Diffrax: Tsit5()": solver_diffrax(solver=diffrax.Tsit5()),
-        "SciPy: 'RK45'": solver_scipy(method="RK45"),
+        "Diffrax: Tsit5()": solver_diffrax(
+            solver=diffrax.Tsit5(), precision_fun=precision_fun
+        ),
+        "SciPy: 'RK45'": solver_scipy(method="RK45", precision_fun=precision_fun),
     }
 
-    # Compute a reference solution
-    reference = solver_scipy(method="LSODA")(1e-13)
-    precision_fun = benchmark_util.rmse_relative(reference)
-
     # Compute all work-precision diagrams
-    results = {}
+    _fig, ax = plt.subplots(figsize=(8, 4), constrained_layout=True)
     pbar = tqdm.tqdm(algorithms.items())
     for label, algo in pbar:
         pbar.set_description(label)
-        param_to_wp = benchmark_util.workprec(
-            algo, precision_fun=precision_fun, timeit_fun=timeit_fun
-        )
-        results[label] = param_to_wp(tolerances)
+        param_to_wp = benchmark_util.workprec(algo, num_timing_calls=repeats)
+        wp = param_to_wp(tolerances)
 
-    _fig, ax = plt.subplots(figsize=(7, 3))
-    for label, wp in results.items():
         linestyle = (
             "dashed" if "iffrax" in label.lower() or "ipy" in label.lower() else "solid"
         )
-        ax.loglog(wp["precision"], wp["work_mean"], label=label, linestyle=linestyle)
+        ax.loglog(
+            wp.precision.mean(axis=-1),
+            wp.work.mean(axis=-1),
+            marker=".",
+            label=label,
+            linestyle=linestyle,
+        )
 
     ax.set_title("Work-precision diagram")
     ax.set_xlabel("Precision (relative RMSE)")
     ax.set_ylabel("Work (avg. wall time)")
     ax.grid(linestyle="dotted", which="both")
-    ax.legend(fontsize="small", loc="center left", bbox_to_anchor=(1, 0.5))
+    ax.legend(loc="center left", frameon=False, bbox_to_anchor=(1, 0.5))
 
-    plt.tight_layout()
     plt.show()
 
 
@@ -97,7 +107,7 @@ def solve_ivp_once():
 
 
 def solver_probdiffeq(
-    num_derivatives: int, implementation, constraint_order: int
+    num_derivatives: int, implementation, constraint_order: int, precision_fun
 ) -> Callable:
     """Construct a solver that wraps ProbDiffEq's solution routines."""
 
@@ -134,7 +144,7 @@ def solver_probdiffeq(
         solution = solve(iwp, t0=t0, t1=t1, atol=1e-3 * tol, rtol=tol)
 
         # Return the terminal value
-        return jax.block_until_ready(solution.u.mean[0])
+        return precision_fun(solution.u.mean[0])
 
     def state_space_model(implementation):
         match implementation:
@@ -156,7 +166,7 @@ def solver_probdiffeq(
     return param_to_solution
 
 
-def solver_diffrax(*, solver) -> Callable:
+def solver_diffrax(*, solver, precision_fun) -> Callable:
     """Construct a solver that wraps Diffrax' solution routines."""
 
     @diffrax.ODETerm
@@ -183,12 +193,12 @@ def solver_diffrax(*, solver) -> Callable:
             max_steps=10_000,
             solver=solver,
         )
-        return jax.block_until_ready(solution.ys[0, :])
+        return precision_fun(solution.ys[0, :])
 
     return param_to_solution
 
 
-def solver_scipy(*, method: str) -> Callable:
+def solver_scipy(*, method: str, precision_fun) -> Callable:
     """Construct a solver that wraps SciPy's solution routines."""
 
     def vf_scipy(_t, y):
@@ -208,7 +218,7 @@ def solver_scipy(*, method: str) -> Callable:
             rtol=tol,
             method=method,
         )
-        return jnp.asarray(solution.y[:, -1])
+        return precision_fun(jnp.asarray(solution.y[:, -1]))
 
     return param_to_solution
 

--- a/benchmarks/A4_work-precision-linear-high-dimensional.py
+++ b/benchmarks/A4_work-precision-linear-high-dimensional.py
@@ -74,7 +74,7 @@ def main(start=3.0, stop=10.0, step=0.5, repeats=2) -> None:
             "dashed" if "iffrax" in label.lower() or "ipy" in label.lower() else "solid"
         )
         ax.loglog(
-            wp.precision.mean(axis=-1),
+            wp.precision,
             wp.work.mean(axis=-1),
             marker=".",
             label=label,

--- a/benchmarks/A4_work-precision-linear-high-dimensional.py
+++ b/benchmarks/A4_work-precision-linear-high-dimensional.py
@@ -32,7 +32,7 @@ def main(start=3.0, stop=10.0, step=0.5, repeats=2) -> None:
     jax.config.update("jax_enable_x64", True)
 
     # Read configuration from command line
-    tolerances = benchmark_util.setup_tolerances(start=start, stop=stop, step=step)
+    tolerances = 0.1 ** jnp.arange(start, stop, step=step)
 
     # Compute a reference solution
     reference = solver_scipy(method="LSODA", precision_fun=lambda x: x)(1e-13)

--- a/benchmarks/A5_work-precision-burgers-pde.py
+++ b/benchmarks/A5_work-precision-burgers-pde.py
@@ -48,40 +48,39 @@ def main(start=3.0, stop=8.0, step=1.0, repeats=1) -> None:
 
     # Read configuration from command line
     tolerances = benchmark_util.setup_tolerances(start=start, stop=stop, step=step)
-    timeit_fun = benchmark_util.setup_timeit(repeats=repeats)
+
+    # Compute a reference solution
+    reference = solver_scipy(method="LSODA", precision_fun=lambda x: x)(1e-13)
+    precision_fun = benchmark_util.rmse_absolute(reference)
 
     # Assemble algorithms
     algorithms = {
-        r"TS1($3$, dense)": solver_dense(num_derivatives=3),
-        r"TS1($3$, blockdiag)": solver_blockdiag(num_derivatives=3),
-        r"TS1($3$, matfree)": solver_matfree(num_derivatives=3),
+        r"TS1($3$, dense)": solver_dense(
+            num_derivatives=3, precision_fun=precision_fun
+        ),
+        r"TS1($3$, blockdiag)": solver_blockdiag(
+            num_derivatives=3, precision_fun=precision_fun
+        ),
+        r"TS1($3$, matfree)": solver_matfree(
+            num_derivatives=3, precision_fun=precision_fun
+        ),
     }
 
-    # Compute a reference solution
-    reference = solver_scipy(method="LSODA")(1e-13)
-    precision_fun = benchmark_util.rmse_absolute(reference)
-
     # Compute all work-precision diagrams
-    results = {}
+    _fig, ax = plt.subplots(figsize=(8, 4), constrained_layout=True)
     pbar = tqdm.tqdm(algorithms.items())
     for label, algo in pbar:
         pbar.set_description(label)
-        param_to_wp = benchmark_util.workprec(
-            algo, precision_fun=precision_fun, timeit_fun=timeit_fun
-        )
-        results[label] = param_to_wp(tolerances)
+        param_to_wp = benchmark_util.workprec(algo, num_timing_calls=repeats)
+        wp = param_to_wp(tolerances)
 
-    _fig, ax = plt.subplots(figsize=(5, 3))
-    for i, (label, wp) in enumerate(results.items()):
-        ax.loglog(wp["precision"], wp["work_mean"], ".-", label=label, color=f"C{i}")
+        ax.loglog(wp.precision.mean(axis=-1), wp.work.mean(axis=-1), ".-", label=label)
 
     ax.set_title("Work-precision diagram")
     ax.set_xlabel("Precision (absolute RMSE)")
     ax.set_ylabel("Work (avg. wall time)")
     ax.grid(linestyle="dotted", which="both")
-    ax.legend(fontsize="small")
-
-    plt.tight_layout()
+    ax.legend(loc="center left", frameon=False, bbox_to_anchor=(1, 0.5))
     plt.show()
 
 
@@ -118,7 +117,7 @@ def solve_ivp_once():
     return solution.t, solution.y.T
 
 
-def solver_blockdiag(*, num_derivatives: int) -> Callable:
+def solver_blockdiag(*, num_derivatives: int, precision_fun) -> Callable:
     """Construct a solver that wraps ProbDiffEq's block-diagonal routines."""
 
     @probdiffeq.ode
@@ -156,12 +155,12 @@ def solver_blockdiag(*, num_derivatives: int) -> Callable:
         )
 
         solution = solve_fn(iwp, t0=t0, t1=t1, atol=1e-3 * tol, rtol=tol)
-        return jax.block_until_ready(solution.u.mean[0])
+        return precision_fun(solution.u.mean[0])
 
     return param_to_solution
 
 
-def solver_matfree(*, num_derivatives: int) -> Callable:
+def solver_matfree(*, num_derivatives: int, precision_fun) -> Callable:
     """Construct a solver that wraps ProbDiffEq's matrix-free routines."""
 
     @probdiffeq.ode
@@ -201,12 +200,12 @@ def solver_matfree(*, num_derivatives: int) -> Callable:
         )
 
         solution = solve_fn(iwp, t0=t0, t1=t1, atol=1e-3 * tol, rtol=tol)
-        return jax.block_until_ready(solution.u.mean[0])
+        return precision_fun(solution.u.mean[0])
 
     return param_to_solution
 
 
-def solver_dense(*, num_derivatives: int) -> Callable:
+def solver_dense(*, num_derivatives: int, precision_fun) -> Callable:
     """Construct a solver that wraps ProbDiffEq's matrix-free routines."""
 
     @probdiffeq.ode
@@ -245,12 +244,12 @@ def solver_dense(*, num_derivatives: int) -> Callable:
 
         solution = solve_fn(iwp, t0=t0, t1=t1, atol=1e-3 * tol, rtol=tol)
 
-        return jax.block_until_ready(solution.u.mean[0])
+        return precision_fun(solution.u.mean[0])
 
     return param_to_solution
 
 
-def solver_scipy(*, method: str) -> Callable:
+def solver_scipy(*, method: str, precision_fun) -> Callable:
     """Construct a solver that wraps SciPy's solution routines."""
 
     def vf_scipy(_t, u):
@@ -279,7 +278,7 @@ def solver_scipy(*, method: str) -> Callable:
             rtol=tol,
             method=method,
         )
-        return jnp.asarray(solution.y[:, -1])
+        return precision_fun(jnp.asarray(solution.y[:, -1]))
 
     return param_to_solution
 

--- a/benchmarks/A5_work-precision-burgers-pde.py
+++ b/benchmarks/A5_work-precision-burgers-pde.py
@@ -74,7 +74,7 @@ def main(start=3.0, stop=8.0, step=1.0, repeats=1) -> None:
         param_to_wp = benchmark_util.workprec(algo, num_timing_calls=repeats)
         wp = param_to_wp(tolerances)
 
-        ax.loglog(wp.precision.mean(axis=-1), wp.work.mean(axis=-1), ".-", label=label)
+        ax.loglog(wp.precision, wp.work.mean(axis=-1), ".-", label=label)
 
     ax.set_title("Work-precision diagram")
     ax.set_xlabel("Precision (absolute RMSE)")

--- a/benchmarks/A5_work-precision-burgers-pde.py
+++ b/benchmarks/A5_work-precision-burgers-pde.py
@@ -47,7 +47,7 @@ def main(start=3.0, stop=8.0, step=1.0, repeats=1) -> None:
     plt.show()
 
     # Read configuration from command line
-    tolerances = benchmark_util.setup_tolerances(start=start, stop=stop, step=step)
+    tolerances = 0.1 ** jnp.arange(start, stop, step=step)
 
     # Compute a reference solution
     reference = solver_scipy(method="LSODA", precision_fun=lambda x: x)(1e-13)

--- a/benchmarks/B0_work-precision-dae-robertson.py
+++ b/benchmarks/B0_work-precision-dae-robertson.py
@@ -1,6 +1,5 @@
 """Walltime | Robertson DAE."""
 
-import statistics
 from collections.abc import Callable
 
 import jax
@@ -87,15 +86,8 @@ def main(start=3.0, stop=10.0, step=0.5, repeats=2, time_span=(1e-6, 1e5)) -> No
         param_to_wp = benchmark_util.workprec(algo, num_timing_calls=repeats)
         wp = param_to_wp(tolerances)
 
-        ax[0].loglog(
-            wp.precision["rmse"].mean(axis=-1), wp.work.mean(axis=-1), ".-", label=label
-        )
-        ax[1].loglog(
-            tolerances,
-            wp.precision["constraint_violation"].mean(axis=-1),
-            "-",
-            label=label,
-        )
+        ax[0].loglog(wp.precision["rmse"], wp.work.mean(axis=-1), ".-", label=label)
+        ax[1].loglog(tolerances, wp.precision["constraint_violation"], "-", label=label)
 
     ax[0].set_title("Work-precision diagram")
     ax[0].set_xlabel("Precision (relative RMSE)")
@@ -266,29 +258,6 @@ def solver_scipy(*, method: str, time_span, precision_fun) -> Callable:
         return precision_fun(jnp.asarray(solution.y[:, -1]))
 
     return param_to_solution
-
-
-def workprec(fun, *, precision_fun: Callable, work_fun: Callable) -> Callable:
-    """Turn a parameter-to-solution function into parameter-to-workprecision."""
-
-    def parameter_list_to_workprecision(list_of_args, /):
-        works_mean = []
-        works_std = []
-        precisions = []
-        for arg in list_of_args:
-            precision = precision_fun(fun(arg).block_until_ready())
-            work = work_fun(lambda: fun(arg).block_until_ready())  # noqa: B023
-
-            precisions.append(precision)
-            works_mean.append(statistics.mean(work))
-            works_std.append(statistics.stdev(work))
-        return {
-            "work_mean": jnp.asarray(works_mean),
-            "work_std": jnp.asarray(works_std),
-            "precision": jnp.asarray(precisions),
-        }
-
-    return parameter_list_to_workprecision
 
 
 main()

--- a/benchmarks/B0_work-precision-dae-robertson.py
+++ b/benchmarks/B0_work-precision-dae-robertson.py
@@ -41,7 +41,7 @@ def main(start=3.0, stop=10.0, step=0.5, repeats=2, time_span=(1e-6, 1e5)) -> No
     plt.show()
 
     # Read configuration from command line
-    tolerances = benchmark_util.setup_tolerances(start=start, stop=stop, step=step)
+    tolerances = 0.1 ** jnp.arange(start, stop, step=step)
 
     # Compute a reference solution
     reference_solver = solver_scipy(

--- a/benchmarks/B0_work-precision-dae-robertson.py
+++ b/benchmarks/B0_work-precision-dae-robertson.py
@@ -43,57 +43,72 @@ def main(start=3.0, stop=10.0, step=0.5, repeats=2, time_span=(1e-6, 1e5)) -> No
 
     # Read configuration from command line
     tolerances = benchmark_util.setup_tolerances(start=start, stop=stop, step=step)
-    timeit_fun = benchmark_util.setup_timeit(repeats=repeats)
+
+    # Compute a reference solution
+    reference_solver = solver_scipy(
+        method="Radau", time_span=time_span, precision_fun=lambda x: x
+    )
+    reference = reference_solver(0.1 * tolerances[-1])
+    rmse_fun = benchmark_util.rmse_relative(reference)
+
+    def precision_fun(received):
+        rmse = rmse_fun(received)
+        eps = jnp.finfo(received.dtype).eps
+        violation = eps + jnp.abs(np.sum(received) - 1.0)
+        return {"rmse": rmse, "constraint_violation": violation}
 
     # Assemble algorithms
     algorithms = {
-        "DAE | Jet(3)": solver_residual(num_derivatives=3, time_span=time_span),
-        "DAE | Jet(4)": solver_residual(num_derivatives=4, time_span=time_span),
-        "ODE | TS1(3)": solver_ode(num_derivatives=3, time_span=time_span),
-        "ODE | TS1(4)": solver_ode(num_derivatives=4, time_span=time_span),
-        "ODE | TS1(7)": solver_ode(num_derivatives=7, time_span=time_span),
-        "ODE | LSODA (Scipy)": solver_scipy(method="LSODA", time_span=time_span),
+        "DAE | Jet(3)": solver_residual(
+            num_derivatives=3, time_span=time_span, precision_fun=precision_fun
+        ),
+        "DAE | Jet(4)": solver_residual(
+            num_derivatives=4, time_span=time_span, precision_fun=precision_fun
+        ),
+        "ODE | TS1(3)": solver_ode(
+            num_derivatives=3, time_span=time_span, precision_fun=precision_fun
+        ),
+        "ODE | TS1(4)": solver_ode(
+            num_derivatives=4, time_span=time_span, precision_fun=precision_fun
+        ),
+        "ODE | TS1(7)": solver_ode(
+            num_derivatives=7, time_span=time_span, precision_fun=precision_fun
+        ),
+        "ODE | LSODA (Scipy)": solver_scipy(
+            method="LSODA", time_span=time_span, precision_fun=precision_fun
+        ),
     }
 
-    # Compute a reference solution
-    reference = solver_scipy(method="Radau", time_span=time_span)(0.1 * tolerances[-1])
-    rmse_fun = rmse_relative(reference)
-
     # Compute all work-precision diagrams
-    results = {}
+    _fig, ax = plt.subplots(ncols=2, figsize=(8, 3), constrained_layout=True)
     pbar = tqdm.tqdm(algorithms.items())
     for label, algo in pbar:
         pbar.set_description(label)
-        param_to_wp = workprec(algo, precision_fun=rmse_fun, work_fun=timeit_fun)
-        results[label] = param_to_wp(tolerances)
-    _fig, ax = plt.subplots(ncols=2, figsize=(13, 5))
+        param_to_wp = benchmark_util.workprec(algo, num_timing_calls=repeats)
+        wp = param_to_wp(tolerances)
 
-    for label, wp in results.items():
-        wdw = 3  # window
-
-        precision, y = wp["precision"], wp["work_mean"]
-        x, _ = precision.T
-        x = jnp.exp(jnp.convolve(jnp.log(x), jnp.ones((wdw,)) / wdw, mode="valid"))
-        y = jnp.exp(jnp.convolve(jnp.log(y), jnp.ones((wdw,)) / wdw, mode="valid"))
-        ax[0].loglog(x, y, label=label)
-
-        x, size = precision.T
-        eps = jnp.finfo(x.dtype).eps
-        ax[1].loglog(tolerances, eps + jnp.abs(size - 1.0), "-", label=label)
+        ax[0].loglog(
+            wp.precision["rmse"].mean(axis=-1), wp.work.mean(axis=-1), ".-", label=label
+        )
+        ax[1].loglog(
+            tolerances,
+            wp.precision["constraint_violation"].mean(axis=-1),
+            "-",
+            label=label,
+        )
 
     ax[0].set_title("Work-precision diagram")
     ax[0].set_xlabel("Precision (relative RMSE)")
     ax[0].set_ylabel("Work (avg. wall time)")
     ax[0].grid(linestyle="dotted", which="both")
-    ax[0].legend(fontsize="small")
+    ax[0].legend(fontsize="xx-small")
 
     ax[1].set_title("Constraint violation")
     ax[1].set_xlabel("Tolerance (user input)")
     ax[1].set_ylabel("Algebraic constraint violation")
     ax[1].grid(linestyle="dotted", which="both")
-    ax[1].legend(fontsize="small")
+    ax[1].legend(fontsize="xx-small")
 
-    plt.tight_layout()
     plt.show()
 
 
@@ -123,7 +138,7 @@ def solve_ivp_once(*, save_at, method, tol):
     return solution.t, solution.y.T
 
 
-def solver_ode(*, num_derivatives: int, time_span) -> Callable:
+def solver_ode(*, num_derivatives: int, time_span, precision_fun) -> Callable:
     """Construct a method that solves Robertson as an ODE."""
 
     @probdiffeq.residual_velocity
@@ -161,12 +176,12 @@ def solver_ode(*, num_derivatives: int, time_span) -> Callable:
         solve = ivpsolve.solve_adaptive_terminal_values(solver=solver, error=error)
         solution = solve(iwp, t0=t0, t1=t1, atol=1e-3 * tol, rtol=tol)
 
-        return jax.block_until_ready(solution.u.mean[0])
+        return precision_fun(solution.u.mean[0])
 
     return param_to_solution
 
 
-def solver_residual(*, num_derivatives: int, time_span) -> Callable:
+def solver_residual(*, num_derivatives: int, time_span, precision_fun) -> Callable:
     """Construct a method that solves Robertson as a DAE."""
 
     @probdiffeq.residual_velocity
@@ -220,12 +235,12 @@ def solver_residual(*, num_derivatives: int, time_span) -> Callable:
         solve = ivpsolve.solve_adaptive_terminal_values(solver=solver, error=error)
         solution = solve(iwp, t0=t0, t1=t1, atol=1e-3 * tol, rtol=tol)
 
-        return jax.block_until_ready(solution.u.mean[0])
+        return precision_fun(solution.u.mean[0])
 
     return param_to_solution
 
 
-def solver_scipy(*, method: str, time_span) -> Callable:
+def solver_scipy(*, method: str, time_span, precision_fun) -> Callable:
     """Construct a solver that wraps SciPy's solution routines."""
 
     def vf(t, y):
@@ -248,26 +263,9 @@ def solver_scipy(*, method: str, time_span) -> Callable:
             rtol=tol,
             method=method,
         )
-        return jnp.asarray(solution.y[:, -1])
+        return precision_fun(jnp.asarray(solution.y[:, -1]))
 
     return param_to_solution
-
-
-def rmse_relative(expected: jax.Array) -> Callable:
-    """Compute the absolute RMSE."""
-    expected = jnp.asarray(expected)
-
-    def rmse(received):
-        received = jnp.asarray(received)
-        error_absolute = jnp.abs(expected - received)
-
-        error_relative = error_absolute / (1e-5 + jnp.abs(expected))
-        rmse = jnp.linalg.norm(error_relative) / jnp.sqrt(error_relative.size)
-
-        algebraic = jnp.sum(received)
-        return rmse, algebraic
-
-    return rmse
 
 
 def workprec(fun, *, precision_fun: Callable, work_fun: Callable) -> Callable:

--- a/benchmarks/C0_taylor-init-fitzhughnagumo.py
+++ b/benchmarks/C0_taylor-init-fitzhughnagumo.py
@@ -14,11 +14,12 @@ from probdiffeq.util import benchmark_util
 jax.config.update("jax_debug_nans", True)
 
 
-def main(max_time=0.25, repeats=2) -> None:
-    """Run the script."""
-    # Set JAX config
-    jax.config.update("jax_enable_x64", True)
+# Set JAX config
+jax.config.update("jax_enable_x64", True)
 
+
+def main(max_time=0.75, repeats=1) -> None:
+    """Run the script."""
     algorithms = {
         r"Forward-mode": odejet_via_jvp(),
         r"Taylor-mode (scan)": taylor_mode_scan(),
@@ -26,48 +27,40 @@ def main(max_time=0.25, repeats=2) -> None:
         r"Taylor-mode (doubling)": taylor_mode_doubling(),
     }
 
-    # Compute a reference solution
-    timeit_fun = benchmark_util.setup_timeit(repeats=repeats)
-
     # Compute all work-precision diagrams
-    results = {}
+    _fig, (axis_compile, axis_perform) = plt.subplots(
+        ncols=2, figsize=(8, 3), constrained_layout=True, dpi=120, sharex=True
+    )
+
+    list_of_args = list(range(1, 20))
     for label, algo in algorithms.items():
         print("\n")
         print(label)
-        results[label] = benchmark_util.adaptive_benchmark(
-            algo, timeit_fun=timeit_fun, max_time=max_time
+        workprec = benchmark_util.workprec(
+            algo, time_max_sec=max_time, print_progress=True, num_timing_calls=repeats
         )
-
-    _fig, (axis_perform, axis_compile) = plt.subplots(
-        ncols=2, figsize=(8, 3), dpi=150, sharex=True, sharey=True
-    )
-
-    for label, wp in results.items():
-        inputs = wp["arguments"]
-        work_compile = wp["work_compile"]
-        work_mean, work_std = wp["work_mean"], wp["work_std"]
+        wp = workprec(list_of_args)
+        inputs = wp.arg
+        work_compile = wp.work_first_run
+        work_mean = wp.work.mean(axis=-1)
 
         if "doubling" in label:
-            num_repeats = jnp.diff(jnp.concatenate((jnp.ones((1,)), inputs)))
-            inputs = jnp.arange(1, jnp.amax(inputs) * 1)
+            num_repeats = 2**inputs
             work_compile = benchmark_util.adaptive_repeat(work_compile, num_repeats)
             work_mean = benchmark_util.adaptive_repeat(work_mean, num_repeats)
-            work_std = benchmark_util.adaptive_repeat(work_std, num_repeats)
+            inputs = jnp.arange(1, 2 ** (jnp.amax(inputs) + 1) - 1)
 
         axis_compile.semilogy(inputs, work_compile, label=label)
         axis_perform.semilogy(inputs, work_mean, label=label)
 
     axis_compile.set_title("Compilation time")
     axis_perform.set_title("Evaluation time")
-    axis_perform.legend(fontsize="small")
-    axis_compile.legend(fontsize="small")
-    axis_compile.set_xlabel("Number of Derivatives")
-    axis_perform.set_xlabel("Number of Derivatives")
-    axis_perform.set_ylabel("Wall time (sec)")
-    axis_perform.grid(linestyle="dotted")
-    axis_compile.grid(linestyle="dotted")
+    axis_compile.set_ylabel("Wall time (sec)")
+    for ax in [axis_perform, axis_compile]:
+        ax.legend(fontsize="x-small")
+        ax.set_xlabel("Number of Derivatives")
+        ax.grid(linestyle="dotted")
 
-    plt.tight_layout()
     plt.show()
 
 
@@ -79,7 +72,7 @@ def taylor_mode_scan() -> Callable:
     def estimate(num):
         jetexpand = probdiffeq.jetexpand_ode_padded_scan(num=num)
         tcoeffs, _ = jetexpand(vf_auto, (u0,), t=0.0)
-        return jnp.asarray(tcoeffs)
+        return jnp.asarray(tcoeffs)[-1]
 
     return estimate
 
@@ -92,7 +85,7 @@ def taylor_mode_unroll() -> Callable:
     def estimate(num):
         jetexpand = probdiffeq.jetexpand_ode_unroll(num=num)
         tcoeffs, _ = jetexpand(vf_auto, (u0,), t=0.0)
-        return jnp.asarray(tcoeffs)
+        return jnp.asarray(tcoeffs)[-1]
 
     return estimate
 
@@ -105,7 +98,7 @@ def taylor_mode_doubling() -> Callable:
     def estimate(num):
         jetexpand = probdiffeq.jetexpand_ode_doubling_unroll(num_doublings=num)
         tcoeffs, _ = jetexpand(vf_auto, (u0,), t=0.0)
-        return jnp.asarray(tcoeffs)
+        return jnp.asarray(tcoeffs)[-1]
 
     return estimate
 
@@ -118,7 +111,7 @@ def odejet_via_jvp() -> Callable:
     def estimate(num):
         jetexpand = probdiffeq.jetexpand_ode_via_jvp(num=num)
         tcoeffs, _ = jetexpand(vf_auto, (u0,), t=0.0)
-        return jnp.asarray(tcoeffs)
+        return jnp.asarray(tcoeffs)[-1]
 
     return estimate
 

--- a/benchmarks/C1_taylor-init-node.py
+++ b/benchmarks/C1_taylor-init-node.py
@@ -13,12 +13,12 @@ from probdiffeq.util import benchmark_util
 # Fail this notebook on NaN detection (to catch those in the CI)
 jax.config.update("jax_debug_nans", True)
 
+# Set JAX config
+jax.config.update("jax_enable_x64", True)
 
-def main(max_time=0.55, repeats=2) -> None:
+
+def main(max_time=0.75, repeats=1) -> None:
     """Run the script."""
-    # Set JAX config
-    jax.config.update("jax_enable_x64", True)
-
     algorithms = {
         r"Forward-mode": odejet_via_jvp(),
         r"Taylor-mode (scan)": taylor_mode_scan(),
@@ -26,48 +26,40 @@ def main(max_time=0.55, repeats=2) -> None:
         r"Taylor-mode (doubling)": taylor_mode_doubling(),
     }
 
-    # Compute a reference solution
-    timeit_fun = benchmark_util.setup_timeit(repeats=repeats)
-
     # Compute all work-precision diagrams
-    results = {}
+    _fig, (axis_compile, axis_perform) = plt.subplots(
+        ncols=2, figsize=(8, 3), constrained_layout=True, dpi=120, sharex=True
+    )
+
+    list_of_args = list(range(1, 20))
     for label, algo in algorithms.items():
         print("\n")
         print(label)
-        results[label] = benchmark_util.adaptive_benchmark(
-            algo, timeit_fun=timeit_fun, max_time=max_time
+        workprec = benchmark_util.workprec(
+            algo, time_max_sec=max_time, print_progress=True, num_timing_calls=repeats
         )
-
-    _fig, (axis_perform, axis_compile) = plt.subplots(
-        ncols=2, figsize=(8, 3), dpi=150, sharex=True, sharey=True
-    )
-
-    for label, wp in results.items():
-        inputs = wp["arguments"]
-        work_compile = wp["work_compile"]
-        work_mean, work_std = wp["work_mean"], wp["work_std"]
+        wp = workprec(list_of_args)
+        inputs = wp.arg
+        work_compile = wp.work_first_run
+        work_mean = wp.work.mean(axis=-1)
 
         if "doubling" in label:
-            num_repeats = jnp.diff(jnp.concatenate((jnp.ones((1,)), inputs)))
-            inputs = jnp.arange(1, jnp.amax(inputs) * 1)
+            num_repeats = 2**inputs
             work_compile = benchmark_util.adaptive_repeat(work_compile, num_repeats)
             work_mean = benchmark_util.adaptive_repeat(work_mean, num_repeats)
-            work_std = benchmark_util.adaptive_repeat(work_std, num_repeats)
+            inputs = jnp.arange(1, 2 ** (jnp.amax(inputs) + 1) - 1)
 
         axis_compile.semilogy(inputs, work_compile, label=label)
         axis_perform.semilogy(inputs, work_mean, label=label)
 
     axis_compile.set_title("Compilation time")
     axis_perform.set_title("Evaluation time")
-    axis_perform.legend(fontsize="small")
-    axis_compile.legend(fontsize="small")
-    axis_compile.set_xlabel("Number of Derivatives")
-    axis_perform.set_xlabel("Number of Derivatives")
-    axis_perform.set_ylabel("Wall time (sec)")
-    axis_perform.grid(linestyle="dotted")
-    axis_compile.grid(linestyle="dotted")
+    axis_compile.set_ylabel("Wall time (sec)")
+    for ax in [axis_perform, axis_compile]:
+        ax.legend(fontsize="x-small")
+        ax.set_xlabel("Number of Derivatives")
+        ax.grid(linestyle="dotted")
 
-    plt.tight_layout()
     plt.show()
 
 
@@ -79,7 +71,7 @@ def taylor_mode_scan() -> Callable:
     def estimate(num):
         jetexpand = probdiffeq.jetexpand_ode_padded_scan(num=num)
         tcoeffs, _ = jetexpand(vf_auto, (u0,), t=0.0)
-        return jnp.asarray(tcoeffs)
+        return jnp.asarray(tcoeffs[-1])
 
     return estimate
 
@@ -92,7 +84,7 @@ def taylor_mode_unroll() -> Callable:
     def estimate(num):
         jetexpand = probdiffeq.jetexpand_ode_unroll(num=num)
         tcoeffs, _ = jetexpand(vf_auto, (u0,), t=0.0)
-        return jnp.asarray(tcoeffs)
+        return jnp.asarray(tcoeffs[-1])
 
     return estimate
 
@@ -105,7 +97,7 @@ def taylor_mode_doubling() -> Callable:
     def estimate(num):
         jetexpand = probdiffeq.jetexpand_ode_doubling_unroll(num_doublings=num)
         tcoeffs, _ = jetexpand(vf_auto, (u0,), t=0.0)
-        return jnp.asarray(tcoeffs)
+        return jnp.asarray(tcoeffs[-1])
 
     return estimate
 
@@ -118,7 +110,7 @@ def odejet_via_jvp() -> Callable:
     def estimate(num):
         jetexpand = probdiffeq.jetexpand_ode_via_jvp(num=num)
         tcoeffs, _ = jetexpand(vf_auto, (u0,), t=0.0)
-        return jnp.asarray(tcoeffs)
+        return jnp.asarray(tcoeffs[-1])
 
     return estimate
 

--- a/benchmarks/C2_taylor-init-pleiades.py
+++ b/benchmarks/C2_taylor-init-pleiades.py
@@ -12,61 +12,52 @@ from probdiffeq.util import benchmark_util
 
 # Fail this notebook on NaN detection (to catch those in the CI)
 jax.config.update("jax_debug_nans", True)
+# Set JAX config
+jax.config.update("jax_enable_x64", True)
 
 
-def main(max_time=0.5, repeats=2) -> None:
+def main(max_time=0.75, repeats=1) -> None:
     """Run the script."""
-    # Set JAX config
-    jax.config.update("jax_enable_x64", True)
-
     algorithms = {
         r"Forward-mode": odejet_via_jvp(),
         r"Taylor-mode (scan)": taylor_mode_scan(),
         r"Taylor-mode (unroll)": taylor_mode_unroll(),
     }
 
-    # Compute a reference solution
-    timeit_fun = benchmark_util.setup_timeit(repeats=repeats)
-
     # Compute all work-precision diagrams
-    results = {}
+    _fig, (axis_compile, axis_perform) = plt.subplots(
+        ncols=2, figsize=(8, 3), constrained_layout=True, dpi=120, sharex=True
+    )
+
+    list_of_args = list(range(1, 20))
     for label, algo in algorithms.items():
         print("\n")
         print(label)
-        results[label] = benchmark_util.adaptive_benchmark(
-            algo, timeit_fun=timeit_fun, max_time=max_time
+        workprec = benchmark_util.workprec(
+            algo, time_max_sec=max_time, print_progress=True, num_timing_calls=repeats
         )
-
-    _fig, (axis_perform, axis_compile) = plt.subplots(
-        ncols=2, figsize=(8, 3), dpi=150, sharex=True, sharey=True
-    )
-
-    for label, wp in results.items():
-        inputs = wp["arguments"]
-        work_compile = wp["work_compile"]
-        work_mean, work_std = wp["work_mean"], wp["work_std"]
+        wp = workprec(list_of_args)
+        inputs = wp.arg
+        work_compile = wp.work_first_run
+        work_mean = wp.work.mean(axis=-1)
 
         if "doubling" in label:
-            num_repeats = jnp.diff(jnp.concatenate((jnp.ones((1,)), inputs)))
-            inputs = jnp.arange(1, jnp.amax(inputs) * 1)
+            num_repeats = 2**inputs
             work_compile = benchmark_util.adaptive_repeat(work_compile, num_repeats)
             work_mean = benchmark_util.adaptive_repeat(work_mean, num_repeats)
-            work_std = benchmark_util.adaptive_repeat(work_std, num_repeats)
+            inputs = jnp.arange(1, 2 ** (jnp.amax(inputs) + 1) - 1)
 
         axis_compile.semilogy(inputs, work_compile, label=label)
         axis_perform.semilogy(inputs, work_mean, label=label)
 
     axis_compile.set_title("Compilation time")
     axis_perform.set_title("Evaluation time")
-    axis_perform.legend(fontsize="small")
-    axis_compile.legend(fontsize="small")
-    axis_compile.set_xlabel("Number of Derivatives")
-    axis_perform.set_xlabel("Number of Derivatives")
-    axis_perform.set_ylabel("Wall time (sec)")
-    axis_perform.grid(linestyle="dotted")
-    axis_compile.grid(linestyle="dotted")
+    axis_compile.set_ylabel("Wall time (sec)")
+    for ax in [axis_perform, axis_compile]:
+        ax.legend(fontsize="x-small")
+        ax.set_xlabel("Number of Derivatives")
+        ax.grid(linestyle="dotted")
 
-    plt.tight_layout()
     plt.show()
 
 
@@ -78,7 +69,7 @@ def taylor_mode_scan() -> Callable:
     def estimate(num):
         jetexpand = probdiffeq.jetexpand_ode_padded_scan(num=num)
         tcoeffs, _ = jetexpand(vf_auto, (u0, du0), t=0.0)
-        return jnp.asarray(tcoeffs)
+        return jnp.asarray(tcoeffs[-1])
 
     return estimate
 
@@ -91,7 +82,7 @@ def taylor_mode_unroll() -> Callable:
     def estimate(num):
         jetexpand = probdiffeq.jetexpand_ode_unroll(num=num)
         tcoeffs, _ = jetexpand(vf_auto, (u0, du0), t=0.0)
-        return jnp.asarray(tcoeffs)
+        return jnp.asarray(tcoeffs[-1])
 
     return estimate
 
@@ -104,7 +95,7 @@ def odejet_via_jvp() -> Callable:
     def estimate(num):
         jetexpand = probdiffeq.jetexpand_ode_via_jvp(num=num)
         tcoeffs, _ = jetexpand(vf_auto, (u0, du0), t=0.0)
-        return jnp.asarray(tcoeffs)
+        return jnp.asarray(tcoeffs[-1])
 
     return estimate
 

--- a/benchmarks/D0_convergence-rates-lotka-volterra.py
+++ b/benchmarks/D0_convergence-rates-lotka-volterra.py
@@ -23,39 +23,17 @@ def main() -> None:
     # High order solvers need double precision
     jax.config.update("jax_enable_x64", True)
 
-    # Assemble algorithms
-    algorithms = {
-        r"TS1(1)": solver_probdiffeq(1),
-        r"TS1(2)": solver_probdiffeq(2),
-        r"TS1(3)": solver_probdiffeq(3),
-        r"TS1(4)": solver_probdiffeq(4),
-        r"TS1(5)": solver_probdiffeq(5),
-        r"TS1(6)": solver_probdiffeq(6),
-        r"TS1(7)": solver_probdiffeq(7),
-        r"TS1(8)": solver_probdiffeq(8),
-        r"TS1(9)": solver_probdiffeq(9),
-        r"TS1(10)": solver_probdiffeq(10),
-        r"TS1(11)": solver_probdiffeq(11),
-        r"TS1(12)": solver_probdiffeq(12),
-        r"TS1(13)": solver_probdiffeq(13),
-        r"TS1(14)": solver_probdiffeq(14),
-        r"TS1(15)": solver_probdiffeq(15),
-        r"TS1(16)": solver_probdiffeq(16),
-        r"TS1(17)": solver_probdiffeq(17),
-    }
-
     # Set up the benchmark (compute a reference etc.)
     reference = solver_scipy(method="LSODA")(1e-12)
     tolerances = benchmark_util.setup_tolerances(start=2, stop=8, step=0.5)
     precision_fun = benchmark_util.rmse_relative(reference)
-    timeit_fun = benchmark_util.setup_timeit(repeats=1)
+
+    # Assemble algorithms
+    algorithms = {}
+    for n in range(1, 17):
+        algorithms[f"TS1({n})"] = solver_probdiffeq(n, precision_fun=precision_fun)
 
     # Compute all work-precision diagrams
-    results = {}
-    for label, algo in tqdm.tqdm(algorithms.items()):
-        param_to_wp = workprec(algo, precision_fun=precision_fun, timeit_fun=timeit_fun)
-        results[label] = param_to_wp(tolerances)
-
     layout = [["values", "trends"]]
     _fig, ax = plt.subplot_mosaic(
         layout,
@@ -65,19 +43,22 @@ def main() -> None:
         sharex=True,
         sharey=True,
     )
-    for i, (keys, values) in enumerate(results.items()):
+    pbar = tqdm.tqdm(algorithms.items())
+    for i, (label, algo) in enumerate(pbar):
+        pbar.set_description(label)
+        param_to_wp = benchmark_util.workprec(algo, num_timing_calls=0)
+        wp = param_to_wp(tolerances)
+
         cmap = mpl.colormaps["managua"]
-        i_clipped = i / len(results.keys())
+        i_clipped = i / len(algorithms.keys())
         color = mpl.colors.to_hex(cmap(i_clipped))
 
-        # Smooth curves
-        x, y = smooth(values["work_num_steps"], values["precision"])
-        (x_lin, y_lin), (scale, _) = linear_trend(
-            values["work_num_steps"], values["precision"]
-        )
+        # Compute linear trend
+        x, y = wp.precision["num_steps"], wp.precision["precision"]
+        (x_lin, y_lin), (scale, _) = linear_trend(x, y)
 
         # All curves start at (1, 1)
-        ax["values"].loglog(x / x.min(), y / y.max(), color=color, label=keys)
+        ax["values"].loglog(x / x.min(), y / y.max(), ".-", color=color, label=label)
         ax["trends"].loglog(
             x_lin / x_lin.min(),
             y_lin / y_lin.max(),
@@ -85,14 +66,14 @@ def main() -> None:
             label=f"Rate: {scale:.1f}",
         )
 
-    ax["values"].set_title("Values (slightly smoothed)")
-    ax["trends"].set_title("Decay rates (linear fit)")
-    ax["values"].set_ylabel("RMSE (normalised)")
+    ax["values"].set_title("True data", fontsize="medium")
+    ax["trends"].set_title("Linear fit", fontsize="medium")
+    ax["values"].set_ylabel("Relative RMSE (normalised)", fontsize="medium")
 
     for a in [ax["values"], ax["trends"]]:
         a.grid(which="minor", linestyle="dotted")
-        a.set_xlabel("Num steps (normalised)")
-        a.legend(fontsize="x-small", ncols=2)
+        a.set_xlabel("Step count (normalised)")
+        a.legend(fontsize="xx-small", ncols=2)
     plt.show()
 
 
@@ -123,7 +104,7 @@ def solver_scipy(*, method: str) -> Callable:
     return param_to_solution
 
 
-def solver_probdiffeq(num_derivatives: int) -> Callable:
+def solver_probdiffeq(num_derivatives: int, precision_fun) -> Callable:
     """Construct a solver that wraps ProbDiffEq's solution routines."""
 
     @probdiffeq.ode
@@ -160,7 +141,10 @@ def solver_probdiffeq(num_derivatives: int) -> Callable:
         solution = solve(iwp, t0=t0, t1=t1, dt0=dt0, atol=1e-2 * tol, rtol=tol)
 
         # Return the terminal value
-        return solution.u.mean[0], solution.num_steps
+        return {
+            "precision": precision_fun(solution.u.mean[0]),
+            "num_steps": solution.num_steps,
+        }
 
     return param_to_solution
 

--- a/benchmarks/D0_convergence-rates-lotka-volterra.py
+++ b/benchmarks/D0_convergence-rates-lotka-volterra.py
@@ -25,7 +25,7 @@ def main() -> None:
 
     # Set up the benchmark (compute a reference etc.)
     reference = solver_scipy(method="LSODA")(1e-12)
-    tolerances = benchmark_util.setup_tolerances(start=2, stop=8, step=0.5)
+    tolerances = 0.1 ** jnp.arange(2, 8, step=0.5)
     precision_fun = benchmark_util.rmse_relative(reference)
 
     # Assemble algorithms

--- a/probdiffeq/util/benchmark_util.py
+++ b/probdiffeq/util/benchmark_util.py
@@ -9,15 +9,6 @@ def setup_tolerances(*, start: float, stop: float, step: float) -> Array:
     return 0.1 ** np.arange(start, stop, step=step)
 
 
-def setup_timeit(*, repeats: int) -> Callable:
-    """Construct a timing function."""
-
-    def timer(fun, /):
-        return timing.repeat(fun, repeats=repeats)
-
-    return timer
-
-
 @tree.register_dataclass
 @structs.dataclass
 class WorkPrec:

--- a/probdiffeq/util/benchmark_util.py
+++ b/probdiffeq/util/benchmark_util.py
@@ -1,6 +1,6 @@
 """Shared utilities for benchmark scripts."""
 
-from probdiffeq.backend import linalg, np, timing
+from probdiffeq.backend import linalg, np, structs, timing, tree
 from probdiffeq.backend.typing import Array, Callable
 
 
@@ -18,30 +18,41 @@ def setup_timeit(*, repeats: int) -> Callable:
     return timer
 
 
-def workprec(fun, *, precision_fun: Callable, timeit_fun: Callable) -> Callable:
-    """Turn a parameter-to-solution function into a parameter-to-work-precision map."""
+@tree.register_dataclass
+@structs.dataclass
+class WorkPrec:
+    """Data for work-precision diagrams."""
 
-    def parameter_list_to_workprecision(list_of_args, /):
-        works_mean = []
-        works_std = []
-        precisions = []
+    work: Array
+    precision: Array
+
+
+def workprec(
+    precision_fun: Callable, *, num_repeats: int = 0
+) -> Callable[[list], WorkPrec]:
+    """Turn a parameter-to-precision function into a parameter-to-work-precision map."""
+
+    def parameter_list_to_workprecision(list_of_args: list, /) -> WorkPrec:
+        workprecs = []
         for arg in list_of_args:
-            # TODO: if we do timing and precision jointly (which means hardcoding timing), then
-            # we can cut runtimes of costlier benchmarks where we only afford repeat=1 in half.
-            precision = precision_fun(fun(arg).block_until_ready())
-            precisions.append(precision)
+            workprec = []
 
-            times = timeit_fun(lambda: fun(arg).block_until_ready())  # noqa: B023
-            mean = np.mean(np.asarray(times))
-            works_mean.append(mean)
-            if len(times) > 1:
-                std = np.std(np.asarray(times), ddof=1)
-                works_std.append(std)
-        return {
-            "work_mean": np.asarray(works_mean),
-            "work_std": np.asarray(works_std),
-            "precision": np.asarray(precisions),
-        }
+            # Compile...
+            _ = precision_fun(arg).block_until_ready()
+
+            # Loop
+            for _ in range(1 + num_repeats):
+                t0 = timing.perf_counter()
+                precision = precision_fun(arg).block_until_ready()
+                work = np.asarray(timing.perf_counter() - t0)
+                workprec.append(WorkPrec(work=work, precision=precision))
+
+            # Transpose workprec tree
+            workprec = tree.tree_array_stack(workprec)
+            workprecs.append(workprec)
+
+        # Transpose workprec tree again to return a WorkPrec object
+        return tree.tree_array_stack(workprecs)
 
     return parameter_list_to_workprecision
 

--- a/probdiffeq/util/benchmark_util.py
+++ b/probdiffeq/util/benchmark_util.py
@@ -29,12 +29,14 @@ def workprec(
             workprec = []
 
             # Compile...
-            _ = precision_fun(arg).block_until_ready()
+            y = precision_fun(arg)
+            tree.tree_map(lambda x: x.block_until_ready(), y)
 
             # Loop
             for _ in range(num_timing_calls):
                 t0 = timing.perf_counter()
-                precision = precision_fun(arg).block_until_ready()
+                precision = precision_fun(arg)
+                tree.tree_map(lambda x: x.block_until_ready(), precision)
                 work = np.asarray(timing.perf_counter() - t0)
                 workprec.append(WorkPrec(work=work, precision=precision))
 

--- a/probdiffeq/util/benchmark_util.py
+++ b/probdiffeq/util/benchmark_util.py
@@ -14,34 +14,64 @@ def setup_tolerances(*, start: float, stop: float, step: float) -> Array:
 class WorkPrec:
     """Data for work-precision diagrams."""
 
+    arg: Array
+    """The inputs for the work-precision diagrams."""
+
+    work_first_run: Array
+    """The time it took for the initial run (includes compilation time)."""
+
     work: Array
+    """A set of runtimes."""
+
     precision: Array
+    """The precision respectively target functions."""
 
 
 def workprec(
-    precision_fun: Callable, *, num_timing_calls: int = 1
+    target_fun: Callable,
+    /,
+    *,
+    num_timing_calls: int = 1,
+    time_max_sec=30,
+    print_progress: bool = False,
 ) -> Callable[[list], WorkPrec]:
     """Turn a parameter-to-precision function into a parameter-to-work-precision map."""
 
     def parameter_list_to_workprecision(list_of_args: list, /) -> WorkPrec:
         workprecs = []
+        time_start = timing.perf_counter()
+
         for arg in list_of_args:
-            workprec = []
+            time_elapsed = timing.perf_counter() - time_start
+            if time_elapsed > time_max_sec:
+                break
+
+            if print_progress:
+                msg = f"arg = {arg} | elapsed: {time_elapsed:.2f} | time_max_sec = {time_max_sec}"
+                print(msg)  # noqa: T201
 
             # Compile...
-            y = precision_fun(arg)
-            tree.tree_map(lambda x: x.block_until_ready(), y)
+            t0 = timing.perf_counter()
+            precision = target_fun(arg)
+            precision = tree.tree_map(lambda x: x.block_until_ready(), precision)
+            work_first_run = np.asarray(timing.perf_counter() - t0)
 
-            # Loop
+            # Call many times to get a set of runtimes
+            works = []
             for _ in range(num_timing_calls):
                 t0 = timing.perf_counter()
-                precision = precision_fun(arg)
-                tree.tree_map(lambda x: x.block_until_ready(), precision)
+                y = target_fun(arg)
+                _ = tree.tree_map(lambda x: x.block_until_ready(), y)
                 work = np.asarray(timing.perf_counter() - t0)
-                workprec.append(WorkPrec(work=work, precision=precision))
+                works.append(work)
 
-            # Transpose workprec tree
-            workprec = tree.tree_array_stack(workprec)
+            arg = np.asarray(arg)
+            workprec = WorkPrec(
+                arg=arg,
+                work_first_run=work_first_run,
+                work=np.asarray(works),
+                precision=precision,
+            )
             workprecs.append(workprec)
 
         # Transpose workprec tree again to return a WorkPrec object
@@ -73,45 +103,6 @@ def rmse_absolute(expected: Array) -> Callable:
         return linalg.vector_norm(error_absolute) / np.sqrt(error_absolute.size)
 
     return rmse
-
-
-def adaptive_benchmark(
-    fun, *, timeit_fun: Callable, max_time, print_progress: bool = True
-) -> dict:
-    """Benchmark a function iteratively until a max-time threshold is exceeded."""
-    work_compile = []
-    work_mean = []
-    work_std = []
-    arguments = []
-
-    t0 = timing.perf_counter()
-    arg = 1
-    while (elapsed := timing.perf_counter() - t0) < max_time:
-        if print_progress:
-            msg = f"num = {arg} | elapsed = {elapsed:.2f} | max_time = {max_time}"
-            print(msg)  # noqa: T201
-        t0 = timing.perf_counter()
-        tcoeffs = fun(arg).block_until_ready()
-        t1 = timing.perf_counter()
-        time_compile = t1 - t0
-
-        time_execute = timeit_fun(lambda: fun(arg).block_until_ready())  # noqa: B023
-
-        arguments.append(len(tcoeffs))
-        work_compile.append(time_compile)
-        work_mean.append(np.mean(np.asarray(time_execute)))
-        work_std.append(np.std(np.asarray(time_execute), ddof=1))
-        arg += 1
-
-    if print_progress:
-        msg = f"num = {arg} | elapsed = {elapsed:.2f} | max_time = {max_time}"
-        print(msg)  # noqa: T201
-    return {
-        "work_mean": np.asarray(work_mean),
-        "work_std": np.asarray(work_std),
-        "work_compile": np.asarray(work_compile),
-        "arguments": np.asarray(arguments),
-    }
 
 
 def adaptive_repeat(xs, ys):

--- a/probdiffeq/util/benchmark_util.py
+++ b/probdiffeq/util/benchmark_util.py
@@ -28,7 +28,7 @@ class WorkPrec:
 
 
 def workprec(
-    precision_fun: Callable, *, num_repeats: int = 0
+    precision_fun: Callable, *, num_timing_calls: int = 1
 ) -> Callable[[list], WorkPrec]:
     """Turn a parameter-to-precision function into a parameter-to-work-precision map."""
 
@@ -41,7 +41,7 @@ def workprec(
             _ = precision_fun(arg).block_until_ready()
 
             # Loop
-            for _ in range(1 + num_repeats):
+            for _ in range(num_timing_calls):
                 t0 = timing.perf_counter()
                 precision = precision_fun(arg).block_until_ready()
                 work = np.asarray(timing.perf_counter() - t0)

--- a/probdiffeq/util/benchmark_util.py
+++ b/probdiffeq/util/benchmark_util.py
@@ -3,13 +3,6 @@
 from probdiffeq.backend import linalg, np, structs, timing, tree
 from probdiffeq.backend.typing import Array, Callable
 
-# TODO: this being a function in the src is a joke...
-
-
-def setup_tolerances(*, start: float, stop: float, step: float) -> Array:
-    """Choose a vector of tolerances."""
-    return 0.1 ** np.arange(start, stop, step=step)
-
 
 @tree.register_dataclass
 @structs.dataclass

--- a/probdiffeq/util/benchmark_util.py
+++ b/probdiffeq/util/benchmark_util.py
@@ -3,6 +3,8 @@
 from probdiffeq.backend import linalg, np, structs, timing, tree
 from probdiffeq.backend.typing import Array, Callable
 
+# TODO: this being a function in the src is a joke...
+
 
 def setup_tolerances(*, start: float, stop: float, step: float) -> Array:
     """Choose a vector of tolerances."""


### PR DESCRIPTION

- Combine both work-precision diagram functions into one 
- Track the actual runtimes instead of sample statistics
- Allow pytree-valued precision functions (useful to track multiple metrics)
- Clean up benchmark code while at it