### PR TITLE
Fix blackjax progressbar handling and remove CI badge from README

### DIFF
--- a/examples/E1_parameter_estimation_blackjax.py
+++ b/examples/E1_parameter_estimation_blackjax.py
@@ -60,7 +60,8 @@ def main():
     # Warmup
     print("\nRunning window adaptation...", end="")
     key, subkey = jax.random.split(key, num=2)
-    warmup = blackjax.window_adaptation(blackjax.nuts, log_M, progress_bar=False)
+
+    warmup = blackjax.window_adaptation(blackjax.nuts, log_M)
     warmup_results, _ = warmup.run(subkey, theta0, num_steps=150)
     print(" done.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ doc = [
     "tueplots",
     "tqdm",
     "optax",
-    "blackjax[progress]>=1.0.0",
+    "blackjax>=1.6.0",
     "diffrax",
     "numba",
     # mkdocs 2.0 is a backwards-incompatible rewrite


### PR DESCRIPTION
... and also remove the CI badge from the README, because it always points to the most recent action, which means that if a PR has a failing CI, the CI is marked as failing on the repo's landing page (which I find undesirable).