### PR TITLE
Remove CI badge from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Probabilistic solvers in JAX
 
-[![CI](https://github.com/pnkraemer/probdiffeq/workflows/ci/badge.svg)](https://github.com/pnkraemer/probdiffeq/actions)
 [![PyPI version](https://img.shields.io/pypi/v/probdiffeq.svg)](https://pypi.python.org/pypi/probdiffeq)
 [![License](https://img.shields.io/pypi/l/probdiffeq.svg)](https://pypi.python.org/pypi/probdiffeq)
 [![Python versions](https://img.shields.io/pypi/pyversions/probdiffeq.svg)](https://pypi.python.org/pypi/probdiffeq)


### PR DESCRIPTION
Because they always point to the most recent action and are thus often uninformative about the main branch. Eg if a PR has a failing test (which is normal), the README badge displays that the CI is failing, which I find undesirable.

 